### PR TITLE
Ship Shared Lists Phase 1 + Smart Suggestions Phase 1 (beta-gated)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ SMS -> Twilio webhook (/sms) -> main.py validates -> ai_service.py processes wit
 | `utils/db_helpers.py` | Encryption-aware database query helpers |
 
 ### Database Tables
-`users`, `reminders`, `recurring_reminders`, `memories`, `lists`, `list_items`, `interactions`, `support_tickets`, `contact_messages`, `broadcast_messages`, `conversation_flags`, `smart_nudges`, `monitoring_issues`, `monitoring_runs`, `issue_patterns`, `issue_pattern_links`, `validation_runs`, `issue_resolutions`, `pattern_resolutions`, `health_snapshots`, `fix_proposals`, `fix_proposal_runs`
+`users`, `reminders`, `recurring_reminders`, `memories`, `lists`, `list_items`, `list_shares`, `interactions`, `support_tickets`, `contact_messages`, `broadcast_messages`, `conversation_flags`, `smart_nudges`, `monitoring_issues`, `monitoring_runs`, `issue_patterns`, `issue_pattern_links`, `validation_runs`, `issue_resolutions`, `pattern_resolutions`, `health_snapshots`, `fix_proposals`, `fix_proposal_runs`
 
 ## Deployment
 
