### PR TITLE
Wire shared lists into all list edit/view paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -4037,11 +4037,14 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
         # If user sends just a number and has lists (but no pending item), show that list
         if incoming_msg.strip().isdigit() and not get_pending_list_item(phone_number):
             list_num = int(incoming_msg.strip())
-            lists = get_lists(phone_number)
-            if lists and 1 <= list_num <= len(lists):
-                selected_list = lists[list_num - 1]
-                list_id = selected_list[0]
-                list_name = selected_list[1]
+            from routes.handlers.lists import get_all_lists_with_shared
+            all_lists = get_all_lists_with_shared(phone_number)
+            if all_lists and 1 <= list_num <= len(all_lists):
+                selected = all_lists[list_num - 1]
+                list_id = selected['list_id']
+                list_name = selected['list_name']
+                is_shared = selected['is_shared']
+                prefix = "[Shared] " if is_shared else ""
                 # Set context so "Delete #" knows we're viewing this specific list
                 create_or_update_user(phone_number, last_active_list=list_name)
                 items = get_list_items(list_id)
@@ -4052,9 +4055,9 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                             item_lines.append(f"{i}. [x] {item_text}")
                         else:
                             item_lines.append(f"{i}. {item_text}")
-                    reply = f"{list_name}:\n\n" + "\n".join(item_lines)
+                    reply = f"{prefix}{list_name}:\n\n" + "\n".join(item_lines)
                 else:
-                    reply = f"Your {list_name} is empty."
+                    reply = f"{prefix}{list_name} is empty." if is_shared else f"Your {list_name} is empty."
 
                 resp = MessagingResponse()
                 resp.message(reply)

