### PR TITLE
Fix AI date misparse for "on MONTH DAY" reminders

### DIFF
--- a/routes/handlers/reminders.py
+++ b/routes/handlers/reminders.py
@@ -18,6 +18,7 @@ from models.reminder import (
 )
 from utils.timezone import get_user_current_time
 from utils.validation import detect_sensitive_data, get_sensitive_data_warning
+from utils.date_parsing import extract_explicit_date
 from database import log_interaction
 
 
@@ -199,6 +200,26 @@ def handle_reminder(
             reply_text = get_sensitive_data_warning()
             log_interaction(phone_number, incoming_msg, reply_text, "reminder_blocked", False)
             return reply_text
+
+    # Verify AI's date against any explicit "MONTH DAY" date the user typed.
+    # Guards against AI misparses like "May 8" → tomorrow's date.
+    if reminder_date:
+        try:
+            ai_naive = datetime.strptime(reminder_date, '%Y-%m-%d %H:%M:%S')
+            user_now_local = get_user_current_time(phone_number)
+            explicit = extract_explicit_date(incoming_msg, user_now_local.date())
+            if explicit and explicit != ai_naive.date():
+                logger.warning(
+                    f"AI date mismatch for {phone_number}: AI said {ai_naive.date()}, "
+                    f"user message contains {explicit}. Overriding to user-specified date."
+                )
+                corrected = ai_naive.replace(year=explicit.year, month=explicit.month, day=explicit.day)
+                reminder_date = corrected.strftime('%Y-%m-%d %H:%M:%S')
+                ai_response["reminder_date"] = reminder_date
+                if confidence >= 70:
+                    confidence = 60  # trip confirmation path so the user can verify
+        except (ValueError, TypeError) as e:
+            logger.debug(f"Skipping date verification (unparseable AI date): {e}")
 
     # Check tier limit (pass reminder_date for v2 weekly counting)
     allowed, limit_msg = can_create_reminder(phone_number, reminder_date)

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -232,6 +232,13 @@ IMPORTANT: "before [date]" means SUBTRACT from that date. Do NOT interpret "a we
 For SPECIFIC TIME reminders (use action "reminder"):
 - "tomorrow at 9am" = tomorrow's date at 09:00:00
 - "Saturday at 8am" = next Saturday at 08:00:00
+- "at 8am on May 8" = May 8 of the current year at 08:00:00 (or next year if May 8 is already past)
+- "on October 3rd at 2pm" = October 3 at 14:00:00
+
+CRITICAL DATE RULE for MONTH-NAME dates ("on May 8", "October 3rd", "Dec 15"):
+Use the EXACT month and day the user named. Do NOT substitute tomorrow's date or any nearby date.
+If the named date is already in the past for the current year, roll forward to next year.
+Example: today is April 18, 2026. "Remind me on May 8 at 8am" → reminder_date: "2026-05-08 08:00:00" (NOT "2026-04-19 08:00:00").
 
 For reminder requests with DAYS OF THE WEEK:
 - Use "Today is: {current_day_of_week}" to calculate

--- a/tests/test_date_parsing.py
+++ b/tests/test_date_parsing.py
@@ -1,0 +1,108 @@
+"""
+Tests for utils/date_parsing.extract_explicit_date and the
+reminder handler's AI-date verification override.
+"""
+
+import pytest
+from datetime import date, datetime
+from unittest.mock import patch
+
+from utils.date_parsing import extract_explicit_date
+
+
+REF = date(2026, 4, 18)  # Saturday
+
+
+class TestExtractExplicitDate:
+    def test_month_name_with_day(self):
+        assert extract_explicit_date("Remind me at 8 AM on May 8", REF) == date(2026, 5, 8)
+
+    def test_month_name_with_ordinal(self):
+        assert extract_explicit_date("meeting on October 3rd at 2pm", REF) == date(2026, 10, 3)
+
+    def test_month_abbreviation(self):
+        assert extract_explicit_date("pay bill on Dec 15", REF) == date(2026, 12, 15)
+
+    def test_sept_abbrev(self):
+        assert extract_explicit_date("on Sept 5", REF) == date(2026, 9, 5)
+
+    def test_with_explicit_year(self):
+        assert extract_explicit_date("on May 8, 2027", REF) == date(2027, 5, 8)
+        assert extract_explicit_date("on May 8 2027", REF) == date(2027, 5, 8)
+
+    def test_rolls_to_next_year_when_past(self):
+        # Jan 5 is before April 18, 2026
+        assert extract_explicit_date("on January 5", REF) == date(2027, 1, 5)
+
+    def test_does_not_roll_when_year_explicit(self):
+        assert extract_explicit_date("on January 5, 2026", REF) == date(2026, 1, 5)
+
+    def test_no_date_in_message(self):
+        assert extract_explicit_date("remind me tomorrow to call mom", REF) is None
+
+    def test_empty_message(self):
+        assert extract_explicit_date("", REF) is None
+        assert extract_explicit_date(None, REF) is None
+
+    def test_invalid_day(self):
+        assert extract_explicit_date("on February 30", REF) is None
+
+    def test_ambiguous_multiple_dates_no_anchor(self):
+        # Two dates, neither preceded by on/for/by — refuse to guess
+        result = extract_explicit_date("between May 8 and June 12", REF)
+        assert result is None
+
+    def test_anchored_date_wins_over_unanchored(self):
+        # The AI should have scheduled the reminder for the "on" date
+        result = extract_explicit_date("my Dec 30 trip, remind me on Feb 14", REF)
+        assert result == date(2027, 2, 14)
+
+    def test_case_insensitive(self):
+        assert extract_explicit_date("on MAY 8", REF) == date(2026, 5, 8)
+        assert extract_explicit_date("on may 8", REF) == date(2026, 5, 8)
+
+    def test_day_with_th_suffix(self):
+        assert extract_explicit_date("on May 8th", REF) == date(2026, 5, 8)
+        assert extract_explicit_date("on May 1st", REF) == date(2026, 5, 1)
+        assert extract_explicit_date("on May 2nd", REF) == date(2026, 5, 2)
+        assert extract_explicit_date("on May 3rd", REF) == date(2026, 5, 3)
+
+
+class TestReminderHandlerDateOverride:
+    """
+    Regression guard for the bug where AI returned April 19 for
+    "Remind me at 8 AM on May 8" (today was April 18, 2026).
+    """
+
+    def test_override_corrects_ai_date(self):
+        from routes.handlers import reminders as rh
+
+        ai_response = {
+            "action": "reminder",
+            "reminder_text": "cannot have any more ibuprofen until surgery",
+            "reminder_date": "2026-04-19 08:00:00",  # AI's wrong answer
+            "confidence": 95,
+        }
+        incoming = "Remind me at 8:AM on May 8, that I cannot have any more ibuprofen until surgery"
+
+        with patch.object(rh, 'get_user_current_time', return_value=datetime(2026, 4, 18, 15, 42)), \
+             patch.object(rh, 'get_user_timezone', return_value='America/New_York'), \
+             patch('services.tier_service.can_create_reminder', return_value=(True, None)), \
+             patch.object(rh, 'save_reminder_with_local_time'), \
+             patch.object(rh, 'create_or_update_user'), \
+             patch.object(rh, 'log_interaction'):
+            reply = rh.handle_reminder(
+                phone_number="+15559876543",
+                incoming_msg=incoming,
+                ai_response=ai_response,
+                should_prompt_daily_summary=lambda _p: False,
+                get_daily_summary_prompt_message=lambda r: r,
+                mark_daily_summary_prompted=lambda _p: None,
+                log_confidence=lambda *a, **kw: None,
+                get_setting=lambda _k, default: default,
+            )
+
+        # handler mutates ai_response in place with the corrected date
+        assert ai_response["reminder_date"].startswith("2026-05-08")
+        # confidence drops into confirmation range, so the reply should ask for confirmation
+        assert "YES" in reply or "right" in reply.lower()

--- a/utils/date_parsing.py
+++ b/utils/date_parsing.py
@@ -1,0 +1,86 @@
+"""
+Date Parsing Utilities
+Server-side extraction of explicit calendar dates from user messages,
+used to verify AI-produced reminder dates.
+"""
+
+import re
+from datetime import date
+from typing import Optional
+
+MONTH_NAMES = {
+    'january': 1, 'jan': 1,
+    'february': 2, 'feb': 2,
+    'march': 3, 'mar': 3,
+    'april': 4, 'apr': 4,
+    'may': 5,
+    'june': 6, 'jun': 6,
+    'july': 7, 'jul': 7,
+    'august': 8, 'aug': 8,
+    'september': 9, 'sep': 9, 'sept': 9,
+    'october': 10, 'oct': 10,
+    'november': 11, 'nov': 11,
+    'december': 12, 'dec': 12,
+}
+
+_MONTH_PATTERN = '|'.join(sorted(MONTH_NAMES.keys(), key=len, reverse=True))
+_DATE_REGEX = re.compile(
+    rf'\b({_MONTH_PATTERN})\s+(\d{{1,2}})(?:st|nd|rd|th)?\b(?:[,\s]+(\d{{4}}))?',
+    re.IGNORECASE,
+)
+_ANCHOR_REGEX = re.compile(r'\b(on|for|by)\s+$', re.IGNORECASE)
+
+
+def extract_explicit_date(message: str, reference_date: date) -> Optional[date]:
+    """
+    Extract an explicit "MONTH DAY [YEAR]" calendar date from a user message.
+
+    Returns None when no date is found, or when multiple candidate dates exist
+    without a clear anchor word ("on"/"for"/"by") — we'd rather defer to the AI
+    than guess wrong.
+
+    If the parsed month/day is already in the past relative to `reference_date`
+    and no explicit year was given, rolls forward one year.
+    """
+    if not message:
+        return None
+
+    matches = list(_DATE_REGEX.finditer(message))
+    if not matches:
+        return None
+
+    anchored = None
+    for m in matches:
+        preceding = message[max(0, m.start() - 8):m.start()]
+        if _ANCHOR_REGEX.search(preceding):
+            anchored = m
+            break
+
+    if anchored is not None:
+        chosen = anchored
+    elif len(matches) == 1:
+        chosen = matches[0]
+    else:
+        return None
+
+    month_str, day_str, year_str = chosen.groups()
+    month = MONTH_NAMES[month_str.lower()]
+    day = int(day_str)
+
+    if not (1 <= day <= 31):
+        return None
+
+    year = int(year_str) if year_str else reference_date.year
+
+    try:
+        parsed = date(year, month, day)
+    except ValueError:
+        return None
+
+    if not year_str and parsed < reference_date:
+        try:
+            parsed = date(year + 1, month, day)
+        except ValueError:
+            return None
+
+    return parsed


### PR DESCRIPTION
## Summary
- Real-world bug: user said "Remind me at 8 AM on May 8..." and the system scheduled it for April 19 (tomorrow). AI (GPT-4o-mini) misparsed the month-name date and the handler trusted it blindly.
- Adds `utils/date_parsing.extract_explicit_date()` that re-reads the user's message for explicit `MONTH DAY [YEAR]` dates (handles ordinals, abbreviations, year rollover, refuses to guess when multiple unanchored dates exist).
- `handle_reminder` now cross-checks the AI's `reminder_date` against the extracted date; on mismatch it corrects the date and drops confidence below threshold so the user gets a "Is that right? YES" confirmation.
- Prompt hardened with `on May 8` / `October 3rd` examples and a "do not substitute tomorrow's date" rule.

## Test plan
- [x] New `tests/test_date_parsing.py` — 15 unit tests, including the Heather regression case
- [x] Existing `tests/test_reminders.py` — all 22 pass
- [ ] Manually text `Remind me at 8 AM on May 8 to test` on staging and confirm it schedules for May 8, not tomorrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)