@@ -181,6 +181,9 @@ When users view a numbered list (memories, lists, reminders, recurring reminders
 
 ### Field Encryption
 Optional AES-256-GCM encryption for PII (names, emails). Enabled via `ENCRYPTION_KEY` and `HASH_KEY` env vars.
+
+### Shared Lists
+Premium-only feature allowing users to share lists with up to 4 non-premium users. Sharing is tracked in `list_shares` table with pending/accepted/declined status. Non-owners can add/remove/complete items but cannot delete, rename, or share the list. Key functions in `models/list_model.py`: `share_list()`, `accept_share()`, `get_accessible_list_by_name()`, `can_user_access_list()`. Handlers in `routes/handlers/lists.py`. Config: `SHARED_LIST_MAX_MEMBERS=4`, `SHARED_LIST_MAX_PER_USER=3`, `SHARED_LIST_MAX_RECEIVED=5`. ACCEPT/DECLINE keywords handled before AI processing. See `docs/shared-lists.md` for full scope.
 
 ### Smart Nudges
 Proactive AI intelligence layer — sends ONE contextual insight per day. 8 nudge types, tier-gated. OFF by default. See `docs/changelog.md` for full implementation details.

--- a/config.py
+++ b/config.py
@@ -230,6 +230,19 @@ TIER_LIMITS = {
 }
 
 # =====================================================
+# SHARED LISTS CONFIGURATION
+# =====================================================
+SHARED_LIST_MAX_MEMBERS = 4       # Max users a list can be shared with
+SHARED_LIST_MAX_PER_USER = 3      # Max shared lists a Premium user can create
+SHARED_LIST_MAX_RECEIVED = 5      # Max shared lists a non-premium user can be on
+
+# Beta whitelist: comma-separated phone numbers (E.164 format) that can initiate shared lists.
+# Empty string = feature available to all Premium users. Set in env to restrict during testing.
+SHARED_LISTS_BETA_PHONES = [
+    p.strip() for p in os.environ.get("SHARED_LISTS_BETA_PHONES", "").split(",") if p.strip()
+]
+
+# =====================================================
 # SMART NUDGES CONFIGURATION
 # =====================================================
 NUDGE_DEFAULT_TIME = "09:00"       # Default nudge time (9:00 AM local)

--- a/config.py
+++ b/config.py
@@ -242,6 +242,12 @@ SHARED_LISTS_BETA_PHONES = [
     p.strip() for p in os.environ.get("SHARED_LISTS_BETA_PHONES", "").split(",") if p.strip()
 ]
 
+# Beta whitelist for Smart Suggestions: comma-separated phone numbers (E.164 format).
+# Empty string = feature available to all Premium users. Set in env to restrict during testing.
+SMART_SUGGESTIONS_BETA_PHONES = [
+    p.strip() for p in os.environ.get("SMART_SUGGESTIONS_BETA_PHONES", "").split(",") if p.strip()
+]
+
 # =====================================================
 # SMART NUDGES CONFIGURATION
 # =====================================================

--- a/database.py
+++ b/database.py
@@ -238,6 +238,23 @@ def init_db():
             )
         ''')
 
+        # List shares table (shared lists between users)
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS list_shares (
+                id SERIAL PRIMARY KEY,
+                list_id INTEGER NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
+                owner_phone TEXT NOT NULL,
+                shared_with_phone TEXT NOT NULL,
+                permission TEXT NOT NULL DEFAULT 'edit',
+                status TEXT NOT NULL DEFAULT 'pending',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                accepted_at TIMESTAMP,
+                owner_phone_hash TEXT,
+                shared_with_phone_hash TEXT,
+                UNIQUE(list_id, shared_with_phone)
+            )
+        ''')
+
         # Broadcast logs table
         c.execute('''
             CREATE TABLE IF NOT EXISTS broadcast_logs (
@@ -672,6 +689,10 @@ def init_db():
             "CREATE INDEX IF NOT EXISTS idx_smart_nudges_phone ON smart_nudges(phone_number, sent_at)",
             # Twilio costs: index for date-range queries
             "CREATE INDEX IF NOT EXISTS idx_twilio_costs_date ON twilio_costs(cost_date)",
+            # Shared lists: indexes for efficient lookups
+            "CREATE INDEX IF NOT EXISTS idx_list_shares_shared_with ON list_shares(shared_with_phone)",
+            "CREATE INDEX IF NOT EXISTS idx_list_shares_list_id ON list_shares(list_id)",
+            "CREATE INDEX IF NOT EXISTS idx_list_shares_owner ON list_shares(owner_phone)",
         ]
 
         for migration in migrations:

--- a/database.py
+++ b/database.py
@@ -245,6 +245,7 @@ def init_db():
                 list_id INTEGER NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
                 owner_phone TEXT NOT NULL,
                 shared_with_phone TEXT NOT NULL,
+                shared_with_name TEXT,
                 permission TEXT NOT NULL DEFAULT 'edit',
                 status TEXT NOT NULL DEFAULT 'pending',
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -661,6 +662,10 @@ def init_db():
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS free_tier_version INTEGER DEFAULT 2",
             # Backfill all existing users to v1 (grandfathered)
             "UPDATE users SET free_tier_version = 1 WHERE free_tier_version = 2 OR free_tier_version IS NULL",
+            # Shared lists: pending name prompt state (JSON with list_id, shared_with_phone, list_name)
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS pending_share_name TEXT",
+            # Shared lists: owner-assigned name for the person they shared with
+            "ALTER TABLE list_shares ADD COLUMN IF NOT EXISTS shared_with_name TEXT",
         ]
 
         # Create indexes on phone_hash columns for efficient lookups

--- a/docs/shared-lists.md
+++ b/docs/shared-lists.md
@@ -1,6 +1,6 @@
 # Shared Lists Feature — Technical Scope & Implementation Plan
 
-**Status:** Scoping complete, ready for Phase 1 implementation
+**Status:** Phase 1 implemented (core sharing, no auto-notifications)
 **Priority:** High — key Premium value prop differentiator
 **Estimated Effort:** Medium — phased rollout
 

--- a/docs/smart-suggestions.md
+++ b/docs/smart-suggestions.md
@@ -1,0 +1,272 @@
+# Smart Suggestions — Technical Scope & Design
+
+**Status:** Design complete, ready for review
+**Priority:** Medium — engagement & retention differentiator
+**Estimated Effort:** Medium — phased rollout across 3 categories
+
+---
+
+## Concept
+
+After a user creates a reminder, list, or memory, the system analyzes the content and offers a contextually relevant follow-up suggestion. The user can accept with YES or ignore it. This turns Remyndrs from a passive tool into one that anticipates what the user needs next.
+
+**Key principle:** Suggest, never auto-create. The user stays in control.
+
+---
+
+## Three Suggestion Categories
+
+### 1. Smart Reminders — "Prep Reminder"
+
+**Trigger:** User creates a reminder for a high-importance event.
+
+**Detection keywords/patterns:**
+| Pattern | Suggestion |
+|---------|------------|
+| doctor, dentist, appointment, checkup | "Want a reminder 12 hours before to prepare?" |
+| interview, meeting (with company name) | "Want a reminder the night before to prep?" |
+| flight, airport, travel | "Want a reminder 3 hours before to leave for the airport?" |
+| birthday, anniversary | "Want a reminder 2 days before to get a gift?" |
+| deadline, due date, submission | "Want a reminder the day before?" |
+| exam, test, quiz | "Want a reminder the night before to review?" |
+| moving, move-in, move-out | "Want a reminder 1 week before to start packing?" |
+| wedding, ceremony | "Want a reminder 1 week before to confirm details?" |
+| vet, pet appointment | "Want a reminder 12 hours before?" |
+| payment, bill, rent | "Want a reminder 2 days before?" |
+
+**Example flow:**
+```
+User:    "Remind me about my doctor appointment Thursday at 2pm"
+System:  "Got it! I'll remind you Thursday at 2:00 PM about your doctor appointment.
+
+          Want me to also remind you Wednesday evening to prepare?"
+User:    "Yes"
+System:  "Done! I'll remind you Wednesday at 7:00 PM to prepare for your doctor appointment."
+```
+
+**Prep reminder timing logic:**
+- Events before noon → reminder the evening before (7 PM local)
+- Events at noon or later → reminder 12 hours before
+- Events days/weeks away (birthday, deadline) → reminder 1-2 days before
+- Minimum gap: 4 hours (don't suggest a prep reminder for something 2 hours away)
+
+### 2. Smart Lists — "List Companion Reminders"
+
+**Trigger:** User creates a new list whose name suggests a time-bound activity.
+
+**Detection keywords/patterns:**
+| List name pattern | Suggestion |
+|-------------------|------------|
+| vacation, trip, travel, packing | "Want a reminder [X days] before your trip to review this list?" |
+| grocery, groceries, shopping | "Want a weekly reminder to check your grocery list?" |
+| party, event, gathering | "Want a reminder the day before to review this list?" |
+| move, moving, packing | "Want a weekly reminder to check off items?" |
+| christmas, holiday, gift | "Want a reminder each week to work through your list?" |
+| school, supplies, back to school | "Want a reminder before school starts to review this?" |
+| wedding, registry | "Want a monthly reminder to review progress?" |
+| project, sprint | "Want a weekly reminder to check progress?" |
+
+**Example flow:**
+```
+User:    "Create a vacation packing list"
+System:  "Created your Vacation Packing List!
+
+          When is your trip? I can remind you to review this list beforehand."
+User:    "June 15th"
+System:  "I'll remind you June 13th to review your Vacation Packing List."
+```
+
+**For recurring lists (grocery):**
+```
+User:    "Create a grocery list"
+System:  "Created your Grocery List!
+
+          Want a weekly reminder to check your grocery list before shopping?"
+User:    "Yes"
+System:  "What day works best? (e.g., Saturday morning)"
+User:    "Saturday morning"
+System:  "Done! I'll remind you every Saturday at 9:00 AM to check your Grocery List."
+```
+
+### 3. Smart Memories — "Maintenance Reminders"
+
+**Trigger:** User saves a memory that implies a recurring maintenance task.
+
+**Detection keywords/patterns:**
+| Memory pattern | Suggestion |
+|----------------|------------|
+| changed air filter, replaced filter | "Want a reminder in 90 days to change it again?" |
+| oil change, changed oil | "Want a reminder in 3 months for the next oil change?" |
+| rotated tires, tire rotation | "Want a reminder in 6 months?" |
+| replaced battery, new battery | "Want a reminder in 1 year to check it?" |
+| paid rent, rent due | "Want a monthly reminder?" |
+| renewed [license/subscription/insurance] | "Want a reminder before it expires?" → ask expiry date |
+| planted [garden/flowers/seeds] | "Want a reminder in 2 weeks to water/check on them?" |
+| cleaned gutters, pressure washed | "Want a reminder in 6 months?" |
+| pest control, exterminator | "Want a reminder in 3 months?" |
+| water heater flush, HVAC service | "Want a reminder in 12 months?" |
+| smoke detector batteries | "Want a reminder in 6 months to replace them again?" |
+
+**Example flow:**
+```
+User:    "Remember I changed the air filter today"
+System:  "Saved! "Changed the air filter today"
+
+          Want a reminder in 90 days to change it again?"
+User:    "Yes"
+System:  "Done! I'll remind you on [date] to change the air filter."
+```
+
+**For memories with variable intervals:**
+```
+User:    "Remember I renewed my car insurance today"
+System:  "Saved! "Renewed car insurance today"
+
+          Want a reminder before it expires? When does it renew next?"
+User:    "January 2027"
+System:  "I'll remind you December 15, 2026 to renew your car insurance."
+```
+
+---
+
+## Architecture
+
+### Detection Layer
+
+A lightweight keyword/pattern matcher — NOT an AI call. This keeps it fast, predictable, and free of additional OpenAI costs. The detection runs synchronously right after the primary action succeeds.
+
+```python
+# services/smart_suggestion_service.py
+
+def get_reminder_suggestion(reminder_text: str, reminder_date: datetime, timezone: str) -> dict | None:
+    """Check if a reminder warrants a prep suggestion.
+    Returns {suggestion_text, prep_date, prep_reminder_text} or None."""
+
+def get_list_suggestion(list_name: str) -> dict | None:
+    """Check if a new list name warrants a companion reminder suggestion.
+    Returns {suggestion_text, needs_date: bool, recurrence: str|None} or None."""
+
+def get_memory_suggestion(memory_text: str) -> dict | None:
+    """Check if a saved memory warrants a maintenance reminder suggestion.
+    Returns {suggestion_text, default_days: int, needs_date: bool} or None."""
+```
+
+### Suggestion Flow
+
+```
+User creates reminder/list/memory
+  → Primary action executes (save to DB, send confirmation)
+  → Detection layer checks content against patterns
+  → If match found AND user is eligible:
+      - Append suggestion to confirmation SMS
+      - Store pending state for YES/NO handling
+  → If no match: normal response, no suggestion
+```
+
+### Pending State
+
+Reuse the existing `pending_reminder_confirmation` JSON pattern:
+
+```json
+{
+  "type": "smart_suggestion",
+  "category": "prep_reminder|list_companion|maintenance_reminder",
+  "suggestion_data": {
+    "reminder_text": "Prepare for doctor appointment",
+    "reminder_date": "2026-04-15 19:00:00",
+    "related_id": 456,
+    "list_name": null,
+    "recurrence": null
+  }
+}
+```
+
+**YES handler:** Creates the suggested reminder (one-time or recurring), sends confirmation.
+**NO / ignore:** Clears the pending state on next message (existing pattern).
+**Other message:** Clears pending state, processes the new message normally.
+
+### Injection Points
+
+| Action | File | Where to inject |
+|--------|------|-----------------|
+| Reminder created | `main.py` ~line 4662 | After usage counter, before `log_interaction` |
+| List created | `routes/handlers/lists.py` ~line 73 | After list counter, before `log_interaction` |
+| Memory saved | `main.py` ~line 4339 | After memory counter, before `log_interaction` |
+
+The suggestion text is appended to `reply_text` with a `\n\n` separator, keeping it in a single SMS where possible.
+
+---
+
+## Tier Gating
+
+| Tier | Smart Suggestions |
+|------|-------------------|
+| Free (v1 & v2) | Off — no suggestions |
+| Premium / Trial | On — all 3 categories |
+| Family | On — all 3 categories |
+
+Smart Suggestions are opt-in by default for Premium users (no toggle needed — they just ignore suggestions they don't want). No separate enable/disable setting to start; revisit if users complain about frequency.
+
+---
+
+## Throttling
+
+- **Max 1 suggestion per conversation turn** — if a user creates a list AND adds items in one message, only suggest for the list creation
+- **No daily limit** — suggestions are contextual responses, not proactive nudges. They only appear when the user just did something, so they're always timely
+- **Cooldown after decline** — if user ignores or declines a suggestion, don't suggest for the same category for the next 3 interactions (track via a counter on the user record)
+
+This is different from Smart Nudges (which are proactive and rate-limited to 1/day). Suggestions are reactive — they ride on an action the user just took.
+
+---
+
+## SMS Cost Impact
+
+Zero incremental cost. Suggestions are appended to the confirmation SMS the system was already sending. The only additional SMS is when the user says YES and gets the "Done!" confirmation — but that's a normal reminder confirmation.
+
+---
+
+## Edge Cases
+
+- **User creates a reminder that already has a prep reminder** — don't suggest a duplicate. Check existing reminders for the same day with similar text.
+- **User creates a list with a name that matches but already has a recurring reminder for it** — skip the suggestion.
+- **Memory text is too vague to suggest a specific interval** — use `needs_date: true` and ask the user when.
+- **User is mid-conversation with another pending state** — don't inject a suggestion. Check for existing pending states before suggesting.
+- **Prep reminder would be in the past** — don't suggest if there isn't enough lead time (< 4 hours).
+- **Character limit** — keep the suggestion line under 80 characters so the total SMS stays under 160 where possible (1 SMS segment). If the confirmation + suggestion exceeds 160, it's fine — Twilio handles multi-segment, and the suggestion is worth the extra segment.
+
+---
+
+## Implementation Order
+
+### Phase 1 — Smart Reminders (Prep Reminders)
+1. `services/smart_suggestion_service.py` — detection logic + timing calculation
+2. `main.py` — inject after reminder creation, handle YES response
+3. Tests — keyword detection, timing logic, YES/NO flow, edge cases
+4. Manual QA with real SMS
+
+### Phase 2 — Smart Memories (Maintenance Reminders)
+1. Add memory detection patterns to suggestion service
+2. `main.py` — inject after memory save, handle YES + date collection
+3. Tests
+
+### Phase 3 — Smart Lists (List Companion Reminders)
+1. Add list detection patterns to suggestion service
+2. `routes/handlers/lists.py` + `main.py` — inject after list creation
+3. Handle the date-collection flow (grocery → "what day?", vacation → "when is your trip?")
+4. Tests
+
+### Phase 4 — Polish
+- Cooldown tracking after declines
+- Duplicate suggestion prevention
+- Admin dashboard metrics (suggestion rate, acceptance rate)
+- Consider AI-powered detection for edge cases keyword matching misses
+
+---
+
+## Open Questions
+
+1. **Should suggestions be configurable per category?** e.g., "Turn off list suggestions but keep reminder suggestions." Adds UX complexity — defer unless users ask.
+2. **Should the prep reminder text reference the original?** e.g., "Prepare for your doctor appointment tomorrow at 2 PM" vs just "Prepare for doctor appointment." Referencing the original is more helpful but longer.
+3. **Should grocery list suggestion default to a specific day?** Or always ask? Asking is safer — people shop on different days.
+4. **What about memories that aren't maintenance?** e.g., "Remember Sarah's birthday is March 15" — should this suggest a yearly reminder? Good idea but needs different detection logic (date extraction from memory text).
+5. **Should we track suggestion acceptance rate?** Yes — this tells us which patterns are valuable vs annoying. Add to Phase 4.

--- a/main.py
+++ b/main.py
@@ -39,12 +39,13 @@ from models.list_model import (
     find_item_in_any_list, get_list_count, get_item_count,
     get_next_available_list_name,
     get_accessible_list_by_name, can_user_access_list,
-    get_shared_lists_for_user, get_pending_shares
+    get_shared_lists_for_user, get_pending_shares,
+    is_shared_list_read_only
 )
 from routes.handlers.lists import (
     handle_share_list, handle_unshare_list, handle_show_list_members,
     handle_leave_shared_list, handle_accept_share, handle_decline_share,
-    format_all_lists_display
+    handle_pending_share_name, format_all_lists_display
 )
 from services.sms_service import send_sms
 from services.ai_service import process_with_ai, parse_list_items
@@ -900,6 +901,12 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                         if condition is None or condition(msg_lower):
                             referral_source = source
                             break
+
+            # Check if this user was invited via a shared list
+            if not referral_source:
+                pending = get_pending_shares(phone_number)
+                if pending:
+                    referral_source = "shared-list"
 
             # Default: tag unmatched new users so they don't show as "Unknown"
             if not referral_source:
@@ -3896,6 +3903,15 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             return Response(content=str(resp), media_type="application/xml")
 
         # ==========================================
+        # SHARED LIST: PENDING NAME AFTER SHARE
+        # ==========================================
+        share_name_result = handle_pending_share_name(phone_number, incoming_msg)
+        if share_name_result:
+            resp = MessagingResponse()
+            resp.message(staging_prefix(share_name_result))
+            return Response(content=str(resp), media_type="application/xml")
+
+        # ==========================================
         # SHARED LIST ACCEPT/DECLINE
         # ==========================================
         if incoming_msg.upper() == "ACCEPT":
@@ -5091,6 +5107,16 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                     if shared_list_match and shared_list_match[2]:  # is_shared=True
                         list_id = shared_list_match[0]
                         list_name = shared_list_match[1]
+
+                        # Check if shared list is read-only (owner no longer Premium)
+                        read_only, owner_name = is_shared_list_read_only(list_id)
+                        if read_only:
+                            reply_text = f"The shared list '{list_name}' is currently read-only because the owner's Premium plan has expired."
+                            log_interaction(phone_number, incoming_msg, reply_text, "add_to_shared_list_readonly", False)
+                            resp = MessagingResponse()
+                            resp.message(staging_prefix(reply_text))
+                            return Response(content=str(resp), media_type="application/xml")
+
                         # Add items to shared list (use owner's item limit, not shared user's)
                         from services.tier_service import get_tier_limits, get_user_tier, add_list_item_counter_to_message
                         tier_limits = get_tier_limits(get_user_tier(shared_list_match[3]))  # owner's tier
@@ -5421,7 +5447,10 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                 from models.list_model import mark_item_complete_by_list_id
                 accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
                 if accessible and accessible[2]:  # is_shared
-                    if mark_item_complete_by_list_id(accessible[0], item_text):
+                    read_only, owner_name = is_shared_list_read_only(accessible[0])
+                    if read_only:
+                        reply_text = f"The shared list '{accessible[1]}' is currently read-only because the owner's Premium plan has expired."
+                    elif mark_item_complete_by_list_id(accessible[0], item_text):
                         reply_text = f"Checked off {item_text} from shared list '{accessible[1]}'"
                     else:
                         reply_text = f"Couldn't find '{item_text}' in '{accessible[1]}'."
@@ -5450,7 +5479,10 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                 from models.list_model import mark_item_incomplete_by_list_id
                 accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
                 if accessible and accessible[2]:  # is_shared
-                    if mark_item_incomplete_by_list_id(accessible[0], item_text):
+                    read_only, owner_name = is_shared_list_read_only(accessible[0])
+                    if read_only:
+                        reply_text = f"The shared list '{accessible[1]}' is currently read-only because the owner's Premium plan has expired."
+                    elif mark_item_incomplete_by_list_id(accessible[0], item_text):
                         reply_text = f"Unmarked {item_text} from shared list '{accessible[1]}'"
                     else:
                         reply_text = f"Couldn't find '{item_text}' to unmark."
@@ -5465,6 +5497,16 @@ def process_single_action(ai_response, phone_number, incoming_msg):
             # Check if this is a shared list the user has access to
             accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
             is_shared_list = accessible and accessible[2]
+
+            # Check if shared list is read-only (owner no longer Premium)
+            if is_shared_list:
+                read_only, owner_name = is_shared_list_read_only(accessible[0])
+                if read_only:
+                    reply_text = f"The shared list '{accessible[1]}' is currently read-only because the owner's Premium plan has expired."
+                    log_interaction(phone_number, incoming_msg, reply_text, "delete_item_readonly", False)
+                    resp = MessagingResponse()
+                    resp.message(staging_prefix(reply_text))
+                    return Response(content=str(resp), media_type="application/xml")
 
             # Ask for confirmation before deleting
             confirm_data = json.dumps({

--- a/main.py
+++ b/main.py
@@ -37,7 +37,14 @@ from models.list_model import (
     add_list_item, mark_item_complete, mark_item_incomplete,
     delete_list_item, delete_list, rename_list, clear_list,
     find_item_in_any_list, get_list_count, get_item_count,
-    get_next_available_list_name
+    get_next_available_list_name,
+    get_accessible_list_by_name, can_user_access_list,
+    get_shared_lists_for_user, get_pending_shares
+)
+from routes.handlers.lists import (
+    handle_share_list, handle_unshare_list, handle_show_list_members,
+    handle_leave_shared_list, handle_accept_share, handle_decline_share,
+    format_all_lists_display
 )
 from services.sms_service import send_sms
 from services.ai_service import process_with_ai, parse_list_items
@@ -1884,10 +1891,13 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                             reply_msg = "Couldn't delete that recurring reminder."
 
                     elif delete_type == 'list_item':
-                        from models.list_model import delete_list_item_by_id
+                        from models.list_model import delete_list_item_by_id, delete_list_item_by_list_id
                         item_id = delete_data.get('id')
+                        shared_list_id = delete_data.get('shared_list_id')
                         if item_id and delete_list_item_by_id(item_id, phone_number):
                             reply_msg = f"Removed '{delete_data['text']}' from {delete_data['list_name']}"
+                        elif shared_list_id and delete_list_item_by_list_id(shared_list_id, delete_data['text']):
+                            reply_msg = f"Removed '{delete_data['text']}' from shared list '{delete_data['list_name']}'"
                         elif delete_list_item(phone_number, delete_data['list_name'], delete_data['text']):
                             reply_msg = f"Removed '{delete_data['text']}' from {delete_data['list_name']}"
                         else:
@@ -3886,16 +3896,44 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             return Response(content=str(resp), media_type="application/xml")
 
         # ==========================================
+        # SHARED LIST ACCEPT/DECLINE
+        # ==========================================
+        if incoming_msg.upper() == "ACCEPT":
+            result = handle_accept_share(phone_number, incoming_msg)
+            if result:
+                resp = MessagingResponse()
+                resp.message(result)
+                return Response(content=str(resp), media_type="application/xml")
+            # No pending shares — fall through to normal processing
+
+        if incoming_msg.upper() == "DECLINE":
+            result = handle_decline_share(phone_number, incoming_msg)
+            if result:
+                resp = MessagingResponse()
+                resp.message(result)
+                return Response(content=str(resp), media_type="application/xml")
+            # No pending shares — fall through to normal processing
+
+        # ==========================================
         # LIST COMMANDS (MY LISTS, SHOW LISTS)
         # ==========================================
         if incoming_msg.upper() in ["MY LISTS", "SHOW LISTS", "LIST LISTS", "LISTS"]:
             # Clear any pending list item state so number responses show lists, not add items
             create_or_update_user(phone_number, pending_list_item=None, pending_delete=False)
-            lists = get_lists(phone_number)
-            if len(lists) == 1:
-                # Only one list, show it directly
-                list_id = lists[0][0]
-                list_name = lists[0][1]
+
+            # Use shared-list-aware display
+            reply = format_all_lists_display(phone_number)
+
+            # Set context so "Delete #" knows we're viewing list of lists
+            own_lists = get_lists(phone_number)
+            shared_lists = get_shared_lists_for_user(phone_number)
+            total_lists = len(own_lists) + len(shared_lists)
+            if total_lists == 1:
+                # Only one list total — show it directly
+                if own_lists:
+                    list_id, list_name = own_lists[0][0], own_lists[0][1]
+                else:
+                    list_id, list_name = shared_lists[0][0], shared_lists[0][1]
                 create_or_update_user(phone_number, last_active_list=list_name)
                 items = get_list_items(list_id)
                 if items:
@@ -3905,18 +3943,20 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                             item_lines.append(f"{i}. [x] {item_text}")
                         else:
                             item_lines.append(f"{i}. {item_text}")
-                    reply = f"{list_name}:\n\n" + "\n".join(item_lines)
+                    prefix = "[Shared] " if shared_lists else ""
+                    reply = f"{prefix}{list_name}:\n\n" + "\n".join(item_lines)
                 else:
-                    reply = f"Your {list_name} is empty."
-            elif lists:
-                list_lines = []
-                for i, (list_id, list_name, item_count, completed_count) in enumerate(lists, 1):
-                    list_lines.append(f"{i}. {list_name} ({item_count} items)")
-                reply = "Your lists:\n\n" + "\n".join(list_lines) + "\n\nReply with a number to see that list."
-                # Set context so "Delete #" knows we're viewing list of lists
+                    prefix = "[Shared] " if shared_lists else ""
+                    reply = f"Your {prefix}{list_name} is empty."
+
+                # Still append pending share note
+                pending = get_pending_shares(phone_number)
+                if pending:
+                    reply += f"\n\nYou have {len(pending)} pending shared list invitation{'s' if len(pending) > 1 else ''}. Reply ACCEPT or DECLINE."
+            elif total_lists > 1:
                 create_or_update_user(phone_number, last_active_list="__LISTS__")
             else:
-                reply = "You don't have any lists yet. Try saying 'Create a grocery list'!"
+                pass  # format_all_lists_display already handles empty case
 
             resp = MessagingResponse()
             resp.message(reply)
@@ -5044,8 +5084,39 @@ def process_single_action(ai_response, phone_number, incoming_msg):
 
                 list_info = get_list_by_name(phone_number, list_name)
 
-                # Auto-create list if it doesn't exist
+                # Check shared lists if not found in own lists
+                shared_list_match = None
                 if not list_info:
+                    shared_list_match = get_accessible_list_by_name(phone_number, list_name)
+                    if shared_list_match and shared_list_match[2]:  # is_shared=True
+                        list_id = shared_list_match[0]
+                        list_name = shared_list_match[1]
+                        # Add items to shared list (use owner's item limit, not shared user's)
+                        from services.tier_service import get_tier_limits, get_user_tier, add_list_item_counter_to_message
+                        tier_limits = get_tier_limits(get_user_tier(shared_list_match[3]))  # owner's tier
+                        max_items = tier_limits['max_items_per_list']
+                        item_count = get_item_count(list_id)
+                        available_slots = max_items - item_count
+
+                        added_items = []
+                        for item in items_to_add:
+                            if len(added_items) < available_slots:
+                                add_list_item(list_id, phone_number, item)
+                                added_items.append(item)
+
+                        create_or_update_user(phone_number, last_active_list=list_name)
+
+                        if not added_items:
+                            reply_text = f"The shared list '{list_name}' is full."
+                        elif len(added_items) == 1:
+                            reply_text = f"Added {added_items[0]} to shared list '{list_name}'"
+                        else:
+                            reply_text = f"Added {len(added_items)} items to shared list '{list_name}': {', '.join(added_items)}"
+
+                        log_interaction(phone_number, incoming_msg, reply_text, "add_to_shared_list", True)
+
+                # Auto-create list if it doesn't exist (and not a shared list)
+                if not list_info and not shared_list_match:
                     from services.tier_service import (
                         can_create_list, get_tier_limits, get_user_tier,
                         format_list_limit_message, format_list_item_limit_message,
@@ -5198,11 +5269,13 @@ def process_single_action(ai_response, phone_number, incoming_msg):
 
         elif ai_response["action"] == "show_list":
             list_name = ai_response.get("list_name")
-            list_info = get_list_by_name(phone_number, list_name)
-            if list_info:
-                # Track last active list
-                create_or_update_user(phone_number, last_active_list=list_info[1])
-                items = get_list_items(list_info[0])
+            # Check own lists first, then shared lists
+            accessible = get_accessible_list_by_name(phone_number, list_name)
+            if accessible:
+                list_id, actual_name, is_shared, owner_phone = accessible
+                create_or_update_user(phone_number, last_active_list=actual_name)
+                items = get_list_items(list_id)
+                prefix = "[Shared] " if is_shared else ""
                 if items:
                     item_lines = []
                     for i, (item_id, item_text, completed) in enumerate(items, 1):
@@ -5210,9 +5283,9 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                             item_lines.append(f"{i}. [x] {item_text}")
                         else:
                             item_lines.append(f"{i}. {item_text}")
-                    reply_text = f"{list_info[1]}:\n\n" + "\n".join(item_lines)
+                    reply_text = f"{prefix}{actual_name}:\n\n" + "\n".join(item_lines)
                 else:
-                    reply_text = f"Your {list_info[1]} is empty."
+                    reply_text = f"Your {prefix}{actual_name} is empty."
             else:
                 reply_text = f"I couldn't find a list called '{list_name}'."
             log_interaction(phone_number, incoming_msg, reply_text, "show_list", True)
@@ -5344,18 +5417,27 @@ def process_single_action(ai_response, phone_number, incoming_msg):
             if mark_item_complete(phone_number, list_name, item_text):
                 reply_text = ai_response.get("confirmation", f"Checked off {item_text}")
             else:
-                # Try to find item in any list
-                found = find_item_in_any_list(phone_number, item_text)
-                if len(found) == 1:
-                    list_name = found[0][1]
-                    if mark_item_complete(phone_number, list_name, item_text):
-                        reply_text = f"Checked off {item_text} from your {list_name}"
+                # Try shared lists
+                from models.list_model import mark_item_complete_by_list_id
+                accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
+                if accessible and accessible[2]:  # is_shared
+                    if mark_item_complete_by_list_id(accessible[0], item_text):
+                        reply_text = f"Checked off {item_text} from shared list '{accessible[1]}'"
+                    else:
+                        reply_text = f"Couldn't find '{item_text}' in '{accessible[1]}'."
+                else:
+                    # Try to find item in any of user's own lists
+                    found = find_item_in_any_list(phone_number, item_text)
+                    if len(found) == 1:
+                        list_name = found[0][1]
+                        if mark_item_complete(phone_number, list_name, item_text):
+                            reply_text = f"Checked off {item_text} from your {list_name}"
+                        else:
+                            reply_text = f"Couldn't find '{item_text}' in your lists."
+                    elif len(found) > 1:
+                        reply_text = f"'{item_text}' is in multiple lists. Please specify which list."
                     else:
                         reply_text = f"Couldn't find '{item_text}' in your lists."
-                elif len(found) > 1:
-                    reply_text = f"'{item_text}' is in multiple lists. Please specify which list."
-                else:
-                    reply_text = f"Couldn't find '{item_text}' in your lists."
             log_interaction(phone_number, incoming_msg, reply_text, "complete_item", True)
 
         elif ai_response["action"] == "uncomplete_item":
@@ -5364,21 +5446,37 @@ def process_single_action(ai_response, phone_number, incoming_msg):
             if mark_item_incomplete(phone_number, list_name, item_text):
                 reply_text = ai_response.get("confirmation", f"Unmarked {item_text}")
             else:
-                reply_text = f"Couldn't find '{item_text}' to unmark."
+                # Try shared lists
+                from models.list_model import mark_item_incomplete_by_list_id
+                accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
+                if accessible and accessible[2]:  # is_shared
+                    if mark_item_incomplete_by_list_id(accessible[0], item_text):
+                        reply_text = f"Unmarked {item_text} from shared list '{accessible[1]}'"
+                    else:
+                        reply_text = f"Couldn't find '{item_text}' to unmark."
+                else:
+                    reply_text = f"Couldn't find '{item_text}' to unmark."
             log_interaction(phone_number, incoming_msg, reply_text, "uncomplete_item", True)
 
         elif ai_response["action"] == "delete_item":
             list_name = ai_response.get("list_name")
             item_text = ai_response.get("item_text")
+
+            # Check if this is a shared list the user has access to
+            accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
+            is_shared_list = accessible and accessible[2]
+
             # Ask for confirmation before deleting
             confirm_data = json.dumps({
                 'awaiting_confirmation': True,
                 'type': 'list_item',
                 'list_name': list_name,
-                'text': item_text
+                'text': item_text,
+                'shared_list_id': accessible[0] if is_shared_list else None
             })
             create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
-            reply_text = f"Remove '{item_text}' from {list_name}?\n\nReply YES to confirm or CANCEL to keep it."
+            prefix = "shared list " if is_shared_list else ""
+            reply_text = f"Remove '{item_text}' from {prefix}{list_name}?\n\nReply YES to confirm or CANCEL to keep it."
             log_interaction(phone_number, incoming_msg, "Asking delete_item confirmation", "delete_item_confirm", True)
 
         elif ai_response["action"] == "delete_list":
@@ -5426,7 +5524,12 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                     create_or_update_user(phone_number, pending_delete=True, pending_list_item=list_name)
                     reply_text = f"Are you sure you want to delete your {list_info[1]} and all its items?\n\nReply YES to confirm."
                 else:
-                    reply_text = f"I couldn't find a list called '{list_name}'."
+                    # Check if it's a shared list they don't own
+                    accessible = get_accessible_list_by_name(phone_number, list_name)
+                    if accessible and accessible[2]:  # is_shared
+                        reply_text = f"'{accessible[1]}' is a shared list. Only the owner can delete it. You can text 'Leave {accessible[1]}' to remove yourself."
+                    else:
+                        reply_text = f"I couldn't find a list called '{list_name}'."
             log_interaction(phone_number, incoming_msg, reply_text, "delete_list", True)
 
         elif ai_response["action"] == "clear_list":
@@ -5447,6 +5550,21 @@ def process_single_action(ai_response, phone_number, incoming_msg):
             else:
                 reply_text = f"I couldn't find a list called '{old_name}'."
             log_interaction(phone_number, incoming_msg, reply_text, "rename_list", True)
+
+        # ==========================================
+        # SHARED LIST ACTION HANDLERS
+        # ==========================================
+        elif ai_response["action"] == "share_list":
+            reply_text = handle_share_list(phone_number, incoming_msg, ai_response)
+
+        elif ai_response["action"] == "unshare_list":
+            reply_text = handle_unshare_list(phone_number, incoming_msg, ai_response)
+
+        elif ai_response["action"] == "show_list_members":
+            reply_text = handle_show_list_members(phone_number, incoming_msg, ai_response)
+
+        elif ai_response["action"] == "leave_shared_list":
+            reply_text = handle_leave_shared_list(phone_number, incoming_msg, ai_response)
 
         elif ai_response["action"] == "delete_reminder":
             search_term = ai_response.get("search_term", "")

--- a/main.py
+++ b/main.py
@@ -4699,7 +4699,8 @@ def process_single_action(ai_response, phone_number, incoming_msg):
             # Smart suggestion: offer a prep reminder for high-importance events
             from services.smart_suggestion_service import get_reminder_suggestion
             from services.tier_service import get_user_tier
-            if get_user_tier(phone_number) in ('premium', 'family') and reminder_date_utc:
+            from config import SMART_SUGGESTIONS_BETA_PHONES
+            if get_user_tier(phone_number) in ('premium', 'family') and reminder_date_utc and (not SMART_SUGGESTIONS_BETA_PHONES or phone_number in SMART_SUGGESTIONS_BETA_PHONES):
                 suggestion = get_reminder_suggestion(reminder_text, reminder_date_utc, user_tz_str)
                 if suggestion and not get_pending_reminder_confirmation(phone_number):
                     reply_text += f"\n\n{suggestion['suggestion_text']}"
@@ -4874,7 +4875,8 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                 # Smart suggestion: offer a prep reminder for high-importance events
                 from services.smart_suggestion_service import get_reminder_suggestion
                 from services.tier_service import get_user_tier
-                if get_user_tier(phone_number) in ('premium', 'family'):
+                from config import SMART_SUGGESTIONS_BETA_PHONES
+                if get_user_tier(phone_number) in ('premium', 'family') and (not SMART_SUGGESTIONS_BETA_PHONES or phone_number in SMART_SUGGESTIONS_BETA_PHONES):
                     suggestion = get_reminder_suggestion(reminder_text, reminder_date_utc, user_tz_str)
                     if suggestion and not get_pending_reminder_confirmation(phone_number):
                         reply_text += f"\n\n{suggestion['suggestion_text']}"

--- a/main.py
+++ b/main.py
@@ -1323,6 +1323,23 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                         else:
                             reply_text = "Sorry, I couldn't save that recurring reminder. Please try again."
                             log_interaction(phone_number, incoming_msg, reply_text, "reminder_confirmed", False)
+                    elif pending_confirmation.get('type') == 'smart_suggestion':
+                        # Smart suggestion: user accepted a prep reminder
+                        reminder_text = pending_confirmation.get('reminder_text')
+                        reminder_date_utc = pending_confirmation.get('reminder_date_utc')
+                        local_time = pending_confirmation.get('local_time')
+                        prep_display = pending_confirmation.get('prep_date_display')
+
+                        user_tz_str = get_user_timezone(phone_number)
+                        reminder_id = save_reminder_with_local_time(phone_number, reminder_text, reminder_date_utc, local_time, user_tz_str)
+
+                        if reminder_id:
+                            reply_text = f"Done! I'll remind you on {prep_display} {format_reminder_confirmation(reminder_text)}."
+                            log_interaction(phone_number, incoming_msg, reply_text, "smart_suggestion_accepted", True)
+                        else:
+                            reply_text = "Sorry, I couldn't save that reminder. Please try again."
+                            log_interaction(phone_number, incoming_msg, reply_text, "smart_suggestion_accepted", False)
+
                     else:
                         logger.error(f"Unrecognized pending confirmation action: '{action}'. Keys: {list(pending_confirmation.keys())}")
                         reply_text = "Sorry, something went wrong. Please try again."
@@ -1342,21 +1359,37 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                     return Response(content=str(resp), media_type="application/xml")
 
             # User says it's wrong - ask for clarification
-            elif msg_lower in ['no', 'n', 'wrong', 'nope', "that's wrong", 'thats wrong', 'incorrect', 'not right']:
-                # Log rejection for calibration tracking
-                stored_confidence = pending_confirmation.get('confidence')
-                if stored_confidence is not None:
-                    CONFIDENCE_THRESHOLD = int(get_setting('confidence_threshold', 70))
-                    log_confidence(phone_number, pending_confirmation.get('action', 'reminder'), stored_confidence, CONFIDENCE_THRESHOLD, confirmed=False, user_message=None)
+            elif msg_lower in ['no', 'n', 'wrong', 'nope', "that's wrong", 'thats wrong', 'incorrect', 'not right', "no thanks", "no thank you", "nah", "i'm good", "im good"]:
+                # Smart suggestion decline — just clear and move on
+                if pending_confirmation.get('type') == 'smart_suggestion':
+                    create_or_update_user(phone_number, pending_reminder_confirmation=None)
+                    log_interaction(phone_number, incoming_msg, "Smart suggestion declined", "smart_suggestion_declined", True)
+                    # Don't send a response — let the message fall through in case
+                    # it's also a new command (e.g., "no, remind me to...")
+                    # But if it's just "no", we need to respond
+                    if msg_lower in ['no', 'n', 'nope', 'nah', "no thanks", "no thank you", "i'm good", "im good"]:
+                        resp = MessagingResponse()
+                        resp.message(staging_prefix("No problem!"))
+                        return Response(content=str(resp), media_type="application/xml")
+                    # Otherwise fall through to process the rest of the message
+                else:
+                    # Log rejection for calibration tracking
+                    stored_confidence = pending_confirmation.get('confidence')
+                    if stored_confidence is not None:
+                        CONFIDENCE_THRESHOLD = int(get_setting('confidence_threshold', 70))
+                        log_confidence(phone_number, pending_confirmation.get('action', 'reminder'), stored_confidence, CONFIDENCE_THRESHOLD, confirmed=False, user_message=None)
 
-                create_or_update_user(phone_number, pending_reminder_confirmation=None)
-                resp = MessagingResponse()
-                resp.message(staging_prefix("No problem! Please tell me again what you'd like to be reminded about, and when.\n\nTip: Try something like \"remind me Tuesday at 3pm to call the dentist\""))
-                log_interaction(phone_number, incoming_msg, "Reminder confirmation rejected", "reminder_rejected", True)
-                return Response(content=str(resp), media_type="application/xml")
+                    create_or_update_user(phone_number, pending_reminder_confirmation=None)
+                    resp = MessagingResponse()
+                    resp.message(staging_prefix("No problem! Please tell me again what you'd like to be reminded about, and when.\n\nTip: Try something like \"remind me Tuesday at 3pm to call the dentist\""))
+                    log_interaction(phone_number, incoming_msg, "Reminder confirmation rejected", "reminder_rejected", True)
+                    return Response(content=str(resp), media_type="application/xml")
 
             # User provides a correction directly - treat as new request
             # (If they say something other than yes/no, assume it's a new/corrected request and let it fall through)
+            # For smart suggestions, silently clear the pending state so it doesn't block the next action
+            if pending_confirmation and pending_confirmation.get('type') == 'smart_suggestion':
+                create_or_update_user(phone_number, pending_reminder_confirmation=None)
 
         # ==========================================
         # UNDO / THAT'S WRONG FALLBACK COMMANDS
@@ -4627,6 +4660,8 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                     logger.error(f"Error preparing confirmation: {e}")
                     # Fall through to create reminder anyway
 
+            reminder_date_utc = None
+            user_tz_str = None
             try:
                 user_tz_str = get_user_timezone(phone_number)
                 tz = pytz.timezone(user_tz_str)
@@ -4660,6 +4695,23 @@ def process_single_action(ai_response, phone_number, incoming_msg):
             # Add usage counter for free tier users
             from services.tier_service import add_usage_counter_to_message
             reply_text = add_usage_counter_to_message(phone_number, reply_text, reminder_date)
+
+            # Smart suggestion: offer a prep reminder for high-importance events
+            from services.smart_suggestion_service import get_reminder_suggestion
+            from services.tier_service import get_user_tier
+            if get_user_tier(phone_number) in ('premium', 'family') and reminder_date_utc:
+                suggestion = get_reminder_suggestion(reminder_text, reminder_date_utc, user_tz_str)
+                if suggestion and not get_pending_reminder_confirmation(phone_number):
+                    reply_text += f"\n\n{suggestion['suggestion_text']}"
+                    pending_data = json.dumps({
+                        'type': 'smart_suggestion',
+                        'category': 'prep_reminder',
+                        'reminder_text': suggestion['prep_reminder_text'],
+                        'reminder_date_utc': suggestion['prep_date_utc'],
+                        'local_time': suggestion['prep_local_time'],
+                        'prep_date_display': suggestion['prep_date_display'],
+                    })
+                    create_or_update_user(phone_number, pending_reminder_confirmation=pending_data)
 
             # Check if this is user's first action and prompt for daily summary
             if should_prompt_daily_summary(phone_number):
@@ -4818,6 +4870,23 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                 # Add usage counter for free tier users
                 from services.tier_service import add_usage_counter_to_message
                 reply_text = add_usage_counter_to_message(phone_number, reply_text, reminder_date_utc)
+
+                # Smart suggestion: offer a prep reminder for high-importance events
+                from services.smart_suggestion_service import get_reminder_suggestion
+                from services.tier_service import get_user_tier
+                if get_user_tier(phone_number) in ('premium', 'family'):
+                    suggestion = get_reminder_suggestion(reminder_text, reminder_date_utc, user_tz_str)
+                    if suggestion and not get_pending_reminder_confirmation(phone_number):
+                        reply_text += f"\n\n{suggestion['suggestion_text']}"
+                        pending_data = json.dumps({
+                            'type': 'smart_suggestion',
+                            'category': 'prep_reminder',
+                            'reminder_text': suggestion['prep_reminder_text'],
+                            'reminder_date_utc': suggestion['prep_date_utc'],
+                            'local_time': suggestion['prep_local_time'],
+                            'prep_date_display': suggestion['prep_date_display'],
+                        })
+                        create_or_update_user(phone_number, pending_reminder_confirmation=pending_data)
 
                 # Check if this is user's first action and prompt for daily summary
                 if should_prompt_daily_summary(phone_number):

--- a/main.py
+++ b/main.py
@@ -916,6 +916,25 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             logger.info(f"Referral source detected for ...{phone_number[-4:]}: {referral_source}")
 
         # ==========================================
+        # NON-USER DECLINING A SHARED LIST INVITATION
+        # ==========================================
+        if not is_user_onboarded(phone_number):
+            decline_words = {"no", "no thanks", "no thank you", "nah", "nope", "decline", "stop"}
+            if incoming_msg.strip().lower() in decline_words:
+                pending = get_pending_shares(phone_number)
+                if pending:
+                    from models.list_model import decline_share, get_share_name
+                    from routes.handlers.lists import _format_phone
+                    for share_id, list_id, owner_phone, list_name in pending:
+                        decline_share(phone_number, list_id)
+                        display_name = get_share_name(list_id, phone_number) or _format_phone(phone_number)
+                        send_sms(owner_phone, f"{display_name} declined your shared list '{list_name}'.", message_type="reply")
+                    resp = MessagingResponse()
+                    resp.message("No problem! The invitation has been declined.")
+                    log_interaction(phone_number, incoming_msg, "Non-user declined shared list invitation", "decline_share_non_user", True)
+                    return Response(content=str(resp), media_type="application/xml")
+
+        # ==========================================
         # ONBOARDING CHECK
         # ==========================================
         if not is_user_onboarded(phone_number):

--- a/models/list_model.py
+++ b/models/list_model.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 from database import get_db_connection, return_db_connection
-from config import logger, ENCRYPTION_ENABLED
+from config import logger, ENCRYPTION_ENABLED, SHARED_LIST_MAX_MEMBERS, SHARED_LIST_MAX_PER_USER, SHARED_LIST_MAX_RECEIVED
 
 
 def create_list(phone_number: str, list_name: str) -> Optional[int]:
@@ -670,6 +670,486 @@ def delete_list_item_by_id(item_id: int, phone_number: str) -> bool:
         return deleted
     except Exception as e:
         logger.error(f"Error deleting list item by id: {e}")
+        return False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+# =====================================================
+# SHARED LIST FUNCTIONS
+# =====================================================
+
+
+def share_list(owner_phone: str, list_id: int, shared_with_phone: str) -> tuple[bool, str]:
+    """Share a list with another user. Returns (success, message)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        # Verify the list belongs to the owner
+        c.execute('SELECT id, list_name FROM lists WHERE id = %s AND phone_number = %s', (list_id, owner_phone))
+        list_row = c.fetchone()
+        if not list_row:
+            # Fallback for encryption
+            if ENCRYPTION_ENABLED:
+                from utils.encryption import hash_phone
+                phone_hash = hash_phone(owner_phone)
+                c.execute('SELECT id, list_name FROM lists WHERE id = %s AND phone_hash = %s', (list_id, phone_hash))
+                list_row = c.fetchone()
+            if not list_row:
+                return False, "List not found."
+
+        # Check if already shared with this user
+        c.execute(
+            'SELECT status FROM list_shares WHERE list_id = %s AND shared_with_phone = %s',
+            (list_id, shared_with_phone)
+        )
+        existing = c.fetchone()
+        if existing:
+            status = existing[0]
+            if status == 'accepted':
+                return False, "This list is already shared with that user."
+            elif status == 'pending':
+                return False, "An invitation is already pending for that user."
+            else:
+                # Declined before — allow re-share by updating
+                c.execute(
+                    '''UPDATE list_shares SET status = 'pending', created_at = CURRENT_TIMESTAMP, accepted_at = NULL
+                       WHERE list_id = %s AND shared_with_phone = %s''',
+                    (list_id, shared_with_phone)
+                )
+                conn.commit()
+                return True, "Invitation re-sent."
+
+        # Check per-list member cap
+        c.execute(
+            "SELECT COUNT(*) FROM list_shares WHERE list_id = %s AND status IN ('pending', 'accepted')",
+            (list_id,)
+        )
+        member_count = c.fetchone()[0]
+        if member_count >= SHARED_LIST_MAX_MEMBERS:
+            return False, f"This list already has {SHARED_LIST_MAX_MEMBERS} shared members (max)."
+
+        # Check owner's total shared list count
+        c.execute(
+            """SELECT COUNT(DISTINCT list_id) FROM list_shares
+               WHERE owner_phone = %s AND status IN ('pending', 'accepted')""",
+            (owner_phone,)
+        )
+        owner_share_count = c.fetchone()[0]
+        if owner_share_count >= SHARED_LIST_MAX_PER_USER:
+            return False, f"You can share up to {SHARED_LIST_MAX_PER_USER} lists. You've reached the limit."
+
+        # Check recipient's received share count
+        c.execute(
+            "SELECT COUNT(*) FROM list_shares WHERE shared_with_phone = %s AND status = 'accepted'",
+            (shared_with_phone,)
+        )
+        received_count = c.fetchone()[0]
+        if received_count >= SHARED_LIST_MAX_RECEIVED:
+            return False, "That user has reached their shared list limit."
+
+        # Create the share
+        if ENCRYPTION_ENABLED:
+            from utils.encryption import hash_phone
+            owner_hash = hash_phone(owner_phone)
+            shared_hash = hash_phone(shared_with_phone)
+            c.execute(
+                '''INSERT INTO list_shares (list_id, owner_phone, shared_with_phone, owner_phone_hash, shared_with_phone_hash)
+                   VALUES (%s, %s, %s, %s, %s)''',
+                (list_id, owner_phone, shared_with_phone, owner_hash, shared_hash)
+            )
+        else:
+            c.execute(
+                'INSERT INTO list_shares (list_id, owner_phone, shared_with_phone) VALUES (%s, %s, %s)',
+                (list_id, owner_phone, shared_with_phone)
+            )
+
+        conn.commit()
+        logger.info(f"Shared list {list_id} with {shared_with_phone[-4:]}")
+        return True, "Invitation sent."
+    except Exception as e:
+        logger.error(f"Error sharing list: {e}")
+        return False, "Something went wrong. Please try again."
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def accept_share(phone_number: str, list_id: int) -> tuple[bool, str]:
+    """Accept a pending shared list invitation. Returns (success, message)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        c.execute(
+            """UPDATE list_shares SET status = 'accepted', accepted_at = CURRENT_TIMESTAMP
+               WHERE shared_with_phone = %s AND list_id = %s AND status = 'pending'""",
+            (phone_number, list_id)
+        )
+        if c.rowcount == 0:
+            return False, "No pending invitation found for this list."
+
+        conn.commit()
+        logger.info(f"User {phone_number[-4:]} accepted share for list {list_id}")
+        return True, "Share accepted."
+    except Exception as e:
+        logger.error(f"Error accepting share: {e}")
+        return False, "Something went wrong. Please try again."
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def decline_share(phone_number: str, list_id: int) -> tuple[bool, str]:
+    """Decline a pending shared list invitation. Returns (success, message)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        c.execute(
+            "DELETE FROM list_shares WHERE shared_with_phone = %s AND list_id = %s AND status = 'pending'",
+            (phone_number, list_id)
+        )
+        if c.rowcount == 0:
+            return False, "No pending invitation found."
+
+        conn.commit()
+        logger.info(f"User {phone_number[-4:]} declined share for list {list_id}")
+        return True, "Invitation declined."
+    except Exception as e:
+        logger.error(f"Error declining share: {e}")
+        return False, "Something went wrong. Please try again."
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def leave_shared_list(phone_number: str, list_id: int) -> tuple[bool, str]:
+    """Leave a shared list. Returns (success, message)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        c.execute(
+            "DELETE FROM list_shares WHERE shared_with_phone = %s AND list_id = %s AND status = 'accepted'",
+            (phone_number, list_id)
+        )
+        if c.rowcount == 0:
+            return False, "You're not a member of this shared list."
+
+        conn.commit()
+        logger.info(f"User {phone_number[-4:]} left shared list {list_id}")
+        return True, "You've left the shared list."
+    except Exception as e:
+        logger.error(f"Error leaving shared list: {e}")
+        return False, "Something went wrong. Please try again."
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def unshare_list(owner_phone: str, list_id: int, shared_with_phone: str) -> tuple[bool, str]:
+    """Remove a specific user's access to a shared list. Returns (success, message)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        c.execute(
+            'DELETE FROM list_shares WHERE list_id = %s AND owner_phone = %s AND shared_with_phone = %s',
+            (list_id, owner_phone, shared_with_phone)
+        )
+        if c.rowcount == 0:
+            return False, "That user doesn't have access to this list."
+
+        conn.commit()
+        logger.info(f"Unshared list {list_id} from {shared_with_phone[-4:]}")
+        return True, "Access removed."
+    except Exception as e:
+        logger.error(f"Error unsharing list: {e}")
+        return False, "Something went wrong. Please try again."
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def unshare_list_all(owner_phone: str, list_id: int) -> tuple[bool, str]:
+    """Remove all sharing from a list. Returns (success, message)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        c.execute(
+            'DELETE FROM list_shares WHERE list_id = %s AND owner_phone = %s',
+            (list_id, owner_phone)
+        )
+        removed = c.rowcount
+        if removed == 0:
+            return False, "This list isn't shared with anyone."
+
+        conn.commit()
+        logger.info(f"Removed all {removed} shares from list {list_id}")
+        return True, f"Stopped sharing with {removed} user{'s' if removed > 1 else ''}."
+    except Exception as e:
+        logger.error(f"Error unsharing list: {e}")
+        return False, "Something went wrong. Please try again."
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def get_list_members(list_id: int) -> list[tuple[str, str, str]]:
+    """Get all members of a shared list. Returns [(phone, status, permission), ...]."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        c.execute(
+            """SELECT shared_with_phone, status, permission
+               FROM list_shares WHERE list_id = %s
+               ORDER BY created_at""",
+            (list_id,)
+        )
+        return c.fetchall()
+    except Exception as e:
+        logger.error(f"Error getting list members: {e}")
+        return []
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def get_pending_shares(phone_number: str) -> list[tuple[int, int, str, str]]:
+    """Get pending share invitations for a user.
+    Returns [(share_id, list_id, owner_phone, list_name), ...]."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        c.execute(
+            """SELECT ls.id, ls.list_id, ls.owner_phone, l.list_name
+               FROM list_shares ls
+               JOIN lists l ON ls.list_id = l.id
+               WHERE ls.shared_with_phone = %s AND ls.status = 'pending'
+               ORDER BY ls.created_at DESC""",
+            (phone_number,)
+        )
+        return c.fetchall()
+    except Exception as e:
+        logger.error(f"Error getting pending shares: {e}")
+        return []
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def get_shared_lists_for_user(phone_number: str) -> list[tuple[int, str, int, int, str]]:
+    """Get all accepted shared lists for a user (lists others shared with them).
+    Returns [(list_id, list_name, item_count, completed_count, owner_phone), ...]."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        c.execute('''
+            SELECT l.id, l.list_name,
+                   COUNT(li.id) as item_count,
+                   SUM(CASE WHEN li.completed THEN 1 ELSE 0 END) as completed_count,
+                   ls.owner_phone
+            FROM list_shares ls
+            JOIN lists l ON ls.list_id = l.id
+            LEFT JOIN list_items li ON l.id = li.list_id
+            WHERE ls.shared_with_phone = %s AND ls.status = 'accepted'
+            GROUP BY l.id, l.list_name, ls.owner_phone
+            ORDER BY l.created_at DESC
+        ''', (phone_number,))
+        return c.fetchall()
+    except Exception as e:
+        logger.error(f"Error getting shared lists: {e}")
+        return []
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def get_accessible_list_by_name(phone_number: str, list_name: str) -> Optional[tuple[int, str, bool, Optional[str]]]:
+    """Find a list the user owns OR has shared access to.
+    Returns (list_id, list_name, is_shared, owner_phone) or None.
+    Checks own lists first, then shared lists."""
+    # Check own lists first
+    own_list = get_list_by_name(phone_number, list_name)
+    if own_list:
+        return (own_list[0], own_list[1], False, None)
+
+    # Check shared lists
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        c.execute('''
+            SELECT l.id, l.list_name, ls.owner_phone
+            FROM list_shares ls
+            JOIN lists l ON ls.list_id = l.id
+            WHERE ls.shared_with_phone = %s AND ls.status = 'accepted'
+              AND LOWER(l.list_name) = LOWER(%s)
+        ''', (phone_number, list_name))
+        result = c.fetchone()
+        if result:
+            return (result[0], result[1], True, result[2])
+        return None
+    except Exception as e:
+        logger.error(f"Error getting accessible list: {e}")
+        return None
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def can_user_access_list(phone_number: str, list_id: int) -> tuple[bool, bool]:
+    """Check if a user can access a list (owns it or has accepted share).
+    Returns (has_access, is_owner)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        # Check ownership
+        if ENCRYPTION_ENABLED:
+            from utils.encryption import hash_phone
+            phone_hash = hash_phone(phone_number)
+            c.execute('SELECT id FROM lists WHERE id = %s AND (phone_hash = %s OR phone_number = %s)',
+                      (list_id, phone_hash, phone_number))
+        else:
+            c.execute('SELECT id FROM lists WHERE id = %s AND phone_number = %s', (list_id, phone_number))
+
+        if c.fetchone():
+            return True, True
+
+        # Check shared access
+        c.execute(
+            "SELECT id FROM list_shares WHERE list_id = %s AND shared_with_phone = %s AND status = 'accepted'",
+            (list_id, phone_number)
+        )
+        if c.fetchone():
+            return True, False
+
+        return False, False
+    except Exception as e:
+        logger.error(f"Error checking list access: {e}")
+        return False, False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def get_share_count_for_list(list_id: int) -> int:
+    """Get the number of users a list is shared with (pending + accepted)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            "SELECT COUNT(*) FROM list_shares WHERE list_id = %s AND status IN ('pending', 'accepted')",
+            (list_id,)
+        )
+        return c.fetchone()[0]
+    except Exception as e:
+        logger.error(f"Error getting share count: {e}")
+        return 0
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def get_owner_shared_list_count(owner_phone: str) -> int:
+    """Get the number of distinct lists an owner has shared."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """SELECT COUNT(DISTINCT list_id) FROM list_shares
+               WHERE owner_phone = %s AND status IN ('pending', 'accepted')""",
+            (owner_phone,)
+        )
+        return c.fetchone()[0]
+    except Exception as e:
+        logger.error(f"Error getting owner share count: {e}")
+        return 0
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def mark_item_complete_by_list_id(list_id: int, item_text: str) -> bool:
+    """Mark an item complete by list_id (for shared list access without ownership check)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            '''UPDATE list_items SET completed = TRUE
+               WHERE list_id = %s AND LOWER(item_text) = LOWER(%s) AND completed = FALSE''',
+            (list_id, item_text)
+        )
+        updated = c.rowcount > 0
+        conn.commit()
+        return updated
+    except Exception as e:
+        logger.error(f"Error marking item complete by list_id: {e}")
+        return False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def mark_item_incomplete_by_list_id(list_id: int, item_text: str) -> bool:
+    """Mark an item incomplete by list_id (for shared list access)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            '''UPDATE list_items SET completed = FALSE
+               WHERE list_id = %s AND LOWER(item_text) = LOWER(%s) AND completed = TRUE''',
+            (list_id, item_text)
+        )
+        updated = c.rowcount > 0
+        conn.commit()
+        return updated
+    except Exception as e:
+        logger.error(f"Error marking item incomplete by list_id: {e}")
+        return False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def delete_list_item_by_list_id(list_id: int, item_text: str) -> bool:
+    """Delete an item by list_id and text (for shared list access)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            'DELETE FROM list_items WHERE list_id = %s AND LOWER(item_text) = LOWER(%s)',
+            (list_id, item_text)
+        )
+        deleted = c.rowcount > 0
+        conn.commit()
+        return deleted
+    except Exception as e:
+        logger.error(f"Error deleting list item by list_id: {e}")
         return False
     finally:
         if conn:

--- a/models/list_model.py
+++ b/models/list_model.py
@@ -818,6 +818,28 @@ def get_share_name(list_id: int, shared_with_phone: str) -> str | None:
             return_db_connection(conn)
 
 
+def get_known_recipients(owner_phone: str, name: str) -> list[tuple[str, str]]:
+    """Look up previous share recipients by name for this owner.
+    Returns [(phone, name), ...] matching the given name (case-insensitive)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """SELECT DISTINCT shared_with_phone, shared_with_name
+               FROM list_shares
+               WHERE owner_phone = %s AND LOWER(shared_with_name) = LOWER(%s)""",
+            (owner_phone, name)
+        )
+        return c.fetchall()
+    except Exception as e:
+        logger.error(f"Error looking up known recipients: {e}")
+        return []
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
 def accept_share(phone_number: str, list_id: int) -> tuple[bool, str]:
     """Accept a pending shared list invitation. Returns (success, message)."""
     conn = None

--- a/models/list_model.py
+++ b/models/list_model.py
@@ -778,6 +778,46 @@ def share_list(owner_phone: str, list_id: int, shared_with_phone: str) -> tuple[
             return_db_connection(conn)
 
 
+def set_share_name(list_id: int, shared_with_phone: str, name: str) -> bool:
+    """Set the owner-assigned name for a shared user."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            'UPDATE list_shares SET shared_with_name = %s WHERE list_id = %s AND shared_with_phone = %s',
+            (name, list_id, shared_with_phone)
+        )
+        conn.commit()
+        return c.rowcount > 0
+    except Exception as e:
+        logger.error(f"Error setting share name: {e}")
+        return False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def get_share_name(list_id: int, shared_with_phone: str) -> str | None:
+    """Get the owner-assigned name for a shared user."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            'SELECT shared_with_name FROM list_shares WHERE list_id = %s AND shared_with_phone = %s',
+            (list_id, shared_with_phone)
+        )
+        row = c.fetchone()
+        return row[0] if row else None
+    except Exception as e:
+        logger.error(f"Error getting share name: {e}")
+        return None
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
 def accept_share(phone_number: str, list_id: int) -> tuple[bool, str]:
     """Accept a pending shared list invitation. Returns (success, message)."""
     conn = None
@@ -905,15 +945,15 @@ def unshare_list_all(owner_phone: str, list_id: int) -> tuple[bool, str]:
             return_db_connection(conn)
 
 
-def get_list_members(list_id: int) -> list[tuple[str, str, str]]:
-    """Get all members of a shared list. Returns [(phone, status, permission), ...]."""
+def get_list_members(list_id: int) -> list[tuple[str, str, str, str | None]]:
+    """Get all members of a shared list. Returns [(phone, status, permission, name), ...]."""
     conn = None
     try:
         conn = get_db_connection()
         c = conn.cursor()
 
         c.execute(
-            """SELECT shared_with_phone, status, permission
+            """SELECT shared_with_phone, status, permission, shared_with_name
                FROM list_shares WHERE list_id = %s
                ORDER BY created_at""",
             (list_id,)
@@ -1047,6 +1087,39 @@ def can_user_access_list(phone_number: str, list_id: int) -> tuple[bool, bool]:
     except Exception as e:
         logger.error(f"Error checking list access: {e}")
         return False, False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def is_shared_list_read_only(list_id: int) -> tuple[bool, str | None]:
+    """Check if a shared list is read-only because the owner is no longer Premium.
+    Returns (is_read_only, owner_first_name)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        # Get owner phone
+        c.execute('SELECT phone_number FROM lists WHERE id = %s', (list_id,))
+        row = c.fetchone()
+        if not row:
+            return False, None
+        owner_phone = row[0]
+
+        # Check owner's tier
+        from services.tier_service import get_user_tier
+        tier = get_user_tier(owner_phone)
+        if tier != 'premium':
+            from models.user import get_user
+            owner = get_user(owner_phone)
+            owner_name = owner[1] if owner else None
+            return True, owner_name
+
+        return False, None
+    except Exception as e:
+        logger.error(f"Error checking shared list read-only: {e}")
+        return False, None
     finally:
         if conn:
             return_db_connection(conn)

--- a/models/user.py
+++ b/models/user.py
@@ -47,6 +47,8 @@ ALLOWED_USER_FIELDS = {
     'inactivity_nudge_sent_at',
     # Free tier versioning
     'free_tier_version',
+    # Shared lists
+    'pending_share_name',
 }
 
 

--- a/routes/handlers/lists.py
+++ b/routes/handlers/lists.py
@@ -521,15 +521,99 @@ def handle_share_list(
     ai_response: dict[str, Any]
 ) -> str:
     """Handle share_list action — share a list with another user."""
+    import json
     from services.tier_service import can_share_list
     from services.sms_service import send_sms
     from models.user import get_user
+    from models.list_model import get_known_recipients, set_share_name
 
     list_name = ai_response.get("list_name")
     target_phone = ai_response.get("phone_number")
+    target_name = ai_response.get("shared_with_name")
 
+    # Check premium status early
+    allowed, limit_msg = can_share_list(phone_number)
+    if not allowed:
+        reply_text = limit_msg
+        log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+        return reply_text
+
+    # Find the list early (needed for all paths)
+    list_info = get_list_by_name(phone_number, list_name)
+    if not list_info:
+        reply_text = f"I couldn't find a list called '{list_name}'."
+        log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+        return reply_text
+
+    list_id, actual_name = list_info
+
+    # --- Path A: Name given instead of phone number ---
+    if not target_phone and target_name:
+        matches = get_known_recipients(phone_number, target_name)
+
+        if len(matches) == 1:
+            # Exact match — use the known phone, skip name prompt
+            target_phone = matches[0][0]
+            recipient_name = matches[0][1]
+
+            if target_phone == phone_number:
+                reply_text = "You can't share a list with yourself!"
+                log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+                return reply_text
+
+            success, message = share_list(phone_number, list_id, target_phone)
+            if not success:
+                reply_text = message
+                log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+                return reply_text
+
+            # We already know the name — save it and send invitation immediately
+            set_share_name(list_id, target_phone, recipient_name)
+            owner_user = get_user(phone_number)
+            owner_name = owner_user[1] if owner_user else "Someone"
+
+            recipient = get_user(target_phone)
+            if recipient:
+                invite_msg = (
+                    f"[Shared List] Hi {recipient_name}! {owner_name} shared '{actual_name}' with you.\n\n"
+                    f"Reply ACCEPT to join or DECLINE to skip."
+                )
+            else:
+                invite_msg = (
+                    f"Hi {recipient_name}! {owner_name} shared a list with you on Remyndrs. "
+                    f"Reply YES to join and see '{actual_name}'."
+                )
+            send_sms(target_phone, invite_msg, message_type="reply")
+
+            reply_text = f"Invitation sent to {recipient_name} for '{actual_name}'."
+            log_interaction(phone_number, incoming_msg, reply_text, "share_list_by_name", True)
+            return reply_text
+
+        elif len(matches) > 1:
+            # Multiple people with same name — ask which one
+            lines = [f"You've shared with multiple people named {target_name}:\n"]
+            for i, (m_phone, m_name) in enumerate(matches, 1):
+                lines.append(f"{i}. {m_name} — {_format_phone(m_phone)}")
+            lines.append(f"\nPlease share using their phone number instead.")
+            reply_text = "\n".join(lines)
+            log_interaction(phone_number, incoming_msg, reply_text, "share_list_disambiguate", True)
+            return reply_text
+
+        else:
+            # Unknown name — ask for phone number
+            pending_data = json.dumps({
+                'list_id': list_id,
+                'list_name': actual_name,
+                'recipient_name': target_name,
+            })
+            create_or_update_user(phone_number, pending_share_name=pending_data)
+            reply_text = f"I don't have a number for {target_name}. What's their phone number?"
+            log_interaction(phone_number, incoming_msg, reply_text, "share_list_ask_phone", True)
+            return reply_text
+
+    # --- Path B: Phone number given ---
     if not target_phone:
-        reply_text = "Please include the phone number of the person you want to share with."
+        reply_text = "Please include the phone number or name of the person you want to share with."
         log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
         return reply_text
 
@@ -542,22 +626,6 @@ def handle_share_list(
         log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
         return reply_text
 
-    # Check premium status
-    allowed, limit_msg = can_share_list(phone_number)
-    if not allowed:
-        reply_text = limit_msg
-        log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
-        return reply_text
-
-    # Find the list
-    list_info = get_list_by_name(phone_number, list_name)
-    if not list_info:
-        reply_text = f"I couldn't find a list called '{list_name}'."
-        log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
-        return reply_text
-
-    list_id, actual_name = list_info
-
     # Create the share
     success, message = share_list(phone_number, list_id, target_phone)
     if not success:
@@ -566,7 +634,6 @@ def handle_share_list(
         return reply_text
 
     # Store pending state — ask for the recipient's name before sending invitation
-    import json
     pending_data = json.dumps({
         'list_id': list_id,
         'shared_with_phone': target_phone,
@@ -580,8 +647,11 @@ def handle_share_list(
 
 
 def handle_pending_share_name(phone_number: str, incoming_msg: str) -> str | None:
-    """Handle the name response after a share_list action.
-    Returns reply text if handled, None if no pending share name."""
+    """Handle the pending response after a share_list action.
+    Two modes:
+      - shared_with_phone set → owner is providing the recipient's name
+      - recipient_name set (no phone) → owner is providing a phone number
+    Returns reply text if handled, None if no pending state."""
     import json
     from services.sms_service import send_sms
     from models.user import get_user
@@ -609,38 +679,78 @@ def handle_pending_share_name(phone_number: str, incoming_msg: str) -> str | Non
         return None
 
     list_id = pending['list_id']
-    target_phone = pending['shared_with_phone']
     list_name = pending['list_name']
+    target_phone = pending.get('shared_with_phone')
+    recipient_name = pending.get('recipient_name')
 
-    # The incoming message is the name
-    recipient_name = incoming_msg.strip().title()
-
-    # Save the name on the share
-    set_share_name(list_id, target_phone, recipient_name)
-
-    # Clear the pending state
-    create_or_update_user(phone_number, pending_share_name=None)
-
-    # Get owner's name for the invitation message
     owner_name = user[1] if user[1] else "Someone"
 
-    # Send the invitation SMS
-    recipient = get_user(target_phone)
-    if recipient:
-        invite_msg = (
-            f"[Shared List] Hi {recipient_name}! {owner_name} shared '{list_name}' with you.\n\n"
-            f"Reply ACCEPT to join or DECLINE to skip."
-        )
-    else:
-        invite_msg = (
-            f"Hi {recipient_name}! {owner_name} shared a list with you on Remyndrs. "
-            f"Reply YES to join and see '{list_name}'."
-        )
-    send_sms(target_phone, invite_msg, message_type="reply")
+    # --- Mode 1: Owner is providing a phone number (we already have the name) ---
+    if recipient_name and not target_phone:
+        target_phone = _normalize_phone(incoming_msg.strip())
 
-    reply_text = f"Invitation sent to {recipient_name} ({_format_phone(target_phone)}) for '{list_name}'."
-    log_interaction(phone_number, incoming_msg, reply_text, "share_list_named", True)
-    return reply_text
+        if target_phone == phone_number:
+            create_or_update_user(phone_number, pending_share_name=None)
+            reply_text = "You can't share a list with yourself!"
+            log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+            return reply_text
+
+        success, message = share_list(phone_number, list_id, target_phone)
+        if not success:
+            create_or_update_user(phone_number, pending_share_name=None)
+            reply_text = message
+            log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+            return reply_text
+
+        set_share_name(list_id, target_phone, recipient_name)
+        create_or_update_user(phone_number, pending_share_name=None)
+
+        # Send invitation
+        recipient = get_user(target_phone)
+        if recipient:
+            invite_msg = (
+                f"[Shared List] Hi {recipient_name}! {owner_name} shared '{list_name}' with you.\n\n"
+                f"Reply ACCEPT to join or DECLINE to skip."
+            )
+        else:
+            invite_msg = (
+                f"Hi {recipient_name}! {owner_name} shared a list with you on Remyndrs. "
+                f"Reply YES to join and see '{list_name}'."
+            )
+        send_sms(target_phone, invite_msg, message_type="reply")
+
+        reply_text = f"Invitation sent to {recipient_name} ({_format_phone(target_phone)}) for '{list_name}'."
+        log_interaction(phone_number, incoming_msg, reply_text, "share_list_named", True)
+        return reply_text
+
+    # --- Mode 2: Owner is providing a name (we already have the phone) ---
+    if target_phone:
+        recipient_name = incoming_msg.strip().title()
+
+        set_share_name(list_id, target_phone, recipient_name)
+        create_or_update_user(phone_number, pending_share_name=None)
+
+        # Send invitation
+        recipient = get_user(target_phone)
+        if recipient:
+            invite_msg = (
+                f"[Shared List] Hi {recipient_name}! {owner_name} shared '{list_name}' with you.\n\n"
+                f"Reply ACCEPT to join or DECLINE to skip."
+            )
+        else:
+            invite_msg = (
+                f"Hi {recipient_name}! {owner_name} shared a list with you on Remyndrs. "
+                f"Reply YES to join and see '{list_name}'."
+            )
+        send_sms(target_phone, invite_msg, message_type="reply")
+
+        reply_text = f"Invitation sent to {recipient_name} ({_format_phone(target_phone)}) for '{list_name}'."
+        log_interaction(phone_number, incoming_msg, reply_text, "share_list_named", True)
+        return reply_text
+
+    # Shouldn't reach here — clear state
+    create_or_update_user(phone_number, pending_share_name=None)
+    return None
 
 
 def handle_unshare_list(

--- a/routes/handlers/lists.py
+++ b/routes/handlers/lists.py
@@ -12,7 +12,14 @@ from models.list_model import (
     create_list, get_list_by_name, get_lists, get_list_items,
     add_list_item, get_item_count, mark_item_complete, mark_item_incomplete,
     delete_list_item, delete_list as db_delete_list, clear_list as db_clear_list,
-    rename_list as db_rename_list, find_item_in_any_list
+    rename_list as db_rename_list, find_item_in_any_list,
+    share_list, unshare_list, unshare_list_all, get_list_members,
+    get_accessible_list_by_name, can_user_access_list,
+    get_shared_lists_for_user, get_pending_shares,
+    accept_share, decline_share, leave_shared_list,
+    add_list_item as db_add_list_item,
+    mark_item_complete_by_list_id, mark_item_incomplete_by_list_id,
+    delete_list_item_by_list_id
 )
 from services.ai_service import parse_list_items
 from utils.validation import (
@@ -501,3 +508,331 @@ def handle_rename_list(
 
     log_interaction(phone_number, incoming_msg, reply_text, "rename_list", True)
     return reply_text
+
+
+# =====================================================
+# SHARED LIST HANDLERS
+# =====================================================
+
+
+def handle_share_list(
+    phone_number: str,
+    incoming_msg: str,
+    ai_response: dict[str, Any]
+) -> str:
+    """Handle share_list action — share a list with another user."""
+    from services.tier_service import can_share_list
+    from services.sms_service import send_sms
+    from models.user import get_user
+
+    list_name = ai_response.get("list_name")
+    target_phone = ai_response.get("phone_number")
+
+    if not target_phone:
+        reply_text = "Please include the phone number of the person you want to share with."
+        log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+        return reply_text
+
+    # Normalize phone number
+    target_phone = _normalize_phone(target_phone)
+
+    # Can't share with yourself
+    if target_phone == phone_number:
+        reply_text = "You can't share a list with yourself!"
+        log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+        return reply_text
+
+    # Check premium status
+    allowed, limit_msg = can_share_list(phone_number)
+    if not allowed:
+        reply_text = limit_msg
+        log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+        return reply_text
+
+    # Find the list
+    list_info = get_list_by_name(phone_number, list_name)
+    if not list_info:
+        reply_text = f"I couldn't find a list called '{list_name}'."
+        log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+        return reply_text
+
+    list_id, actual_name = list_info
+
+    # Create the share
+    success, message = share_list(phone_number, list_id, target_phone)
+    if not success:
+        reply_text = message
+        log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
+        return reply_text
+
+    # Get owner's name for the invitation message
+    owner_user = get_user(phone_number)
+    owner_name = owner_user.get('first_name', 'Someone') if owner_user else 'Someone'
+
+    # Check if recipient is on Remyndrs
+    recipient = get_user(target_phone)
+    if recipient:
+        # Existing user — send invitation SMS
+        invite_msg = (
+            f"[Shared List] {owner_name} shared '{actual_name}' with you!\n\n"
+            f"Reply ACCEPT to join or DECLINE to skip."
+        )
+        send_sms(target_phone, invite_msg, message_type="reply")
+    else:
+        # Not on Remyndrs — send signup invitation
+        invite_msg = (
+            f"{owner_name} shared a list with you on Remyndrs! "
+            f"Reply YES to join and see '{actual_name}'."
+        )
+        send_sms(target_phone, invite_msg, message_type="reply")
+
+    reply_text = f"Invitation sent to {_format_phone(target_phone)} for '{actual_name}'."
+    log_interaction(phone_number, incoming_msg, reply_text, "share_list", True)
+    return reply_text
+
+
+def handle_unshare_list(
+    phone_number: str,
+    incoming_msg: str,
+    ai_response: dict[str, Any]
+) -> str:
+    """Handle unshare_list action — remove sharing from a list."""
+    list_name = ai_response.get("list_name")
+    target_phone = ai_response.get("phone_number")
+
+    list_info = get_list_by_name(phone_number, list_name)
+    if not list_info:
+        reply_text = f"I couldn't find a list called '{list_name}'."
+        log_interaction(phone_number, incoming_msg, reply_text, "unshare_list", False)
+        return reply_text
+
+    list_id, actual_name = list_info
+
+    if target_phone:
+        # Remove specific user
+        target_phone = _normalize_phone(target_phone)
+        success, message = unshare_list(phone_number, list_id, target_phone)
+        if success:
+            reply_text = f"Removed {_format_phone(target_phone)} from '{actual_name}'."
+        else:
+            reply_text = message
+    else:
+        # Remove all sharing
+        success, message = unshare_list_all(phone_number, list_id)
+        if success:
+            reply_text = f"Stopped sharing '{actual_name}'. {message}"
+        else:
+            reply_text = message
+
+    log_interaction(phone_number, incoming_msg, reply_text, "unshare_list", success)
+    return reply_text
+
+
+def handle_show_list_members(
+    phone_number: str,
+    incoming_msg: str,
+    ai_response: dict[str, Any]
+) -> str:
+    """Handle show_list_members action — show who has access to a shared list."""
+    from models.user import get_user
+
+    list_name = ai_response.get("list_name")
+    list_info = get_list_by_name(phone_number, list_name)
+
+    if not list_info:
+        reply_text = f"I couldn't find a list called '{list_name}'."
+        log_interaction(phone_number, incoming_msg, reply_text, "show_list_members", False)
+        return reply_text
+
+    list_id, actual_name = list_info
+    members = get_list_members(list_id)
+
+    if not members:
+        reply_text = f"'{actual_name}' isn't shared with anyone."
+    else:
+        lines = [f"'{actual_name}' is shared with:\n"]
+        for i, (member_phone, status, permission) in enumerate(members, 1):
+            # Try to get member's name
+            member_user = get_user(member_phone)
+            member_name = member_user.get('first_name', '') if member_user else ''
+            display = member_name if member_name else _format_phone(member_phone)
+
+            status_label = " (pending)" if status == 'pending' else ""
+            lines.append(f"{i}. {display}{status_label}")
+
+        reply_text = "\n".join(lines)
+
+    log_interaction(phone_number, incoming_msg, reply_text, "show_list_members", True)
+    return reply_text
+
+
+def handle_leave_shared_list(
+    phone_number: str,
+    incoming_msg: str,
+    ai_response: dict[str, Any]
+) -> str:
+    """Handle leave_shared_list action — user leaves a shared list they don't own."""
+    from models.list_model import get_accessible_list_by_name
+
+    list_name = ai_response.get("list_name")
+    accessible = get_accessible_list_by_name(phone_number, list_name)
+
+    if not accessible:
+        reply_text = f"I couldn't find a shared list called '{list_name}'."
+        log_interaction(phone_number, incoming_msg, reply_text, "leave_shared_list", False)
+        return reply_text
+
+    list_id, actual_name, is_shared, owner_phone = accessible
+
+    if not is_shared:
+        reply_text = f"'{actual_name}' is your own list. Use 'delete {actual_name}' to remove it."
+        log_interaction(phone_number, incoming_msg, reply_text, "leave_shared_list", False)
+        return reply_text
+
+    success, message = leave_shared_list(phone_number, list_id)
+    if success:
+        reply_text = f"You've left '{actual_name}'."
+    else:
+        reply_text = message
+
+    log_interaction(phone_number, incoming_msg, reply_text, "leave_shared_list", success)
+    return reply_text
+
+
+def handle_accept_share(phone_number: str, incoming_msg: str) -> str:
+    """Handle ACCEPT keyword for pending shared list invitations."""
+    pending = get_pending_shares(phone_number)
+
+    if not pending:
+        return None  # No pending shares — let normal processing continue
+
+    if len(pending) == 1:
+        share_id, list_id, owner_phone, list_name = pending[0]
+        success, message = accept_share(phone_number, list_id)
+        if success:
+            reply_text = f"You now have access to '{list_name}'! Text 'Show {list_name}' to see it."
+        else:
+            reply_text = message
+    else:
+        # Multiple pending — accept the most recent
+        share_id, list_id, owner_phone, list_name = pending[0]
+        success, message = accept_share(phone_number, list_id)
+        remaining = len(pending) - 1
+        if success:
+            reply_text = (
+                f"You now have access to '{list_name}'!\n\n"
+                f"You have {remaining} more pending invitation{'s' if remaining > 1 else ''}. "
+                f"Reply ACCEPT again to accept the next one."
+            )
+        else:
+            reply_text = message
+
+    log_interaction(phone_number, incoming_msg, reply_text, "accept_share", True)
+    return reply_text
+
+
+def handle_decline_share(phone_number: str, incoming_msg: str) -> str:
+    """Handle DECLINE keyword for pending shared list invitations."""
+    from services.sms_service import send_sms
+
+    pending = get_pending_shares(phone_number)
+
+    if not pending:
+        return None  # No pending shares — let normal processing continue
+
+    share_id, list_id, owner_phone, list_name = pending[0]
+    success, message = decline_share(phone_number, list_id)
+
+    if success:
+        reply_text = f"Declined the invitation for '{list_name}'."
+        # Notify the owner
+        send_sms(owner_phone, f"{_format_phone(phone_number)} declined your shared list '{list_name}'.", message_type="reply")
+    else:
+        reply_text = message
+
+    log_interaction(phone_number, incoming_msg, reply_text, "decline_share", True)
+    return reply_text
+
+
+# =====================================================
+# SHARED LIST DISPLAY HELPERS
+# =====================================================
+
+
+def get_all_lists_with_shared(phone_number: str) -> list[dict]:
+    """Get all lists (owned + shared) for display. Returns list of dicts with list info."""
+    own_lists = get_lists(phone_number)
+    shared_lists = get_shared_lists_for_user(phone_number)
+
+    result = []
+    for list_id, list_name, item_count, completed_count in own_lists:
+        result.append({
+            'list_id': list_id,
+            'list_name': list_name,
+            'item_count': item_count or 0,
+            'completed_count': completed_count or 0,
+            'is_shared': False,
+            'owner_phone': None,
+        })
+
+    for list_id, list_name, item_count, completed_count, owner_phone in shared_lists:
+        result.append({
+            'list_id': list_id,
+            'list_name': list_name,
+            'item_count': item_count or 0,
+            'completed_count': completed_count or 0,
+            'is_shared': True,
+            'owner_phone': owner_phone,
+        })
+
+    return result
+
+
+def format_all_lists_display(phone_number: str) -> str:
+    """Format all lists (owned + shared) for SMS display."""
+    all_lists = get_all_lists_with_shared(phone_number)
+
+    if not all_lists:
+        return "You don't have any lists yet. Try 'Create a grocery list'!"
+
+    lines = []
+    for i, lst in enumerate(all_lists, 1):
+        prefix = "[Shared] " if lst['is_shared'] else ""
+        lines.append(f"{i}. {prefix}{lst['list_name']} ({lst['item_count']} items)")
+
+    # Check for pending invitations
+    pending = get_pending_shares(phone_number)
+    pending_note = ""
+    if pending:
+        pending_note = f"\n\nYou have {len(pending)} pending shared list invitation{'s' if len(pending) > 1 else ''}. Reply ACCEPT or DECLINE."
+
+    return "Your lists:\n\n" + "\n".join(lines) + "\n\nReply with a number to see that list." + pending_note
+
+
+# =====================================================
+# PHONE NUMBER HELPERS
+# =====================================================
+
+
+def _normalize_phone(phone: str) -> str:
+    """Normalize a phone number to E.164 format."""
+    # Strip all non-digit characters
+    digits = ''.join(c for c in phone if c.isdigit())
+
+    # Add country code if missing
+    if len(digits) == 10:
+        digits = '1' + digits
+    if not digits.startswith('+'):
+        digits = '+' + digits
+
+    return digits
+
+
+def _format_phone(phone: str) -> str:
+    """Format a phone number for display: (555) 123-4567."""
+    digits = ''.join(c for c in phone if c.isdigit())
+    if len(digits) == 11 and digits[0] == '1':
+        digits = digits[1:]
+    if len(digits) == 10:
+        return f"({digits[:3]}) {digits[3:6]}-{digits[6:]}"
+    return phone

--- a/routes/handlers/lists.py
+++ b/routes/handlers/lists.py
@@ -565,29 +565,81 @@ def handle_share_list(
         log_interaction(phone_number, incoming_msg, reply_text, "share_list", False)
         return reply_text
 
-    # Get owner's name for the invitation message
-    owner_user = get_user(phone_number)
-    owner_name = owner_user.get('first_name', 'Someone') if owner_user else 'Someone'
+    # Store pending state — ask for the recipient's name before sending invitation
+    import json
+    pending_data = json.dumps({
+        'list_id': list_id,
+        'shared_with_phone': target_phone,
+        'list_name': actual_name,
+    })
+    create_or_update_user(phone_number, pending_share_name=pending_data)
 
-    # Check if recipient is on Remyndrs
+    reply_text = f"What's the name of the person at {_format_phone(target_phone)}?"
+    log_interaction(phone_number, incoming_msg, reply_text, "share_list_ask_name", True)
+    return reply_text
+
+
+def handle_pending_share_name(phone_number: str, incoming_msg: str) -> str | None:
+    """Handle the name response after a share_list action.
+    Returns reply text if handled, None if no pending share name."""
+    import json
+    from services.sms_service import send_sms
+    from models.user import get_user
+    from models.list_model import set_share_name
+
+    user = get_user(phone_number)
+    if not user:
+        return None
+
+    # pending_share_name is stored in the user record
+    from database import get_db_connection, return_db_connection
+    conn = get_db_connection()
+    c = conn.cursor()
+    c.execute('SELECT pending_share_name FROM users WHERE phone_number = %s', (phone_number,))
+    row = c.fetchone()
+    return_db_connection(conn)
+
+    if not row or not row[0]:
+        return None
+
+    try:
+        pending = json.loads(row[0])
+    except (json.JSONDecodeError, TypeError):
+        create_or_update_user(phone_number, pending_share_name=None)
+        return None
+
+    list_id = pending['list_id']
+    target_phone = pending['shared_with_phone']
+    list_name = pending['list_name']
+
+    # The incoming message is the name
+    recipient_name = incoming_msg.strip().title()
+
+    # Save the name on the share
+    set_share_name(list_id, target_phone, recipient_name)
+
+    # Clear the pending state
+    create_or_update_user(phone_number, pending_share_name=None)
+
+    # Get owner's name for the invitation message
+    owner_name = user[1] if user[1] else "Someone"
+
+    # Send the invitation SMS
     recipient = get_user(target_phone)
     if recipient:
-        # Existing user — send invitation SMS
         invite_msg = (
-            f"[Shared List] {owner_name} shared '{actual_name}' with you!\n\n"
+            f"[Shared List] Hi {recipient_name}! {owner_name} shared '{list_name}' with you.\n\n"
             f"Reply ACCEPT to join or DECLINE to skip."
         )
-        send_sms(target_phone, invite_msg, message_type="reply")
     else:
-        # Not on Remyndrs — send signup invitation
         invite_msg = (
-            f"{owner_name} shared a list with you on Remyndrs! "
-            f"Reply YES to join and see '{actual_name}'."
+            f"Hi {recipient_name}! {owner_name} shared a list with you on Remyndrs. "
+            f"Reply YES to join and see '{list_name}'."
         )
-        send_sms(target_phone, invite_msg, message_type="reply")
+    send_sms(target_phone, invite_msg, message_type="reply")
 
-    reply_text = f"Invitation sent to {_format_phone(target_phone)} for '{actual_name}'."
-    log_interaction(phone_number, incoming_msg, reply_text, "share_list", True)
+    reply_text = f"Invitation sent to {recipient_name} ({_format_phone(target_phone)}) for '{list_name}'."
+    log_interaction(phone_number, incoming_msg, reply_text, "share_list_named", True)
     return reply_text
 
 
@@ -651,12 +703,8 @@ def handle_show_list_members(
         reply_text = f"'{actual_name}' isn't shared with anyone."
     else:
         lines = [f"'{actual_name}' is shared with:\n"]
-        for i, (member_phone, status, permission) in enumerate(members, 1):
-            # Try to get member's name
-            member_user = get_user(member_phone)
-            member_name = member_user.get('first_name', '') if member_user else ''
-            display = member_name if member_name else _format_phone(member_phone)
-
+        for i, (member_phone, status, permission, name) in enumerate(members, 1):
+            display = name if name else _format_phone(member_phone)
             status_label = " (pending)" if status == 'pending' else ""
             lines.append(f"{i}. {display}{status_label}")
 
@@ -701,6 +749,9 @@ def handle_leave_shared_list(
 
 def handle_accept_share(phone_number: str, incoming_msg: str) -> str:
     """Handle ACCEPT keyword for pending shared list invitations."""
+    from services.sms_service import send_sms
+    from models.list_model import get_share_name
+
     pending = get_pending_shares(phone_number)
 
     if not pending:
@@ -711,6 +762,8 @@ def handle_accept_share(phone_number: str, incoming_msg: str) -> str:
         success, message = accept_share(phone_number, list_id)
         if success:
             reply_text = f"You now have access to '{list_name}'! Text 'Show {list_name}' to see it."
+            display_name = get_share_name(list_id, phone_number) or _format_phone(phone_number)
+            send_sms(owner_phone, f"{display_name} accepted your shared list '{list_name}'.", message_type="reply")
         else:
             reply_text = message
     else:
@@ -724,6 +777,8 @@ def handle_accept_share(phone_number: str, incoming_msg: str) -> str:
                 f"You have {remaining} more pending invitation{'s' if remaining > 1 else ''}. "
                 f"Reply ACCEPT again to accept the next one."
             )
+            display_name = get_share_name(list_id, phone_number) or _format_phone(phone_number)
+            send_sms(owner_phone, f"{display_name} accepted your shared list '{list_name}'.", message_type="reply")
         else:
             reply_text = message
 
@@ -734,6 +789,7 @@ def handle_accept_share(phone_number: str, incoming_msg: str) -> str:
 def handle_decline_share(phone_number: str, incoming_msg: str) -> str:
     """Handle DECLINE keyword for pending shared list invitations."""
     from services.sms_service import send_sms
+    from models.list_model import get_share_name
 
     pending = get_pending_shares(phone_number)
 
@@ -746,7 +802,8 @@ def handle_decline_share(phone_number: str, incoming_msg: str) -> str:
     if success:
         reply_text = f"Declined the invitation for '{list_name}'."
         # Notify the owner
-        send_sms(owner_phone, f"{_format_phone(phone_number)} declined your shared list '{list_name}'.", message_type="reply")
+        display_name = get_share_name(list_id, phone_number) or _format_phone(phone_number)
+        send_sms(owner_phone, f"{display_name} declined your shared list '{list_name}'.", message_type="reply")
     else:
         reply_text = message
 

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -650,13 +650,17 @@ For SHARING A LIST (Premium users only):
 {{
     "action": "share_list",
     "list_name": "the name of the list to share",
-    "phone_number": "the phone number to share with (digits only, with country code)",
-    "confirmation": "Sharing [list name] with [phone number]"
+    "phone_number": "the phone number to share with (optional, E.164 format with +1 country code)",
+    "shared_with_name": "the name of the person to share with (optional, when no phone number given)",
+    "confirmation": "Sharing [list name] with [phone number or name]"
 }}
+Include phone_number when the user provides digits. Include shared_with_name when the user provides a name instead.
 Examples:
 - "Share grocery list with 555-123-4567" → {{"action": "share_list", "list_name": "grocery list", "phone_number": "+15551234567"}}
 - "Share my todo list with 8015551234" → {{"action": "share_list", "list_name": "todo list", "phone_number": "+18015551234"}}
-Note: Normalize the phone number to E.164 format with +1 country code if not provided.
+- "Share vacation list with Sarah" → {{"action": "share_list", "list_name": "vacation list", "shared_with_name": "Sarah"}}
+- "Share grocery list with Mom" → {{"action": "share_list", "list_name": "grocery list", "shared_with_name": "Mom"}}
+Note: Normalize phone numbers to E.164 format with +1 country code if not provided.
 
 For REMOVING A USER FROM A SHARED LIST:
 {{

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -646,6 +646,49 @@ For RENAMING A LIST:
     "confirmation": "Renamed [old name] to [new name]"
 }}
 
+For SHARING A LIST (Premium users only):
+{{
+    "action": "share_list",
+    "list_name": "the name of the list to share",
+    "phone_number": "the phone number to share with (digits only, with country code)",
+    "confirmation": "Sharing [list name] with [phone number]"
+}}
+Examples:
+- "Share grocery list with 555-123-4567" → {{"action": "share_list", "list_name": "grocery list", "phone_number": "+15551234567"}}
+- "Share my todo list with 8015551234" → {{"action": "share_list", "list_name": "todo list", "phone_number": "+18015551234"}}
+Note: Normalize the phone number to E.164 format with +1 country code if not provided.
+
+For REMOVING A USER FROM A SHARED LIST:
+{{
+    "action": "unshare_list",
+    "list_name": "the name of the shared list",
+    "phone_number": "the phone number to remove (optional — omit to stop sharing with everyone)",
+    "confirmation": "Removed access for [phone number]"
+}}
+Examples:
+- "Stop sharing grocery list with 555-123-4567" → {{"action": "unshare_list", "list_name": "grocery list", "phone_number": "+15551234567"}}
+- "Stop sharing grocery list" → {{"action": "unshare_list", "list_name": "grocery list"}}
+
+For SHOWING WHO HAS ACCESS TO A SHARED LIST:
+{{
+    "action": "show_list_members",
+    "list_name": "the name of the shared list",
+    "confirmation": "Showing members of [list name]"
+}}
+Examples:
+- "Who's on my grocery list?" → {{"action": "show_list_members", "list_name": "grocery list"}}
+- "Who can see my todo list?" → {{"action": "show_list_members", "list_name": "todo list"}}
+
+For LEAVING A SHARED LIST (non-owner):
+{{
+    "action": "leave_shared_list",
+    "list_name": "the name of the shared list to leave",
+    "confirmation": "Leaving [list name]"
+}}
+Examples:
+- "Leave grocery list" → {{"action": "leave_shared_list", "list_name": "grocery list"}}
+- "Remove me from the grocery list" → {{"action": "leave_shared_list", "list_name": "grocery list"}}
+
 MULTI-COMMAND SUPPORT:
 If the user's message contains MULTIPLE distinct commands, return an array of actions instead of a single action.
 

--- a/services/onboarding_service.py
+++ b/services/onboarding_service.py
@@ -12,6 +12,7 @@ from twilio.twiml.messaging_response import MessagingResponse
 from config import logger, FREE_TRIAL_DAYS, TIER_PREMIUM, API_BASE_URL, PREMIUM_MONTHLY_PRICE
 from models.user import get_user, get_onboarding_step, create_or_update_user
 from models.memory import save_memory
+from models.list_model import get_pending_shares, accept_share, get_share_name
 from utils.timezone import get_timezone_from_zip, get_user_current_time
 from utils.formatting import get_onboarding_prompt
 from services.sms_service import send_sms
@@ -193,8 +194,18 @@ You're on step {step} of 2 - just {remaining} more {question_word}!
             create_or_update_user(phone_number, onboarding_step=1)
             track_onboarding_progress(phone_number, 1)
 
-            # Enhanced welcome message with clearer value proposition
-            resp.message("""Welcome to Remyndrs! 👋
+            # Check if this user was invited via a shared list
+            pending = get_pending_shares(phone_number)
+            if pending:
+                _share_id, _list_id, owner_phone, list_name = pending[0]
+                owner = get_user(owner_phone)
+                owner_name = owner[1] if owner else "Someone"
+                resp.message(f"""{owner_name} shared '{list_name}' with you on Remyndrs!
+
+Let's get you set up in 30 seconds so you can see it. What's your first name?""")
+            else:
+                # Enhanced welcome message with clearer value proposition
+                resp.message("""Welcome to Remyndrs! 👋
 
 I'm your AI-powered reminder assistant. I'll help you remember anything—from daily tasks to important dates.
 
@@ -270,6 +281,24 @@ Last question: ZIP code?
             # Uncomment post-launch when ready to activate for new trial users:
             # create_or_update_user(phone_number, smart_nudges_enabled=True)
 
+            # Auto-accept any pending shared list invitations
+            accepted_lists = []
+            pending = get_pending_shares(phone_number)
+            for share_id, list_id, owner_phone, list_name in pending:
+                success, _ = accept_share(phone_number, list_id)
+                if success:
+                    accepted_lists.append((list_name, owner_phone))
+                    # Notify the owner
+                    display_name = get_share_name(list_id, phone_number)
+                    if not display_name:
+                        new_user = get_user(phone_number)
+                        display_name = new_user[1] if new_user else "Someone"
+                    send_sms(
+                        owner_phone,
+                        f"{display_name} joined Remyndrs and accepted your shared list '{list_name}'!",
+                        message_type="reply"
+                    )
+
             # Get user's name for personalized message
             user = get_user(phone_number)
             first_name = user[1]
@@ -284,8 +313,17 @@ Last question: ZIP code?
             trial_end_local = trial_end_date.replace(tzinfo=pytz.UTC).astimezone(user_tz)
             trial_end_str = trial_end_local.strftime('%B %d')
 
-            # Send completion message - focused on immediate value + trial awareness
-            resp.message(f"""Perfect! You're all set, {first_name}! 🎉
+            # Send completion message — customized if they joined via shared list
+            if accepted_lists:
+                list_name, _ = accepted_lists[0]
+                shared_note = f"\n\nYou now have access to '{list_name}'! Text 'Show {list_name}' to see it."
+                if len(accepted_lists) > 1:
+                    shared_note += f"\n(Plus {len(accepted_lists) - 1} more shared list{'s' if len(accepted_lists) > 2 else ''}!)"
+                resp.message(f"""You're all set, {first_name}! 🎉
+
+You have full Premium access until {trial_end_str} — unlimited reminders, lists & memories. After that, the core service is free forever — no credit card ever needed.{shared_note}""")
+            else:
+                resp.message(f"""Perfect! You're all set, {first_name}! 🎉
 
 You have full Premium access until {trial_end_str} — unlimited reminders, lists & memories. After that, the core service is free forever — no credit card ever needed.
 

--- a/services/smart_suggestion_service.py
+++ b/services/smart_suggestion_service.py
@@ -1,0 +1,190 @@
+"""
+Smart Suggestion Service
+Detects opportunities to suggest follow-up actions after reminders, lists, and memories.
+Phase 1: Prep reminders for high-importance events.
+"""
+
+import re
+from datetime import datetime, timedelta
+from config import logger
+
+# Minimum hours between the prep reminder and the actual event.
+# Don't suggest a prep reminder if there isn't enough lead time.
+MIN_PREP_GAP_HOURS = 4
+
+# Pattern definitions: (compiled regex, default prep hours before event, suggestion template)
+# Prep hours are overridden by _calculate_prep_time for smarter timing.
+PREP_REMINDER_PATTERNS = [
+    # Medical
+    (re.compile(r'\b(doctor|dentist|appointment|checkup|check-up|physical|therapist|surgeon|specialist|dermatologist|orthodontist|optometrist)\b', re.I),
+     12, "prepare for your {event}"),
+    (re.compile(r'\b(vet|veterinarian|pet appointment)\b', re.I),
+     12, "prepare for the vet appointment"),
+
+    # Professional
+    (re.compile(r'\b(interview|job interview)\b', re.I),
+     14, "prepare for your interview"),
+    (re.compile(r'\b(presentation|demo|pitch)\b', re.I),
+     14, "prepare for your {event}"),
+
+    # Travel
+    (re.compile(r'\b(flight|airport|travel|fly out|flying)\b', re.I),
+     3, "leave for the airport"),
+    (re.compile(r'\b(road trip|drive to|driving to)\b', re.I),
+     2, "pack the car"),
+
+    # Social / milestones
+    (re.compile(r'\b(birthday|anniversary)\b', re.I),
+     48, "get a gift for the {event}"),
+    (re.compile(r'\b(wedding|ceremony|reception)\b', re.I),
+     168, "confirm details for the {event}"),  # 1 week
+
+    # Academic
+    (re.compile(r'\b(exam|test|quiz|midterm|final)\b', re.I),
+     14, "review for your {event}"),
+
+    # Deadlines
+    (re.compile(r'\b(deadline|due date|submission|due)\b', re.I),
+     24, "finish up before the {event}"),
+
+    # Moving
+    (re.compile(r'\b(moving|move-in|move-out|moving day)\b', re.I),
+     168, "start packing for your move"),  # 1 week
+
+    # Financial
+    (re.compile(r'\b(payment|bill|rent|mortgage|insurance)\b', re.I),
+     48, "prepare for your {event}"),
+
+    # Meetings (less aggressive — only if it looks formal)
+    (re.compile(r'\b(meeting with|meet with|conference|call with)\b', re.I),
+     2, "prepare for your {event}"),
+]
+
+
+def get_reminder_suggestion(
+    reminder_text: str,
+    reminder_date_utc: str,
+    timezone: str,
+) -> dict | None:
+    """Check if a reminder warrants a prep suggestion.
+
+    Args:
+        reminder_text: The text of the reminder the user just created.
+        reminder_date_utc: UTC datetime string (YYYY-MM-DD HH:MM:SS).
+        timezone: User's timezone string (e.g., "America/New_York").
+
+    Returns:
+        dict with {suggestion_text, prep_date_utc, prep_reminder_text} or None.
+    """
+    import pytz
+
+    # Match against patterns
+    matched_pattern = None
+    for pattern, default_hours, template in PREP_REMINDER_PATTERNS:
+        if pattern.search(reminder_text):
+            matched_pattern = (pattern, default_hours, template)
+            break
+
+    if not matched_pattern:
+        return None
+
+    pattern, default_hours, template = matched_pattern
+
+    # Parse the reminder date
+    try:
+        reminder_dt_utc = datetime.strptime(reminder_date_utc, '%Y-%m-%d %H:%M:%S')
+        tz = pytz.timezone(timezone)
+        reminder_dt_local = pytz.UTC.localize(reminder_dt_utc).astimezone(tz)
+        now_local = datetime.now(tz)
+    except Exception as e:
+        logger.error(f"Error parsing reminder date for suggestion: {e}")
+        return None
+
+    # Calculate prep time
+    prep_dt_local = _calculate_prep_time(reminder_dt_local, default_hours, now_local)
+
+    if prep_dt_local is None:
+        return None
+
+    # Check minimum gap
+    hours_until_event = (reminder_dt_local - now_local).total_seconds() / 3600
+    if hours_until_event < MIN_PREP_GAP_HOURS:
+        return None
+
+    # Check prep time is in the future
+    if prep_dt_local <= now_local:
+        return None
+
+    # Build the suggestion
+    # Extract the event keyword for the template
+    match = matched_pattern[0].search(reminder_text)
+    event_word = match.group(0) if match else "event"
+    prep_text = template.format(event=event_word)
+
+    # Format the suggestion time for display
+    prep_time_str = prep_dt_local.strftime('%I:%M %p').lstrip('0')
+    prep_date_str = prep_dt_local.strftime('%A, %B %d')
+
+    # Determine how to phrase the suggestion
+    days_diff = (reminder_dt_local.date() - prep_dt_local.date()).days
+    if days_diff == 0:
+        time_phrase = f"earlier that day at {prep_time_str}"
+    elif days_diff == 1:
+        time_phrase = f"the evening before at {prep_time_str}"
+    elif days_diff <= 7:
+        time_phrase = f"on {prep_date_str} at {prep_time_str}"
+    else:
+        time_phrase = f"on {prep_date_str}"
+
+    suggestion_text = f"Want me to also remind you {time_phrase} to {prep_text}?"
+
+    # Convert prep time back to UTC for storage
+    prep_dt_utc = prep_dt_local.astimezone(pytz.UTC).replace(tzinfo=None)
+
+    return {
+        'suggestion_text': suggestion_text,
+        'prep_date_utc': prep_dt_utc.strftime('%Y-%m-%d %H:%M:%S'),
+        'prep_local_time': prep_dt_local.strftime('%H:%M'),
+        'prep_reminder_text': prep_text.capitalize(),
+        'prep_date_display': f"{prep_date_str} at {prep_time_str}",
+    }
+
+
+def _calculate_prep_time(
+    event_dt_local: datetime,
+    default_hours: int,
+    now_local: datetime,
+) -> datetime | None:
+    """Calculate when the prep reminder should fire.
+
+    Logic:
+    - Events before noon → reminder at 7 PM the evening before
+    - Events at noon or later → reminder 12 hours before (or default_hours)
+    - Events days/weeks away (birthday, deadline, wedding) → use default_hours
+    - If default_hours >= 48, use default_hours directly (multi-day lead)
+    - Never schedule before now + 1 hour (give the user breathing room)
+    """
+    # Multi-day lead events (birthday, deadline, wedding, moving)
+    if default_hours >= 48:
+        prep_dt = event_dt_local - timedelta(hours=default_hours)
+        # Set to 9 AM local for multi-day leads
+        prep_dt = prep_dt.replace(hour=9, minute=0, second=0, microsecond=0)
+        if prep_dt <= now_local + timedelta(hours=1):
+            return None
+        return prep_dt
+
+    # Short-lead events (same day or next day)
+    if event_dt_local.hour < 12:
+        # Morning event → evening before at 7 PM
+        prep_dt = (event_dt_local - timedelta(days=1)).replace(
+            hour=19, minute=0, second=0, microsecond=0
+        )
+    else:
+        # Afternoon/evening event → default_hours before
+        prep_dt = event_dt_local - timedelta(hours=default_hours)
+
+    # Don't schedule before now + 1 hour
+    if prep_dt <= now_local + timedelta(hours=1):
+        return None
+
+    return prep_dt

--- a/services/tier_service.py
+++ b/services/tier_service.py
@@ -384,6 +384,32 @@ def can_create_list(phone_number: str) -> tuple[bool, str | None]:
     return (True, None)
 
 
+def can_share_list(phone_number: str) -> tuple[bool, str | None]:
+    """Check if user can share a list (must be Premium, and in beta whitelist if set)."""
+    from config import SHARED_LISTS_BETA_PHONES
+    if SHARED_LISTS_BETA_PHONES and phone_number not in SHARED_LISTS_BETA_PHONES:
+        return (False, "Shared lists aren't available for your account yet. Stay tuned!")
+
+    tier = get_user_tier(phone_number)
+    if tier not in (TIER_PREMIUM, TIER_FAMILY):
+        from config import PREMIUM_MONTHLY_PRICE
+        return (
+            False,
+            f"Shared lists are a Premium feature. Text UPGRADE to unlock shared lists ({PREMIUM_MONTHLY_PRICE}/mo)."
+        )
+
+    from models.list_model import get_owner_shared_list_count
+    from config import SHARED_LIST_MAX_PER_USER
+    shared_count = get_owner_shared_list_count(phone_number)
+    if shared_count >= SHARED_LIST_MAX_PER_USER:
+        return (
+            False,
+            f"You've reached your limit of {SHARED_LIST_MAX_PER_USER} shared lists."
+        )
+
+    return (True, None)
+
+
 def can_add_list_item(phone_number: str, list_id: int) -> tuple[bool, str | None]:
     """Check if user can add another item to a list."""
     if BETA_MODE:

--- a/tests/test_shared_lists.py
+++ b/tests/test_shared_lists.py
@@ -751,3 +751,31 @@ class TestNonUserInvitationFlow:
         assert "welcome" in result["output"].lower() or "remyndrs" in result["output"].lower()
         # Should NOT mention any shared list
         assert "shared" not in result["output"].lower()
+
+    @pytest.mark.asyncio
+    async def test_non_user_declines_invitation_with_no(self, premium_owner, owner_list, simulator, sms_capture):
+        """Non-user replying NO declines the share and does NOT start onboarding."""
+        from models.list_model import share_list, get_pending_shares
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_NEW)
+        sms_capture.messages.clear()
+
+        result = await simulator.send_message(PHONE_NEW, "No")
+
+        # Should get a polite decline message, NOT onboarding
+        assert "declined" in result["output"].lower() or "no problem" in result["output"].lower()
+        assert "name" not in result["output"].lower()
+
+        # Pending share should be gone
+        pending = get_pending_shares(PHONE_NEW)
+        assert len(pending) == 0
+
+        # Owner should be notified
+        owner_msgs = [m for m in sms_capture.messages if m["to"] == PHONE_OWNER]
+        assert any("declined" in m["message"].lower() for m in owner_msgs)
+
+    @pytest.mark.asyncio
+    async def test_non_user_no_without_pending_share_goes_to_onboarding(self, simulator, sms_capture):
+        """Non-user saying NO without a pending share just enters normal onboarding."""
+        result = await simulator.send_message(PHONE_NEW, "No")
+        # Should enter onboarding, not get a decline message
+        assert "welcome" in result["output"].lower() or "name" in result["output"].lower()

--- a/tests/test_shared_lists.py
+++ b/tests/test_shared_lists.py
@@ -5,9 +5,11 @@ Covers: sharing flow, permissions, limits, accept/decline, and list operations o
 
 import pytest
 import json
+from unittest.mock import patch
 
 PHONE_OWNER = "+15559876543"   # Premium owner (same as test_phone)
 PHONE_SHARED = "+15559876544"  # Shared user (free tier)
+PHONE_NEW = "+15559876545"     # Non-Remyndrs user (for invitation flow tests)
 
 
 @pytest.fixture(autouse=True)
@@ -20,7 +22,7 @@ def clean_shared_list_data():
         try:
             conn = get_db_connection()
             c = conn.cursor()
-            for phone in [PHONE_OWNER, PHONE_SHARED]:
+            for phone in [PHONE_OWNER, PHONE_SHARED, PHONE_NEW]:
                 c.execute("DELETE FROM list_shares WHERE owner_phone = %s OR shared_with_phone = %s", (phone, phone))
                 c.execute("DELETE FROM list_items WHERE phone_number = %s", (phone,))
                 c.execute("DELETE FROM lists WHERE phone_number = %s", (phone,))
@@ -398,6 +400,84 @@ class TestSharedListHandlers:
 
 
 # =====================================================
+# NAME PROMPT FLOW TESTS
+# =====================================================
+
+
+class TestShareNamePromptFlow:
+    """Tests for the name prompt flow when sharing a list."""
+
+    def test_set_and_get_share_name(self, premium_owner, free_user, owner_list):
+        """Test that a name can be set and retrieved for a share."""
+        from models.list_model import share_list, set_share_name, get_share_name
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+
+        set_share_name(owner_list["list_id"], PHONE_SHARED, "Jane")
+        name = get_share_name(owner_list["list_id"], PHONE_SHARED)
+        assert name == "Jane"
+
+    def test_get_list_members_includes_name(self, premium_owner, free_user, owner_list):
+        """Test that get_list_members returns the shared_with_name."""
+        from models.list_model import share_list, set_share_name, get_list_members
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        set_share_name(owner_list["list_id"], PHONE_SHARED, "Jane")
+
+        members = get_list_members(owner_list["list_id"])
+        assert len(members) == 1
+        assert members[0][3] == "Jane"
+
+    def test_pending_share_name_handler(self, premium_owner, free_user, owner_list):
+        """Test that handle_pending_share_name saves name and sends invitation."""
+        import json
+        from models.list_model import share_list, get_share_name
+        from models.user import create_or_update_user
+        from routes.handlers.lists import handle_pending_share_name
+
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+
+        # Set up pending state (as handle_share_list would)
+        pending_data = json.dumps({
+            'list_id': owner_list["list_id"],
+            'shared_with_phone': PHONE_SHARED,
+            'list_name': "Grocery List",
+        })
+        create_or_update_user(PHONE_OWNER, pending_share_name=pending_data)
+
+        # Simulate owner replying with a name
+        result = handle_pending_share_name(PHONE_OWNER, "Jane")
+        assert result is not None
+        assert "Jane" in result
+        assert "Grocery List" in result
+
+        # Name should be saved on the share
+        name = get_share_name(owner_list["list_id"], PHONE_SHARED)
+        assert name == "Jane"
+
+    def test_no_pending_share_name_returns_none(self, premium_owner):
+        """Test that handle_pending_share_name returns None when no pending state."""
+        from routes.handlers.lists import handle_pending_share_name
+        result = handle_pending_share_name(PHONE_OWNER, "Jane")
+        assert result is None
+
+    def test_accept_notification_uses_share_name(self, premium_owner, free_user, owner_list, sms_capture):
+        """Test that accept notification uses the owner-assigned name."""
+        from models.list_model import share_list, accept_share, set_share_name
+        from routes.handlers.lists import handle_accept_share
+
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        set_share_name(owner_list["list_id"], PHONE_SHARED, "Jane")
+        sms_capture.messages.clear()
+
+        handle_accept_share(PHONE_SHARED, "ACCEPT")
+
+        # Owner notification should use "Jane" not the phone number
+        owner_msgs = [m for m in sms_capture.messages if m["to"] == PHONE_OWNER]
+        assert len(owner_msgs) >= 1
+        assert "Jane" in owner_msgs[0]["message"]
+        assert "accepted" in owner_msgs[0]["message"].lower()
+
+
+# =====================================================
 # CASCADE DELETE TESTS
 # =====================================================
 
@@ -421,3 +501,147 @@ class TestCascadeDelete:
         # Share should be gone (cascade delete)
         shared = get_shared_lists_for_user(PHONE_SHARED)
         assert len(shared) == 0
+
+
+# =====================================================
+# OWNER DOWNGRADE (READ-ONLY) TESTS
+# =====================================================
+
+
+class TestOwnerDowngradeReadOnly:
+    """Tests for shared lists becoming read-only when owner loses Premium."""
+
+    def test_is_shared_list_read_only_premium_owner(self, premium_owner, owner_list):
+        """Shared list with Premium owner is NOT read-only."""
+        from models.list_model import is_shared_list_read_only
+        read_only, owner_name = is_shared_list_read_only(owner_list["list_id"])
+        assert read_only is False
+
+    def test_is_shared_list_read_only_free_owner(self, premium_owner, free_user, owner_list):
+        """Shared list becomes read-only when owner downgrades to free."""
+        from models.list_model import is_shared_list_read_only, share_list, accept_share
+        from models.user import create_or_update_user
+
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        # Downgrade owner
+        create_or_update_user(PHONE_OWNER, premium_status="free", trial_end_date=None)
+
+        read_only, owner_name = is_shared_list_read_only(owner_list["list_id"])
+        assert read_only is True
+        assert owner_name == "Brad"
+
+    def test_shared_user_can_still_view_after_downgrade(self, premium_owner, free_user, owner_list):
+        """Shared user can still view a shared list after owner downgrades."""
+        from models.list_model import share_list, accept_share, get_accessible_list_by_name, get_list_items
+        from models.user import create_or_update_user
+
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        # Downgrade owner
+        create_or_update_user(PHONE_OWNER, premium_status="free", trial_end_date=None)
+
+        # Shared user can still find and view the list
+        accessible = get_accessible_list_by_name(PHONE_SHARED, "Grocery List")
+        assert accessible is not None
+        items = get_list_items(accessible[0])
+        assert len(items) == 2  # Milk and Eggs from owner_list fixture
+
+    def test_owner_can_still_delete_after_downgrade(self, premium_owner, free_user, owner_list):
+        """Owner can still delete their shared list even after downgrading."""
+        from models.list_model import share_list, accept_share, delete_list, get_shared_lists_for_user
+        from models.user import create_or_update_user
+
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        # Downgrade owner
+        create_or_update_user(PHONE_OWNER, premium_status="free", trial_end_date=None)
+
+        # Owner can still delete
+        delete_list(PHONE_OWNER, "Grocery List")
+        shared = get_shared_lists_for_user(PHONE_SHARED)
+        assert len(shared) == 0
+
+
+# =====================================================
+# NON-USER INVITATION FLOW TESTS
+# =====================================================
+
+
+class TestNonUserInvitationFlow:
+    """Tests for sharing a list with someone who isn't on Remyndrs yet."""
+
+    @pytest.mark.asyncio
+    async def test_non_user_onboarding_shows_shared_list_welcome(self, premium_owner, owner_list, simulator, sms_capture):
+        """Non-user replying YES gets a customized welcome mentioning the shared list."""
+        from models.list_model import share_list
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_NEW)
+
+        # Non-user texts YES — enters onboarding step 0
+        result = await simulator.send_message(PHONE_NEW, "YES")
+        assert "Brad" in result["output"] or "shared" in result["output"].lower()
+        assert "Grocery List" in result["output"]
+        assert "name" in result["output"].lower()
+
+    @pytest.mark.asyncio
+    async def test_non_user_full_onboarding_auto_accepts_share(self, premium_owner, owner_list, simulator, sms_capture):
+        """Non-user completes onboarding → pending share is auto-accepted → owner notified."""
+        from models.list_model import share_list, get_shared_lists_for_user
+
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_NEW)
+        sms_capture.messages.clear()
+
+        # Step 0: initial message
+        await simulator.send_message(PHONE_NEW, "YES")
+
+        # Step 1: provide name
+        await simulator.send_message(PHONE_NEW, "Sarah")
+
+        # Step 2: provide ZIP → completes onboarding
+        result = await simulator.send_message(PHONE_NEW, "90210")
+
+        # Completion message should mention the shared list
+        assert "Grocery List" in result["output"]
+        assert "all set" in result["output"].lower() or "set" in result["output"].lower()
+
+        # Share should now be accepted
+        shared = get_shared_lists_for_user(PHONE_NEW)
+        assert len(shared) == 1
+        assert shared[0][1] == "Grocery List"
+
+        # Owner should have been notified
+        owner_msgs = [m for m in sms_capture.messages if m["to"] == PHONE_OWNER]
+        assert any("joined" in m["message"].lower() or "accepted" in m["message"].lower() for m in owner_msgs)
+
+    @pytest.mark.asyncio
+    async def test_non_user_referral_source_tagged(self, premium_owner, owner_list, simulator, sms_capture):
+        """Non-user invited via shared list gets tagged with 'shared-list' referral source."""
+        from models.list_model import share_list
+        from database import get_db_connection, return_db_connection
+
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_NEW)
+
+        # Complete onboarding (referral set after user record exists)
+        await simulator.send_message(PHONE_NEW, "YES")
+        await simulator.send_message(PHONE_NEW, "Sarah")
+
+        # Check referral source (set during step 1 when user record exists)
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute("SELECT referral_source FROM users WHERE phone_number = %s", (PHONE_NEW,))
+        row = c.fetchone()
+        return_db_connection(conn)
+
+        assert row is not None
+        assert row[0] == "shared-list"
+
+    @pytest.mark.asyncio
+    async def test_non_user_without_pending_share_gets_normal_welcome(self, simulator, sms_capture):
+        """A non-user without pending shares gets the normal welcome message."""
+        result = await simulator.send_message(PHONE_NEW, "Hi")
+        assert "welcome" in result["output"].lower() or "remyndrs" in result["output"].lower()
+        # Should NOT mention any shared list
+        assert "shared" not in result["output"].lower()

--- a/tests/test_shared_lists.py
+++ b/tests/test_shared_lists.py
@@ -478,6 +478,112 @@ class TestShareNamePromptFlow:
 
 
 # =====================================================
+# SHARE BY NAME TESTS
+# =====================================================
+
+
+class TestShareByName:
+    """Tests for sharing a list using a previously-known recipient name."""
+
+    def test_get_known_recipients_finds_match(self, premium_owner, free_user, owner_list):
+        """Known recipient lookup finds a previous share by name."""
+        from models.list_model import share_list, set_share_name, get_known_recipients
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        set_share_name(owner_list["list_id"], PHONE_SHARED, "Jane")
+
+        matches = get_known_recipients(PHONE_OWNER, "Jane")
+        assert len(matches) == 1
+        assert matches[0][0] == PHONE_SHARED
+        assert matches[0][1] == "Jane"
+
+    def test_get_known_recipients_case_insensitive(self, premium_owner, free_user, owner_list):
+        """Name lookup is case-insensitive."""
+        from models.list_model import share_list, set_share_name, get_known_recipients
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        set_share_name(owner_list["list_id"], PHONE_SHARED, "Jane")
+
+        matches = get_known_recipients(PHONE_OWNER, "jane")
+        assert len(matches) == 1
+
+    def test_get_known_recipients_no_match(self, premium_owner, owner_list):
+        """Unknown name returns empty list."""
+        from models.list_model import get_known_recipients
+        matches = get_known_recipients(PHONE_OWNER, "Nobody")
+        assert len(matches) == 0
+
+    def test_share_by_known_name_skips_name_prompt(self, premium_owner, free_user, owner_list, sms_capture):
+        """Sharing with a known name resolves to phone and sends invitation immediately."""
+        from models.list_model import share_list, set_share_name, create_list, get_list_members
+        from routes.handlers.lists import handle_share_list
+
+        # First share establishes the name
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        set_share_name(owner_list["list_id"], PHONE_SHARED, "Jane")
+
+        # Create a second list to share by name
+        second_list_id = create_list(PHONE_OWNER, "Vacation List")
+        sms_capture.messages.clear()
+
+        ai_response = {
+            "action": "share_list",
+            "list_name": "Vacation List",
+            "shared_with_name": "Jane",
+        }
+        result = handle_share_list(PHONE_OWNER, "Share vacation list with Jane", ai_response)
+
+        # Should send invitation immediately (no name prompt)
+        assert "Invitation sent" in result
+        assert "Jane" in result
+
+        # Invitation SMS should have been sent to the shared user
+        invite_msgs = [m for m in sms_capture.messages if m["to"] == PHONE_SHARED]
+        assert len(invite_msgs) >= 1
+        assert "Jane" in invite_msgs[0]["message"]
+
+    def test_share_by_unknown_name_asks_for_phone(self, premium_owner, owner_list):
+        """Sharing with an unknown name asks for the phone number."""
+        from routes.handlers.lists import handle_share_list
+
+        ai_response = {
+            "action": "share_list",
+            "list_name": "Grocery List",
+            "shared_with_name": "Mom",
+        }
+        result = handle_share_list(PHONE_OWNER, "Share grocery list with Mom", ai_response)
+
+        assert "phone number" in result.lower()
+        assert "Mom" in result
+
+    def test_share_by_unknown_name_then_provide_phone(self, premium_owner, free_user, owner_list, sms_capture):
+        """After asking for phone, owner provides it → share created + invitation sent."""
+        from routes.handlers.lists import handle_share_list, handle_pending_share_name
+        from models.list_model import get_share_name
+
+        ai_response = {
+            "action": "share_list",
+            "list_name": "Grocery List",
+            "shared_with_name": "Mom",
+        }
+        handle_share_list(PHONE_OWNER, "Share grocery list with Mom", ai_response)
+        sms_capture.messages.clear()
+
+        # Owner provides phone number
+        result = handle_pending_share_name(PHONE_OWNER, PHONE_SHARED)
+
+        assert "Invitation sent" in result
+        assert "Mom" in result
+
+        # Name should be saved
+        name = get_share_name(owner_list["list_id"], PHONE_SHARED)
+        assert name == "Mom"
+
+        # Invitation SMS should have been sent
+        invite_msgs = [m for m in sms_capture.messages if m["to"] == PHONE_SHARED]
+        assert len(invite_msgs) >= 1
+        assert "Mom" in invite_msgs[0]["message"]
+
+
+# =====================================================
 # CASCADE DELETE TESTS
 # =====================================================
 

--- a/tests/test_shared_lists.py
+++ b/tests/test_shared_lists.py
@@ -1,0 +1,423 @@
+"""
+Tests for Shared Lists feature.
+Covers: sharing flow, permissions, limits, accept/decline, and list operations on shared lists.
+"""
+
+import pytest
+import json
+
+PHONE_OWNER = "+15559876543"   # Premium owner (same as test_phone)
+PHONE_SHARED = "+15559876544"  # Shared user (free tier)
+
+
+@pytest.fixture(autouse=True)
+def clean_shared_list_data():
+    """Clean up shared list test data before and after each test."""
+    from database import get_db_connection, return_db_connection
+
+    def cleanup():
+        conn = None
+        try:
+            conn = get_db_connection()
+            c = conn.cursor()
+            for phone in [PHONE_OWNER, PHONE_SHARED]:
+                c.execute("DELETE FROM list_shares WHERE owner_phone = %s OR shared_with_phone = %s", (phone, phone))
+                c.execute("DELETE FROM list_items WHERE phone_number = %s", (phone,))
+                c.execute("DELETE FROM lists WHERE phone_number = %s", (phone,))
+                c.execute("DELETE FROM conversation_analysis WHERE log_id IN (SELECT id FROM logs WHERE phone_number = %s)", (phone,))
+                c.execute("DELETE FROM logs WHERE phone_number = %s", (phone,))
+                c.execute("DELETE FROM reminders WHERE phone_number = %s", (phone,))
+                c.execute("DELETE FROM recurring_reminders WHERE phone_number = %s", (phone,))
+                c.execute("DELETE FROM memories WHERE phone_number = %s", (phone,))
+                c.execute("DELETE FROM smart_nudges WHERE phone_number = %s", (phone,))
+                c.execute("DELETE FROM support_tickets WHERE phone_number = %s", (phone,))
+                c.execute("DELETE FROM users WHERE phone_number = %s", (phone,))
+                c.execute("DELETE FROM onboarding_progress WHERE phone_number = %s", (phone,))
+            conn.commit()
+        except Exception as e:
+            print(f"Cleanup error: {e}")
+            if conn:
+                conn.rollback()
+        finally:
+            if conn:
+                return_db_connection(conn)
+
+    cleanup()
+    yield
+    cleanup()
+
+
+@pytest.fixture
+def premium_owner():
+    """Create a premium onboarded user (the list owner)."""
+    from models.user import create_or_update_user
+    create_or_update_user(
+        PHONE_OWNER,
+        first_name="Brad",
+        last_name="Owner",
+        zip_code="10001",
+        timezone="America/New_York",
+        onboarding_complete=True,
+        premium_status="premium",
+    )
+    return {"phone": PHONE_OWNER, "first_name": "Brad"}
+
+
+@pytest.fixture
+def free_user():
+    """Create a free tier onboarded user (shared list recipient)."""
+    from models.user import create_or_update_user
+    create_or_update_user(
+        PHONE_SHARED,
+        first_name="Jane",
+        last_name="Free",
+        zip_code="90210",
+        timezone="America/Los_Angeles",
+        onboarding_complete=True,
+        premium_status="free",
+    )
+    return {"phone": PHONE_SHARED, "first_name": "Jane"}
+
+
+@pytest.fixture
+def owner_list(premium_owner):
+    """Create a list owned by the premium user."""
+    from models.list_model import create_list, add_list_item
+    list_id = create_list(PHONE_OWNER, "Grocery List")
+    add_list_item(list_id, PHONE_OWNER, "Milk")
+    add_list_item(list_id, PHONE_OWNER, "Eggs")
+    return {"list_id": list_id, "name": "Grocery List"}
+
+
+# =====================================================
+# MODEL LAYER TESTS
+# =====================================================
+
+
+class TestShareListModel:
+    """Tests for list_model sharing functions."""
+
+    def test_share_list_success(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list
+        success, msg = share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        assert success is True
+        assert "sent" in msg.lower() or "re-sent" in msg.lower()
+
+    def test_share_list_duplicate(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        success, msg = share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        assert success is False
+        assert "pending" in msg.lower() or "already" in msg.lower()
+
+    def test_share_list_not_owner(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list
+        success, msg = share_list(PHONE_SHARED, owner_list["list_id"], PHONE_OWNER)
+        assert success is False
+        assert "not found" in msg.lower()
+
+    def test_accept_share(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, accept_share, get_shared_lists_for_user
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        success, msg = accept_share(PHONE_SHARED, owner_list["list_id"])
+        assert success is True
+
+        shared = get_shared_lists_for_user(PHONE_SHARED)
+        assert len(shared) == 1
+        assert shared[0][1] == "Grocery List"
+
+    def test_decline_share(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, decline_share, get_pending_shares
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+
+        pending = get_pending_shares(PHONE_SHARED)
+        assert len(pending) == 1
+
+        success, msg = decline_share(PHONE_SHARED, owner_list["list_id"])
+        assert success is True
+
+        pending = get_pending_shares(PHONE_SHARED)
+        assert len(pending) == 0
+
+    def test_leave_shared_list(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, accept_share, leave_shared_list, get_shared_lists_for_user
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        success, msg = leave_shared_list(PHONE_SHARED, owner_list["list_id"])
+        assert success is True
+
+        shared = get_shared_lists_for_user(PHONE_SHARED)
+        assert len(shared) == 0
+
+    def test_unshare_specific_user(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, accept_share, unshare_list, get_list_members
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        success, msg = unshare_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        assert success is True
+
+        members = get_list_members(owner_list["list_id"])
+        assert len(members) == 0
+
+    def test_unshare_all(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, unshare_list_all
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+
+        success, msg = unshare_list_all(PHONE_OWNER, owner_list["list_id"])
+        assert success is True
+        assert "1 user" in msg
+
+    def test_get_list_members(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, get_list_members
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+
+        members = get_list_members(owner_list["list_id"])
+        assert len(members) == 1
+        assert members[0][0] == PHONE_SHARED
+        assert members[0][1] == "pending"
+
+
+class TestAccessibleList:
+    """Tests for get_accessible_list_by_name and can_user_access_list."""
+
+    def test_own_list_accessible(self, premium_owner, owner_list):
+        from models.list_model import get_accessible_list_by_name
+        result = get_accessible_list_by_name(PHONE_OWNER, "Grocery List")
+        assert result is not None
+        list_id, name, is_shared, owner_phone = result
+        assert name == "Grocery List"
+        assert is_shared is False
+        assert owner_phone is None
+
+    def test_shared_list_accessible(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, accept_share, get_accessible_list_by_name
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        result = get_accessible_list_by_name(PHONE_SHARED, "Grocery List")
+        assert result is not None
+        list_id, name, is_shared, owner_phone = result
+        assert name == "Grocery List"
+        assert is_shared is True
+        assert owner_phone == PHONE_OWNER
+
+    def test_pending_share_not_accessible(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, get_accessible_list_by_name
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        # Don't accept
+
+        result = get_accessible_list_by_name(PHONE_SHARED, "Grocery List")
+        assert result is None
+
+    def test_can_user_access_list_owner(self, premium_owner, owner_list):
+        from models.list_model import can_user_access_list
+        has_access, is_owner = can_user_access_list(PHONE_OWNER, owner_list["list_id"])
+        assert has_access is True
+        assert is_owner is True
+
+    def test_can_user_access_list_shared(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, accept_share, can_user_access_list
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        has_access, is_owner = can_user_access_list(PHONE_SHARED, owner_list["list_id"])
+        assert has_access is True
+        assert is_owner is False
+
+    def test_can_user_access_list_no_access(self, premium_owner, free_user, owner_list):
+        from models.list_model import can_user_access_list
+        has_access, is_owner = can_user_access_list(PHONE_SHARED, owner_list["list_id"])
+        assert has_access is False
+        assert is_owner is False
+
+
+class TestSharedListItemOperations:
+    """Tests for item operations on shared lists."""
+
+    def test_add_item_to_shared_list(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, accept_share, add_list_item, get_list_items
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        # Shared user adds item
+        add_list_item(owner_list["list_id"], PHONE_SHARED, "Bread")
+        items = get_list_items(owner_list["list_id"])
+        item_texts = [item[1] for item in items]
+        assert "Bread" in item_texts
+
+    def test_complete_item_on_shared_list(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, accept_share, mark_item_complete_by_list_id, get_list_items
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        success = mark_item_complete_by_list_id(owner_list["list_id"], "Milk")
+        assert success is True
+
+        items = get_list_items(owner_list["list_id"])
+        for item_id, text, completed in items:
+            if text == "Milk":
+                assert completed is True
+
+    def test_delete_item_from_shared_list(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, accept_share, delete_list_item_by_list_id, get_list_items
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        success = delete_list_item_by_list_id(owner_list["list_id"], "Eggs")
+        assert success is True
+
+        items = get_list_items(owner_list["list_id"])
+        item_texts = [item[1] for item in items]
+        assert "Eggs" not in item_texts
+
+
+# =====================================================
+# TIER SERVICE TESTS
+# =====================================================
+
+
+class TestShareListTierGating:
+    """Tests for Premium-only gating on shared lists."""
+
+    def test_premium_can_share(self, premium_owner):
+        from services.tier_service import can_share_list
+        allowed, msg = can_share_list(PHONE_OWNER)
+        assert allowed is True
+        assert msg is None
+
+    def test_free_cannot_share(self, free_user):
+        from services.tier_service import can_share_list
+        allowed, msg = can_share_list(PHONE_SHARED)
+        assert allowed is False
+        assert "premium" in msg.lower() or "upgrade" in msg.lower()
+
+
+# =====================================================
+# LIMIT ENFORCEMENT TESTS
+# =====================================================
+
+
+class TestShareLimits:
+    """Tests for shared list limits."""
+
+    def test_max_members_per_list(self, premium_owner, owner_list):
+        """Test that a list can't be shared with more than SHARED_LIST_MAX_MEMBERS users."""
+        from models.list_model import share_list
+        from models.user import create_or_update_user
+        from config import SHARED_LIST_MAX_MEMBERS
+
+        # Create and share with max users
+        for i in range(SHARED_LIST_MAX_MEMBERS):
+            phone = f"+1555000000{i}"
+            create_or_update_user(phone, first_name=f"User{i}", onboarding_complete=True)
+            success, msg = share_list(PHONE_OWNER, owner_list["list_id"], phone)
+            assert success is True, f"Failed to share with user {i}: {msg}"
+
+        # Try to share with one more
+        extra_phone = "+15550000099"
+        create_or_update_user(extra_phone, first_name="Extra", onboarding_complete=True)
+        success, msg = share_list(PHONE_OWNER, owner_list["list_id"], extra_phone)
+        assert success is False
+        assert "max" in msg.lower() or str(SHARED_LIST_MAX_MEMBERS) in msg
+
+        # Cleanup extra users
+        from database import get_db_connection, return_db_connection
+        conn = get_db_connection()
+        c = conn.cursor()
+        for i in range(SHARED_LIST_MAX_MEMBERS):
+            c.execute("DELETE FROM users WHERE phone_number = %s", (f"+1555000000{i}",))
+        c.execute("DELETE FROM users WHERE phone_number = %s", (extra_phone,))
+        conn.commit()
+        return_db_connection(conn)
+
+    def test_max_shared_lists_per_owner(self, premium_owner, free_user):
+        """Test that an owner can't share more than SHARED_LIST_MAX_PER_USER lists."""
+        from models.list_model import create_list, share_list
+        from config import SHARED_LIST_MAX_PER_USER
+
+        for i in range(SHARED_LIST_MAX_PER_USER):
+            list_id = create_list(PHONE_OWNER, f"List {i}")
+            success, msg = share_list(PHONE_OWNER, list_id, PHONE_SHARED)
+            assert success is True, f"Failed to share list {i}: {msg}"
+
+        # Try to share one more
+        extra_list_id = create_list(PHONE_OWNER, "Extra List")
+        success, msg = share_list(PHONE_OWNER, extra_list_id, PHONE_SHARED)
+        assert success is False
+        assert "limit" in msg.lower()
+
+    def test_reshare_after_decline(self, premium_owner, free_user, owner_list):
+        """Test that a declined share can be re-sent."""
+        from models.list_model import share_list, decline_share
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        decline_share(PHONE_SHARED, owner_list["list_id"])
+
+        # Re-share should work
+        success, msg = share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        assert success is True
+        assert "sent" in msg.lower()
+
+
+# =====================================================
+# HANDLER TESTS
+# =====================================================
+
+
+class TestSharedListHandlers:
+    """Tests for shared list handler functions."""
+
+    def test_format_all_lists_display_with_shared(self, premium_owner, free_user, owner_list):
+        from models.list_model import share_list, accept_share, create_list
+        from routes.handlers.lists import format_all_lists_display
+
+        # Free user has own list + shared list
+        create_list(PHONE_SHARED, "My Personal List")
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        display = format_all_lists_display(PHONE_SHARED)
+        assert "My Personal List" in display
+        assert "[Shared] Grocery List" in display
+
+    def test_format_all_lists_display_no_lists(self, free_user):
+        from routes.handlers.lists import format_all_lists_display
+        display = format_all_lists_display(PHONE_SHARED)
+        assert "don't have any lists" in display.lower()
+
+    def test_normalize_phone(self):
+        from routes.handlers.lists import _normalize_phone
+        assert _normalize_phone("555-123-4567") == "+15551234567"
+        assert _normalize_phone("15551234567") == "+115551234567" or _normalize_phone("15551234567") == "+15551234567"
+        assert _normalize_phone("+15551234567") == "+15551234567"
+
+    def test_format_phone(self):
+        from routes.handlers.lists import _format_phone
+        assert _format_phone("+15551234567") == "(555) 123-4567"
+
+
+# =====================================================
+# CASCADE DELETE TESTS
+# =====================================================
+
+
+class TestCascadeDelete:
+    """Tests for cascade behavior when lists are deleted."""
+
+    def test_delete_shared_list_removes_shares(self, premium_owner, free_user, owner_list):
+        """When owner deletes a list, all shares should be cascade-deleted."""
+        from models.list_model import share_list, accept_share, delete_list, get_shared_lists_for_user
+        share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+        accept_share(PHONE_SHARED, owner_list["list_id"])
+
+        # Verify share exists
+        shared = get_shared_lists_for_user(PHONE_SHARED)
+        assert len(shared) == 1
+
+        # Owner deletes the list
+        delete_list(PHONE_OWNER, "Grocery List")
+
+        # Share should be gone (cascade delete)
+        shared = get_shared_lists_for_user(PHONE_SHARED)
+        assert len(shared) == 0

--- a/tests/test_smart_suggestions.py
+++ b/tests/test_smart_suggestions.py
@@ -1,0 +1,204 @@
+"""
+Tests for Smart Suggestions — Phase 1: Prep Reminders.
+Covers: keyword detection, timing calculation, suggestion injection, YES/NO handling.
+"""
+
+import pytest
+from datetime import datetime, timedelta
+import pytz
+
+
+# =====================================================
+# DETECTION TESTS
+# =====================================================
+
+
+class TestPrepReminderDetection:
+    """Tests for get_reminder_suggestion keyword matching."""
+
+    def _make_future_utc(self, hours_ahead=48):
+        """Helper: UTC datetime string N hours from now."""
+        dt = datetime.utcnow() + timedelta(hours=hours_ahead)
+        return dt.strftime('%Y-%m-%d %H:%M:%S')
+
+    def test_detects_doctor_appointment(self):
+        from services.smart_suggestion_service import get_reminder_suggestion
+        result = get_reminder_suggestion(
+            "doctor appointment",
+            self._make_future_utc(48),
+            "America/New_York"
+        )
+        assert result is not None
+        assert "remind" in result['suggestion_text'].lower() or "want" in result['suggestion_text'].lower()
+
+    def test_detects_interview(self):
+        from services.smart_suggestion_service import get_reminder_suggestion
+        result = get_reminder_suggestion(
+            "job interview at Google",
+            self._make_future_utc(48),
+            "America/New_York"
+        )
+        assert result is not None
+        assert "interview" in result['prep_reminder_text'].lower()
+
+    def test_detects_flight(self):
+        from services.smart_suggestion_service import get_reminder_suggestion
+        result = get_reminder_suggestion(
+            "flight to NYC",
+            self._make_future_utc(48),
+            "America/New_York"
+        )
+        assert result is not None
+        assert "airport" in result['prep_reminder_text'].lower()
+
+    def test_detects_birthday(self):
+        from services.smart_suggestion_service import get_reminder_suggestion
+        result = get_reminder_suggestion(
+            "Mom's birthday",
+            self._make_future_utc(72),
+            "America/New_York"
+        )
+        assert result is not None
+        assert "gift" in result['prep_reminder_text'].lower()
+
+    def test_detects_deadline(self):
+        from services.smart_suggestion_service import get_reminder_suggestion
+        result = get_reminder_suggestion(
+            "project deadline",
+            self._make_future_utc(48),
+            "America/New_York"
+        )
+        assert result is not None
+
+    def test_detects_exam(self):
+        from services.smart_suggestion_service import get_reminder_suggestion
+        result = get_reminder_suggestion(
+            "final exam",
+            self._make_future_utc(48),
+            "America/New_York"
+        )
+        assert result is not None
+        assert "review" in result['prep_reminder_text'].lower()
+
+    def test_no_match_for_generic_reminder(self):
+        from services.smart_suggestion_service import get_reminder_suggestion
+        result = get_reminder_suggestion(
+            "call mom",
+            self._make_future_utc(48),
+            "America/New_York"
+        )
+        assert result is None
+
+    def test_no_match_for_groceries(self):
+        from services.smart_suggestion_service import get_reminder_suggestion
+        result = get_reminder_suggestion(
+            "buy groceries",
+            self._make_future_utc(48),
+            "America/New_York"
+        )
+        assert result is None
+
+    def test_case_insensitive(self):
+        from services.smart_suggestion_service import get_reminder_suggestion
+        result = get_reminder_suggestion(
+            "DOCTOR APPOINTMENT",
+            self._make_future_utc(48),
+            "America/New_York"
+        )
+        assert result is not None
+
+
+# =====================================================
+# TIMING TESTS
+# =====================================================
+
+
+class TestPrepReminderTiming:
+    """Tests for prep reminder timing calculation."""
+
+    def test_no_suggestion_if_too_soon(self):
+        """Events less than 4 hours away shouldn't get suggestions."""
+        from services.smart_suggestion_service import get_reminder_suggestion
+        soon = datetime.utcnow() + timedelta(hours=2)
+        result = get_reminder_suggestion(
+            "doctor appointment",
+            soon.strftime('%Y-%m-%d %H:%M:%S'),
+            "America/New_York"
+        )
+        assert result is None
+
+    def test_no_suggestion_if_prep_in_past(self):
+        """If the calculated prep time would be in the past, no suggestion."""
+        from services.smart_suggestion_service import get_reminder_suggestion
+        # Event 5 hours away — prep would be now-ish or past for 12h default
+        soon = datetime.utcnow() + timedelta(hours=5)
+        result = get_reminder_suggestion(
+            "doctor appointment",
+            soon.strftime('%Y-%m-%d %H:%M:%S'),
+            "America/New_York"
+        )
+        # May or may not return depending on exact timing — just shouldn't crash
+        # The key constraint: if returned, prep_date_utc must be in the future
+        if result:
+            prep_dt = datetime.strptime(result['prep_date_utc'], '%Y-%m-%d %H:%M:%S')
+            assert prep_dt > datetime.utcnow()
+
+    def test_morning_event_gets_evening_before(self):
+        """Morning events should get an evening-before prep reminder."""
+        from services.smart_suggestion_service import _calculate_prep_time
+
+        tz = pytz.timezone("America/New_York")
+        now = datetime.now(tz)
+
+        # Create a morning event 2 days from now at 9 AM
+        event = (now + timedelta(days=2)).replace(hour=9, minute=0, second=0, microsecond=0)
+        prep = _calculate_prep_time(event, 12, now)
+
+        assert prep is not None
+        assert prep.hour == 19  # 7 PM
+        assert prep.date() == (event - timedelta(days=1)).date()
+
+    def test_afternoon_event_gets_hours_before(self):
+        """Afternoon events should get a reminder N hours before."""
+        from services.smart_suggestion_service import _calculate_prep_time
+
+        tz = pytz.timezone("America/New_York")
+        now = datetime.now(tz)
+
+        # Create an afternoon event 2 days from now at 3 PM
+        event = (now + timedelta(days=2)).replace(hour=15, minute=0, second=0, microsecond=0)
+        prep = _calculate_prep_time(event, 12, now)
+
+        assert prep is not None
+        # Should be 12 hours before (3 AM) — but that's fine for the calculation
+        assert prep < event
+
+    def test_birthday_gets_days_before(self):
+        """Birthdays (48h default) should get a reminder 2 days before at 9 AM."""
+        from services.smart_suggestion_service import _calculate_prep_time
+
+        tz = pytz.timezone("America/New_York")
+        now = datetime.now(tz)
+
+        event = (now + timedelta(days=7)).replace(hour=12, minute=0, second=0, microsecond=0)
+        prep = _calculate_prep_time(event, 48, now)
+
+        assert prep is not None
+        assert prep.hour == 9  # 9 AM
+        assert (event.date() - prep.date()).days == 2
+
+    def test_suggestion_has_required_fields(self):
+        """Returned suggestion dict should have all required fields."""
+        from services.smart_suggestion_service import get_reminder_suggestion
+        future = datetime.utcnow() + timedelta(days=3)
+        result = get_reminder_suggestion(
+            "dentist appointment",
+            future.strftime('%Y-%m-%d %H:%M:%S'),
+            "America/New_York"
+        )
+        assert result is not None
+        assert 'suggestion_text' in result
+        assert 'prep_date_utc' in result
+        assert 'prep_local_time' in result
+        assert 'prep_reminder_text' in result
+        assert 'prep_date_display' in result


### PR DESCRIPTION
## Summary
Ships two independently-developed Phase 1 features. Both are **beta-gated by env var** (`SHARED_LISTS_BETA_PHONES`, `SMART_SUGGESTIONS_BETA_PHONES`), so they are invisible to all users until explicitly whitelisted — safe to merge even without immediate rollout.

### Shared Lists Phase 1 (4 commits)
- `b038b69` — core Phase 1: `list_shares` table, share/accept/decline/leave flow, permission model (owner vs shared-user), tier gate (`can_share_list`), beta whitelist
- `0d430f7` — UX polish: name prompt during share, non-user onboarding (invite recipient joins Remyndrs), owner-downgrade guard
- `c5dfa34` — share-by-name: resolves known recipients without re-entering phone numbers
- `55a90a6` — non-user NO decline handling

Phase 2 (batched change notifications) and Phase 3 (name-collision disambiguation, admin dashboard, mute-per-list) are scoped in `docs/shared-lists.md` but **not** in this PR.

### Smart Suggestions Phase 1 (2 commits)
- `691c271` — detects high-importance events (doctor appointments, flights, interviews, deadlines, exams, birthdays) and offers to create a prep reminder
- `b2553eb` — `SMART_SUGGESTIONS_BETA_PHONES` env var gate

Full scope in `docs/smart-suggestions.md`.

### Also includes
- Merge of `main` picks up the date-parsing fix (#240).

## Test plan
- [x] `python run_tests.py --quick` — 237 passed; 2 pre-existing failures in `test_context_switching.py` confirmed to also exist on `main` (unrelated)
- [x] New `tests/test_shared_lists.py` (781 lines) — share flow, permission checks, limit enforcement, name prompt, non-user onboarding, downgrade guard, cascade delete
- [x] New `tests/test_smart_suggestions.py` (204 lines) — detection + timing + field shape
- [ ] Post-merge: add one phone to each beta env var on Render and smoke-test end-to-end via SMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)