--- a/routes/handlers/lists.py
+++ b/routes/handlers/lists.py
@@ -19,7 +19,7 @@ from models.list_model import (
     accept_share, decline_share, leave_shared_list,
     add_list_item as db_add_list_item,
     mark_item_complete_by_list_id, mark_item_incomplete_by_list_id,
-    delete_list_item_by_list_id
+    delete_list_item_by_list_id, is_shared_list_read_only
 )
 from services.ai_service import parse_list_items
 from utils.validation import (
@@ -118,7 +118,24 @@ def handle_add_to_list(
 
     # Parse multiple items
     items_to_add = parse_list_items(item_text, phone_number)
-    list_info = get_list_by_name(phone_number, list_name)
+
+    # Look up list across owned + accepted shared lists
+    accessible = get_accessible_list_by_name(phone_number, list_name)
+    is_shared = False
+    owner_phone = None
+    if accessible:
+        list_id, actual_name, is_shared, owner_phone = accessible
+        list_info = (list_id, actual_name)
+    else:
+        list_info = None
+
+    # Enforce read-only for shared lists whose owner has lost Premium
+    if is_shared:
+        read_only, _ = is_shared_list_read_only(list_info[0])
+        if read_only:
+            reply_text = f"The shared list '{list_info[1]}' is currently read-only because the owner's Premium plan has expired."
+            log_interaction(phone_number, incoming_msg, reply_text, "add_to_list", False)
+            return reply_text
 
     # Auto-create list if it doesn't exist
     if not list_info:
@@ -159,14 +176,17 @@ def handle_add_to_list(
         list_id = list_info[0]
         list_name = list_info[1]
 
-        allowed, limit_msg = can_add_list_item(phone_number, list_id)
+        # For shared lists, tier limits follow the list owner (who is Premium)
+        limit_phone = owner_phone if is_shared else phone_number
+
+        allowed, limit_msg = can_add_list_item(limit_phone, list_id)
         if not allowed:
             # List is already full - use Level 4 formatter
             reply_text = format_list_item_limit_message(
-                phone_number, list_name, items_to_add, 0
+                limit_phone, list_name, items_to_add, 0
             )
         else:
-            tier_limits = get_tier_limits(get_user_tier(phone_number))
+            tier_limits = get_tier_limits(get_user_tier(limit_phone))
             max_items = tier_limits['max_items_per_list']
             item_count = get_item_count(list_id)
             available_slots = max_items - item_count
@@ -183,17 +203,21 @@ def handle_add_to_list(
             if len(added_items) < len(items_to_add):
                 # Some items skipped - use Level 4 formatter
                 reply_text = format_list_item_limit_message(
-                    phone_number, list_name, items_to_add, len(added_items)
+                    limit_phone, list_name, items_to_add, len(added_items)
                 )
             else:
                 # All items added successfully
+                display_name = f"shared list '{list_name}'" if is_shared else f"your {list_name}"
                 if len(added_items) == 1:
-                    base_reply = ai_response.get("confirmation", f"Added {added_items[0]} to your {list_name}")
+                    base_reply = ai_response.get("confirmation", f"Added {added_items[0]} to {display_name}")
                 else:
-                    base_reply = f"Added {len(added_items)} items to your {list_name}: {', '.join(added_items)}"
+                    base_reply = f"Added {len(added_items)} items to {display_name}: {', '.join(added_items)}"
 
-                # Add progressive counter
-                reply_text = add_list_item_counter_to_message(phone_number, list_id, base_reply)
+                # Progressive counter only for owned lists (shared lists follow owner's limits)
+                if not is_shared:
+                    reply_text = add_list_item_counter_to_message(phone_number, list_id, base_reply)
+                else:
+                    reply_text = base_reply
 
     log_interaction(phone_number, incoming_msg, reply_text, "add_to_list", True)
     return reply_text
@@ -204,30 +228,43 @@ def handle_add_item_ask_list(
     incoming_msg: str,
     ai_response: dict[str, Any]
 ) -> str:
-    """Handle add_item_ask_list action - when list name is ambiguous."""
+    """Handle add_item_ask_list action - when list name is ambiguous.
+
+    Disambiguation menu includes owned + accepted shared lists (marked [Shared]).
+    """
     from services.tier_service import (
         can_add_list_item, get_tier_limits, get_user_tier,
         format_list_item_limit_message, add_list_item_counter_to_message
     )
 
     item_text = ai_response.get("item_text")
-    lists = get_lists(phone_number)
+    all_lists = get_all_lists_with_shared(phone_number)
 
-    if len(lists) == 1:
+    if len(all_lists) == 1:
         # Only one list, add directly
-        list_id = lists[0][0]
-        list_name = lists[0][1]
+        only = all_lists[0]
+        list_id = only['list_id']
+        list_name = only['list_name']
+        is_shared = only['is_shared']
+        owner_phone = only['owner_phone']
+
+        if is_shared:
+            read_only, _ = is_shared_list_read_only(list_id)
+            if read_only:
+                reply_text = f"The shared list '{list_name}' is currently read-only because the owner's Premium plan has expired."
+                log_interaction(phone_number, incoming_msg, reply_text, "add_item_ask_list", False)
+                return reply_text
 
         items_to_add = parse_list_items(item_text, phone_number)
+        limit_phone = owner_phone if is_shared else phone_number
 
-        allowed, limit_msg = can_add_list_item(phone_number, list_id)
+        allowed, _ = can_add_list_item(limit_phone, list_id)
         if not allowed:
-            # List is full - use Level 4 formatter
             reply_text = format_list_item_limit_message(
-                phone_number, list_name, items_to_add, 0
+                limit_phone, list_name, items_to_add, 0
             )
         else:
-            tier_limits = get_tier_limits(get_user_tier(phone_number))
+            tier_limits = get_tier_limits(get_user_tier(limit_phone))
             max_items = tier_limits['max_items_per_list']
             item_count = get_item_count(list_id)
             available_slots = max_items - item_count
@@ -240,26 +277,24 @@ def handle_add_item_ask_list(
 
             create_or_update_user(phone_number, last_active_list=list_name)
 
-            # Handle partial or full adds with progressive education
             if len(added_items) < len(items_to_add):
-                # Some items skipped - use Level 4 formatter
                 reply_text = format_list_item_limit_message(
-                    phone_number, list_name, items_to_add, len(added_items)
+                    limit_phone, list_name, items_to_add, len(added_items)
                 )
             else:
-                # All items added successfully
+                display = f"shared list '{list_name}'" if is_shared else f"your {list_name}"
                 if len(added_items) == 1:
-                    base_reply = f"Added {added_items[0]} to your {list_name}"
+                    base_reply = f"Added {added_items[0]} to {display}"
                 else:
-                    base_reply = f"Added {len(added_items)} items to your {list_name}: {', '.join(added_items)}"
+                    base_reply = f"Added {len(added_items)} items to {display}: {', '.join(added_items)}"
+                reply_text = base_reply if is_shared else add_list_item_counter_to_message(phone_number, list_id, base_reply)
 
-                # Add progressive counter
-                reply_text = add_list_item_counter_to_message(phone_number, list_id, base_reply)
-
-    elif len(lists) > 1:
-        # Multiple lists, ask which one
+    elif len(all_lists) > 1:
         create_or_update_user(phone_number, pending_list_item=item_text)
-        list_options = "\n".join([f"{i+1}. {l[1]}" for i, l in enumerate(lists)])
+        list_options = "\n".join(
+            f"{i+1}. {'[Shared] ' if l['is_shared'] else ''}{l['list_name']}"
+            for i, l in enumerate(all_lists)
+        )
         reply_text = f"Which list would you like to add these to?\n\n{list_options}\n\nReply with a number:"
     else:
         reply_text = "You don't have any lists yet. Try 'Create a grocery list' first!"
@@ -273,13 +308,15 @@ def handle_show_list(
     incoming_msg: str,
     ai_response: dict[str, Any]
 ) -> str:
-    """Handle show_list action - show a specific list."""
+    """Handle show_list action - show a specific list (owned or shared)."""
     list_name = ai_response.get("list_name")
-    list_info = get_list_by_name(phone_number, list_name)
+    accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
 
-    if list_info:
-        create_or_update_user(phone_number, last_active_list=list_info[1])
-        items = get_list_items(list_info[0])
+    if accessible:
+        list_id, actual_name, is_shared, _owner_phone = accessible
+        create_or_update_user(phone_number, last_active_list=actual_name)
+        items = get_list_items(list_id)
+        prefix = "[Shared] " if is_shared else ""
 
         if items:
             item_lines = []
@@ -288,9 +325,9 @@ def handle_show_list(
                     item_lines.append(f"{i}. [x] {item_text}")
                 else:
                     item_lines.append(f"{i}. {item_text}")
-            reply_text = f"{list_info[1]}:\n\n" + "\n".join(item_lines)
+            reply_text = f"{prefix}{actual_name}:\n\n" + "\n".join(item_lines)
         else:
-            reply_text = f"Your {list_info[1]} is empty."
+            reply_text = f"{prefix}{actual_name} is empty." if is_shared else f"Your {actual_name} is empty."
     else:
         reply_text = f"I couldn't find a list called '{list_name}'."
 
@@ -304,9 +341,11 @@ def handle_show_current_list(phone_number: str, incoming_msg: str) -> str:
     logger.info(f"show_current_list: last_active={last_active}")
 
     if last_active:
-        list_info = get_list_by_name(phone_number, last_active)
-        if list_info:
-            items = get_list_items(list_info[0])
+        accessible = get_accessible_list_by_name(phone_number, last_active)
+        if accessible:
+            list_id, actual_name, is_shared, _owner_phone = accessible
+            items = get_list_items(list_id)
+            prefix = "[Shared] " if is_shared else ""
             if items:
                 item_lines = []
                 for i, (item_id, item_text, completed) in enumerate(items, 1):
@@ -314,9 +353,9 @@ def handle_show_current_list(phone_number: str, incoming_msg: str) -> str:
                         item_lines.append(f"{i}. [x] {item_text}")
                     else:
                         item_lines.append(f"{i}. {item_text}")
-                reply_text = f"{list_info[1]}:\n\n" + "\n".join(item_lines)
+                reply_text = f"{prefix}{actual_name}:\n\n" + "\n".join(item_lines)
             else:
-                reply_text = f"Your {list_info[1]} is empty."
+                reply_text = f"{prefix}{actual_name} is empty." if is_shared else f"Your {actual_name} is empty."
         else:
             # Last active list was deleted
             reply_text = _show_all_lists_or_single(phone_number)
@@ -328,12 +367,15 @@ def handle_show_current_list(phone_number: str, incoming_msg: str) -> str:
 
 
 def _show_all_lists_or_single(phone_number: str) -> str:
-    """Helper to show all lists or single list directly."""
-    lists = get_lists(phone_number)
+    """Helper to show all lists (owned + shared) or single list directly."""
+    all_lists = get_all_lists_with_shared(phone_number)
 
-    if len(lists) == 1:
-        list_id = lists[0][0]
-        list_name = lists[0][1]
+    if len(all_lists) == 1:
+        only = all_lists[0]
+        list_id = only['list_id']
+        list_name = only['list_name']
+        is_shared = only['is_shared']
+        prefix = "[Shared] " if is_shared else ""
         create_or_update_user(phone_number, last_active_list=list_name)
         items = get_list_items(list_id)
 
@@ -344,26 +386,22 @@ def _show_all_lists_or_single(phone_number: str) -> str:
                     item_lines.append(f"{i}. [x] {item_text}")
                 else:
                     item_lines.append(f"{i}. {item_text}")
-            return f"{list_name}:\n\n" + "\n".join(item_lines)
+            return f"{prefix}{list_name}:\n\n" + "\n".join(item_lines)
         else:
-            return f"Your {list_name} is empty."
-    elif lists:
-        list_lines = [f"{i+1}. {l[1]} ({l[2]} items)" for i, l in enumerate(lists)]
+            return f"{prefix}{list_name} is empty." if is_shared else f"Your {list_name} is empty."
+    elif all_lists:
+        list_lines = []
+        for i, lst in enumerate(all_lists, 1):
+            prefix = "[Shared] " if lst['is_shared'] else ""
+            list_lines.append(f"{i}. {prefix}{lst['list_name']} ({lst['item_count']} items)")
         return "Your lists:\n\n" + "\n".join(list_lines) + "\n\nReply with a number to see that list."
     else:
         return "You don't have any lists yet. Try 'Create a grocery list'!"
 
 
 def handle_show_all_lists(phone_number: str, incoming_msg: str) -> str:
-    """Handle show_all_lists action."""
-    lists = get_lists(phone_number)
-
-    if lists:
-        list_lines = [f"{i+1}. {l[1]} ({l[2]} items)" for i, l in enumerate(lists)]
-        reply_text = "Your lists:\n\n" + "\n".join(list_lines) + "\n\nReply with a number to see that list."
-    else:
-        reply_text = "You don't have any lists yet. Try 'Create a grocery list'!"
-
+    """Handle show_all_lists action (owned + shared)."""
+    reply_text = format_all_lists_display(phone_number)
     log_interaction(phone_number, incoming_msg, reply_text, "show_all_lists", True)
     return reply_text
 
@@ -373,14 +411,26 @@ def handle_complete_item(
     incoming_msg: str,
     ai_response: dict[str, Any]
 ) -> str:
-    """Handle complete_item action - mark item as done."""
+    """Handle complete_item action - mark item as done (owned or shared list)."""
     list_name = ai_response.get("list_name")
     item_text = ai_response.get("item_text")
 
-    if mark_item_complete(phone_number, list_name, item_text):
-        reply_text = ai_response.get("confirmation", f"Checked off {item_text}")
+    accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
+    if accessible:
+        list_id, actual_name, is_shared, _owner_phone = accessible
+        if is_shared:
+            read_only, _ = is_shared_list_read_only(list_id)
+            if read_only:
+                reply_text = f"The shared list '{actual_name}' is currently read-only because the owner's Premium plan has expired."
+                log_interaction(phone_number, incoming_msg, reply_text, "complete_item", False)
+                return reply_text
+        if mark_item_complete_by_list_id(list_id, item_text):
+            display = f"shared list '{actual_name}'" if is_shared else f"your {actual_name}"
+            reply_text = ai_response.get("confirmation", f"Checked off {item_text} from {display}")
+        else:
+            reply_text = f"Couldn't find '{item_text}' in '{actual_name}'."
     else:
-        # Try to find item in any list
+        # Try to find item in any owned list
         found = find_item_in_any_list(phone_number, item_text)
         if len(found) == 1:
             list_name = found[0][1]
@@ -402,12 +452,24 @@ def handle_uncomplete_item(
     incoming_msg: str,
     ai_response: dict[str, Any]
 ) -> str:
-    """Handle uncomplete_item action - unmark item as done."""
+    """Handle uncomplete_item action - unmark item as done (owned or shared list)."""
     list_name = ai_response.get("list_name")
     item_text = ai_response.get("item_text")
 
-    if mark_item_incomplete(phone_number, list_name, item_text):
-        reply_text = ai_response.get("confirmation", f"Unmarked {item_text}")
+    accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
+    if accessible:
+        list_id, actual_name, is_shared, _owner_phone = accessible
+        if is_shared:
+            read_only, _ = is_shared_list_read_only(list_id)
+            if read_only:
+                reply_text = f"The shared list '{actual_name}' is currently read-only because the owner's Premium plan has expired."
+                log_interaction(phone_number, incoming_msg, reply_text, "uncomplete_item", False)
+                return reply_text
+        if mark_item_incomplete_by_list_id(list_id, item_text):
+            display = f"shared list '{actual_name}'" if is_shared else f"your {actual_name}"
+            reply_text = ai_response.get("confirmation", f"Unmarked {item_text} in {display}")
+        else:
+            reply_text = f"Couldn't find '{item_text}' to unmark."
     else:
         reply_text = f"Couldn't find '{item_text}' to unmark."
 
@@ -420,20 +482,44 @@ def handle_delete_item(
     incoming_msg: str,
     ai_response: dict[str, Any]
 ) -> str:
-    """Handle delete_item action - remove item from list (asks for confirmation)."""
+    """Handle delete_item action - remove item from list (asks for confirmation).
+
+    Resolves across owned + shared lists so the confirmation step can act on the right list.
+    """
     list_name = ai_response.get("list_name")
     item_text = ai_response.get("item_text")
 
-    # Store pending delete for confirmation
-    confirm_data = json.dumps({
-        'awaiting_confirmation': True,
-        'type': 'list_item',
-        'list_name': list_name,
-        'text': item_text
-    })
-    create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
+    accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
+    if accessible:
+        list_id, actual_name, is_shared, _owner_phone = accessible
+        if is_shared:
+            read_only, _ = is_shared_list_read_only(list_id)
+            if read_only:
+                reply_text = f"The shared list '{actual_name}' is currently read-only because the owner's Premium plan has expired."
+                log_interaction(phone_number, incoming_msg, reply_text, "delete_item_confirm", False)
+                return reply_text
+        confirm_data = json.dumps({
+            'awaiting_confirmation': True,
+            'type': 'list_item',
+            'list_name': actual_name,
+            'list_id': list_id,
+            'is_shared': is_shared,
+            'text': item_text,
+        })
+        create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
+        display = f"shared list '{actual_name}'" if is_shared else actual_name
+        reply_text = f"Remove '{item_text}' from {display}?\n\nReply YES to confirm or CANCEL to keep it."
+    else:
+        # Preserve old behavior: store with name only; confirmation will report not-found
+        confirm_data = json.dumps({
+            'awaiting_confirmation': True,
+            'type': 'list_item',
+            'list_name': list_name,
+            'text': item_text,
+        })
+        create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
+        reply_text = f"Remove '{item_text}' from {list_name}?\n\nReply YES to confirm or CANCEL to keep it."
 
-    reply_text = f"Remove '{item_text}' from {list_name}?\n\nReply YES to confirm or CANCEL to keep it."
     log_interaction(phone_number, incoming_msg, "Asking delete_item confirmation", "delete_item_confirm", True)
     return reply_text
 
@@ -443,7 +529,7 @@ def handle_delete_list(
     incoming_msg: str,
     ai_response: dict[str, Any]
 ) -> str:
-    """Handle delete_list action - delete entire list."""
+    """Handle delete_list action - delete entire list (owner only)."""
     list_name = ai_response.get("list_name")
     list_info = get_list_by_name(phone_number, list_name)
 
@@ -460,7 +546,12 @@ def handle_delete_list(
             db_delete_list(phone_number, actual_name)
             reply_text = f"Deleted your {actual_name}."
     else:
-        reply_text = f"I couldn't find a list called '{list_name}'."
+        # Not owned — is it a shared list?
+        accessible = get_accessible_list_by_name(phone_number, list_name)
+        if accessible and accessible[2]:  # is_shared
+            reply_text = f"Only the owner can delete '{accessible[1]}'. Reply 'Leave {accessible[1]}' to remove yourself from the share."
+        else:
+            reply_text = f"I couldn't find a list called '{list_name}'."
 
     log_interaction(phone_number, incoming_msg, reply_text, "delete_list", True)
     return reply_text
@@ -471,7 +562,7 @@ def handle_clear_list(
     incoming_msg: str,
     ai_response: dict[str, Any]
 ) -> str:
-    """Handle clear_list action - remove all items from list."""
+    """Handle clear_list action - remove all items from list (owner only)."""
     list_name = ai_response.get("list_name")
     list_info = get_list_by_name(phone_number, list_name)
 
@@ -479,7 +570,11 @@ def handle_clear_list(
         db_clear_list(phone_number, list_info[1])
         reply_text = f"Cleared all items from your {list_info[1]}."
     else:
-        reply_text = f"I couldn't find a list called '{list_name}'."
+        accessible = get_accessible_list_by_name(phone_number, list_name)
+        if accessible and accessible[2]:  # is_shared
+            reply_text = f"Only the owner can clear '{accessible[1]}'."
+        else:
+            reply_text = f"I couldn't find a list called '{list_name}'."
 
     log_interaction(phone_number, incoming_msg, reply_text, "clear_list", True)
     return reply_text
@@ -490,11 +585,18 @@ def handle_rename_list(
     incoming_msg: str,
     ai_response: dict[str, Any]
 ) -> str:
-    """Handle rename_list action."""
+    """Handle rename_list action (owner only)."""
     old_name = ai_response.get("old_name")
     new_name = ai_response.get("new_name")
 
     list_info = get_list_by_name(phone_number, old_name)
+
+    if not list_info:
+        accessible = get_accessible_list_by_name(phone_number, old_name)
+        if accessible and accessible[2]:  # is_shared
+            reply_text = f"Only the owner can rename '{accessible[1]}'."
+            log_interaction(phone_number, incoming_msg, reply_text, "rename_list", False)
+            return reply_text
 
     if list_info:
         is_valid, result = validate_list_name(new_name)

--- a/routes/handlers/pending_states.py
+++ b/routes/handlers/pending_states.py
@@ -88,7 +88,16 @@ def handle_pending_delete(
                     reply_msg = "Couldn't delete that recurring reminder."
 
             elif delete_type == 'list_item':
-                if delete_list_item(phone_number, delete_data['list_name'], delete_data['text']):
+                list_id = delete_data.get('list_id')
+                is_shared = delete_data.get('is_shared', False)
+                if list_id is not None:
+                    from models.list_model import delete_list_item_by_list_id
+                    if delete_list_item_by_list_id(list_id, delete_data['text']):
+                        display = f"shared list '{delete_data['list_name']}'" if is_shared else delete_data['list_name']
+                        reply_msg = f"Removed '{delete_data['text']}' from {display}"
+                    else:
+                        reply_msg = "Couldn't delete that item."
+                elif delete_list_item(phone_number, delete_data['list_name'], delete_data['text']):
                     reply_msg = f"Removed '{delete_data['text']}' from {delete_data['list_name']}"
                 else:
                     reply_msg = "Couldn't delete that item."
@@ -306,31 +315,39 @@ def handle_pending_list_item(
         return (False, None)
 
     list_num = int(incoming_msg.strip())
-    lists = get_lists(phone_number)
+    from routes.handlers.lists import get_all_lists_with_shared
+    from models.list_model import is_shared_list_read_only
+    all_lists = get_all_lists_with_shared(phone_number)
 
-    if 1 <= list_num <= len(lists):
-        selected_list = lists[list_num - 1]
-        list_id = selected_list[0]
-        list_name = selected_list[1]
+    if 1 <= list_num <= len(all_lists):
+        selected = all_lists[list_num - 1]
+        list_id = selected['list_id']
+        list_name = selected['list_name']
+        is_shared = selected['is_shared']
+        owner_phone = selected['owner_phone']
 
-        # Parse multiple items
+        if is_shared:
+            read_only, _ = is_shared_list_read_only(list_id)
+            if read_only:
+                create_or_update_user(phone_number, pending_list_item=None)
+                return (True, f"The shared list '{list_name}' is currently read-only because the owner's Premium plan has expired.")
+
+        limit_phone = owner_phone if is_shared else phone_number
         items_to_add = parse_list_items(pending_item, phone_number)
 
-        # Check item limit using tier-aware limits
-        tier_limits = get_tier_limits(get_user_tier(phone_number))
+        # Tier limits follow the list owner for shared lists
+        tier_limits = get_tier_limits(get_user_tier(limit_phone))
         max_items = tier_limits['max_items_per_list']
         item_count = get_item_count(list_id)
         available_slots = max_items - item_count
 
         if available_slots <= 0:
             create_or_update_user(phone_number, pending_list_item=None)
-            # Use Level 4 formatter for clear WHY-WHAT-HOW message
             reply_msg = format_list_item_limit_message(
-                phone_number, list_name, items_to_add, 0
+                limit_phone, list_name, items_to_add, 0
             )
             return (True, reply_msg)
 
-        # Add items
         added_items = []
         for item in items_to_add:
             if len(added_items) < available_slots:
@@ -339,26 +356,22 @@ def handle_pending_list_item(
 
         create_or_update_user(phone_number, pending_list_item=None, last_active_list=list_name)
 
-        # Handle partial or full adds with progressive education
         if len(added_items) < len(items_to_add):
-            # Some items skipped - use Level 4 formatter
             reply_msg = format_list_item_limit_message(
-                phone_number, list_name, items_to_add, len(added_items)
+                limit_phone, list_name, items_to_add, len(added_items)
             )
         else:
-            # All items added successfully
+            display = f"shared list '{list_name}'" if is_shared else f"your {list_name}"
             if len(added_items) == 1:
-                base_reply = f"Added {added_items[0]} to your {list_name}"
+                base_reply = f"Added {added_items[0]} to {display}"
             else:
-                base_reply = f"Added {len(added_items)} items to your {list_name}: {', '.join(added_items)}"
-
-            # Add progressive counter
-            reply_msg = add_list_item_counter_to_message(phone_number, list_id, base_reply)
+                base_reply = f"Added {len(added_items)} items to {display}: {', '.join(added_items)}"
+            reply_msg = base_reply if is_shared else add_list_item_counter_to_message(phone_number, list_id, base_reply)
 
         log_interaction(phone_number, incoming_msg, f"Added {len(added_items)} items to {list_name}", "add_to_list", True)
         return (True, reply_msg)
     else:
-        return (True, f"Please reply with a number between 1 and {len(lists)}")
+        return (True, f"Please reply with a number between 1 and {len(all_lists)}")
 
 
 def handle_pending_reminder_confirmation(

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -14,7 +14,7 @@ from config import OPENAI_API_KEY, OPENAI_MODEL, OPENAI_TEMPERATURE, OPENAI_MAX_
 from models.memory import get_memories
 from models.reminder import get_user_reminders
 from models.user import get_user_timezone, get_user_first_name
-from models.list_model import get_lists, get_list_items
+from models.list_model import get_lists, get_list_items, get_shared_lists_for_user
 from utils.timezone import get_user_current_time
 from database import log_api_usage
 
@@ -124,11 +124,14 @@ def process_with_ai(message: str, phone_number: str, context: dict[str, Any]) ->
         else:
             reminders_context = "No reminders set."
 
-        # Get and format lists
-        lists = get_lists(phone_number)
-        if lists:
+        # Get and format lists (owned + accepted shared)
+        owned = [(lid, name, count, False) for (lid, name, count, _done) in get_lists(phone_number)]
+        shared = [(lid, name, count, True) for (lid, name, count, _done, _owner) in get_shared_lists_for_user(phone_number)]
+        all_lists = owned + shared
+        if all_lists:
             formatted_lists = []
-            for list_id, list_name, item_count, completed_count in lists:
+            for list_id, list_name, item_count, is_shared in all_lists:
+                prefix = "[Shared] " if is_shared else ""
                 items = get_list_items(list_id)
                 if items:
                     item_texts = []
@@ -137,9 +140,9 @@ def process_with_ai(message: str, phone_number: str, context: dict[str, Any]) ->
                             item_texts.append(f"  [x] {item_text}")
                         else:
                             item_texts.append(f"  [ ] {item_text}")
-                    formatted_lists.append(f"- {list_name} ({item_count} items):\n" + "\n".join(item_texts))
+                    formatted_lists.append(f"- {prefix}{list_name} ({item_count} items):\n" + "\n".join(item_texts))
                 else:
-                    formatted_lists.append(f"- {list_name} (empty)")
+                    formatted_lists.append(f"- {prefix}{list_name} (empty)")
             lists_context = "\n".join(formatted_lists)
         else:
             lists_context = "No lists created yet."
@@ -175,6 +178,8 @@ USER'S REMINDERS:
 
 USER'S LISTS:
 {lists_context}
+
+Lists prefixed with [Shared] are shared lists the user has accepted from someone else. The user CAN: view, add items, remove items, check/uncheck items. The user CANNOT: delete the list, rename the list, or re-share it — only the list's owner can. When the user names a list in a message, match against all lists above (owned and shared).
 
 IMPORTANT: Each memory shows when it was recorded. Use these dates when answering questions about "when did I..."
 

--- a/tests/test_shared_lists.py
+++ b/tests/test_shared_lists.py
@@ -779,3 +779,167 @@ class TestNonUserInvitationFlow:
         result = await simulator.send_message(PHONE_NEW, "No")
         # Should enter onboarding, not get a decline message
         assert "welcome" in result["output"].lower() or "name" in result["output"].lower()
+
+
+# =====================================================
+# REGRESSION: Non-owner edit paths on shared lists
+# See GitHub issue / Heather's bug report 2026-04-18:
+# shared list recipient tried to add item, got disambiguation menu
+# that didn't include the shared list.
+# =====================================================
+
+
+@pytest.fixture
+def accepted_share(premium_owner, free_user, owner_list):
+    """Share owner_list with free_user and auto-accept."""
+    from models.list_model import share_list, accept_share
+    share_list(PHONE_OWNER, owner_list["list_id"], PHONE_SHARED)
+    accept_share(PHONE_SHARED, owner_list["list_id"])
+    return owner_list
+
+
+class TestSharedListEditPaths:
+    """Non-owner operations on an accepted shared list must work end-to-end."""
+
+    def test_add_to_list_adds_item_to_shared_list(self, accepted_share):
+        from routes.handlers.lists import handle_add_to_list
+        from models.list_model import get_list_items
+
+        with patch('routes.handlers.lists.log_interaction'):
+            reply = handle_add_to_list(
+                phone_number=PHONE_SHARED,
+                incoming_msg="Add cheese to the Grocery List",
+                ai_response={"list_name": "Grocery List", "item_text": "cheese"},
+            )
+
+        assert "cheese" in reply.lower()
+        assert "shared" in reply.lower()  # UI tells recipient it's a shared list
+        items = [i[1] for i in get_list_items(accepted_share["list_id"])]
+        assert "cheese" in items
+
+    def test_add_to_list_does_not_create_duplicate_for_non_owner(self, accepted_share):
+        """Non-owner adding to a shared list must not silently auto-create a personal duplicate."""
+        from routes.handlers.lists import handle_add_to_list
+        from models.list_model import get_lists
+
+        before = {l[1] for l in get_lists(PHONE_SHARED)}
+        with patch('routes.handlers.lists.log_interaction'):
+            handle_add_to_list(
+                phone_number=PHONE_SHARED,
+                incoming_msg="Add cheese to Grocery List",
+                ai_response={"list_name": "Grocery List", "item_text": "cheese"},
+            )
+        after = {l[1] for l in get_lists(PHONE_SHARED)}
+        assert after == before, "Shared-list add created a phantom personal list for the non-owner"
+
+    def test_show_list_displays_shared(self, accepted_share):
+        from routes.handlers.lists import handle_show_list
+
+        with patch('routes.handlers.lists.log_interaction'):
+            reply = handle_show_list(
+                phone_number=PHONE_SHARED,
+                incoming_msg="Show Grocery List",
+                ai_response={"list_name": "Grocery List"},
+            )
+        assert "[Shared]" in reply
+        assert "Milk" in reply
+        assert "Eggs" in reply
+
+    def test_add_item_ask_list_includes_shared_in_menu(self, accepted_share):
+        """The Heather-bug regression: disambiguation menu must include accessible shared lists."""
+        from routes.handlers.lists import handle_add_item_ask_list, create_list
+
+        # Give the recipient a couple of personal lists too so we get the menu branch
+        create_list(PHONE_SHARED, "honey do list")
+        create_list(PHONE_SHARED, "birthday list")
+
+        with patch('routes.handlers.lists.log_interaction'):
+            reply = handle_add_item_ask_list(
+                phone_number=PHONE_SHARED,
+                incoming_msg="Add cheese",
+                ai_response={"item_text": "cheese"},
+            )
+        assert "Which list" in reply
+        assert "[Shared] Grocery List" in reply, (
+            f"Disambiguation menu missing shared list. Got: {reply}"
+        )
+
+    def test_complete_item_on_shared_list(self, accepted_share):
+        from routes.handlers.lists import handle_complete_item
+        from models.list_model import get_list_items
+
+        with patch('routes.handlers.lists.log_interaction'):
+            reply = handle_complete_item(
+                phone_number=PHONE_SHARED,
+                incoming_msg="Check off Milk on Grocery List",
+                ai_response={"list_name": "Grocery List", "item_text": "Milk"},
+            )
+        assert "milk" in reply.lower()
+        completed = [i for i in get_list_items(accepted_share["list_id"]) if i[2]]
+        assert any("milk" in item[1].lower() for item in completed)
+
+    def test_non_owner_cannot_delete_shared_list(self, accepted_share):
+        from routes.handlers.lists import handle_delete_list
+        from models.list_model import get_list_by_name
+
+        with patch('routes.handlers.lists.log_interaction'):
+            reply = handle_delete_list(
+                phone_number=PHONE_SHARED,
+                incoming_msg="Delete Grocery List",
+                ai_response={"list_name": "Grocery List"},
+            )
+        assert "owner" in reply.lower()
+        # List still exists on the owner's side
+        assert get_list_by_name(PHONE_OWNER, "Grocery List") is not None
+
+    def test_non_owner_cannot_rename_shared_list(self, accepted_share):
+        from routes.handlers.lists import handle_rename_list
+        from models.list_model import get_list_by_name
+
+        with patch('routes.handlers.lists.log_interaction'):
+            reply = handle_rename_list(
+                phone_number=PHONE_SHARED,
+                incoming_msg="Rename Grocery List to Food",
+                ai_response={"old_name": "Grocery List", "new_name": "Food"},
+            )
+        assert "owner" in reply.lower()
+        assert get_list_by_name(PHONE_OWNER, "Grocery List") is not None
+
+    def test_non_owner_cannot_clear_shared_list(self, accepted_share):
+        from routes.handlers.lists import handle_clear_list
+        from models.list_model import get_list_items
+
+        with patch('routes.handlers.lists.log_interaction'):
+            reply = handle_clear_list(
+                phone_number=PHONE_SHARED,
+                incoming_msg="Clear Grocery List",
+                ai_response={"list_name": "Grocery List"},
+            )
+        assert "owner" in reply.lower()
+        # Items still there
+        assert len(get_list_items(accepted_share["list_id"])) == 2
+
+    def test_ai_context_includes_shared_lists(self, accepted_share):
+        """AI prompt must include shared lists so the model can route messages to them."""
+        from services.ai_service import process_with_ai
+
+        # Capture the prompt passed to OpenAI without actually calling it
+        captured = {}
+
+        class _FakeResp:
+            def __init__(self):
+                self.choices = [type('C', (), {'message': type('M', (), {'content': '{"action":"help","response":"ok"}'})()})()]
+                self.usage = type('U', (), {'prompt_tokens': 1, 'completion_tokens': 1, 'total_tokens': 2})()
+
+        def fake_create(**kwargs):
+            captured['messages'] = kwargs.get('messages', [])
+            return _FakeResp()
+
+        with patch('services.ai_service.OpenAI') as mock_openai:
+            mock_openai.return_value.chat.completions.create = fake_create
+            process_with_ai("hi", PHONE_SHARED, {})
+
+        system_prompt = next((m['content'] for m in captured.get('messages', []) if m['role'] == 'system'), "")
+        assert "[Shared] Grocery List" in system_prompt, (
+            f"AI system prompt missing shared list context. Got:\n{system_prompt[:800]}"
+        )


### PR DESCRIPTION
## Summary
Fixes the Heather regression: after accepting a share, the recipient said \"Add cheese to the Sam's list\" and got a disambiguation menu offering only her own 3 personal lists — the shared list wasn't in the menu at all. Root cause was that Phase 1 shipped the *sharing* flow but several read/edit sites still resolved lists through owned-only helpers (\`get_list_by_name\`, \`get_lists\`).

## Changes
- **\`services/ai_service.py\`** — AI's \`USER'S LISTS\` context now includes accepted shared lists with a \`[Shared]\` prefix, plus a prompt rule describing what recipients can/can't do.
- **\`routes/handlers/lists.py\`** — \`handle_add_to_list\`, \`handle_show_list\`, \`handle_show_current_list\`, \`_show_all_lists_or_single\`, \`handle_show_all_lists\`, \`handle_add_item_ask_list\`, \`handle_complete_item\`, \`handle_uncomplete_item\`, \`handle_delete_item\` now resolve lists via \`get_accessible_list_by_name\` / \`get_all_lists_with_shared\`. Tier limits on shared lists follow the list owner's tier. Owner-only operations (\`delete_list\`, \`clear_list\`, \`rename_list\`) explicitly reject non-owners with an \"only the owner\" message.
- **\`routes/handlers/pending_states.py\`** — delete-item confirmation and add-item numbered selection both resolve across owned + shared lists.
- **\`main.py\`** — the \"reply with a number to view\" flow after \"My Lists\" now accepts shared-list indices.
- **\`tests/test_shared_lists.py\`** — 9 new regression tests for the Heather scenario.

## Test plan
- [x] \`python -m pytest tests/test_shared_lists.py\` — 58/58 pass (49 existing + 9 new)
- [x] \`python run_tests.py --quick\` — 246 pass, 2 pre-existing context-switching failures that also exist on \`main\` (unrelated)
- [ ] Post-merge: redo Heather's test from two phones — recipient adds item, checks off item, tries to delete the list (should be blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)