### PR TITLE
Fix shared-list add_to_list crash (main.py inline dispatch)

### DIFF
--- a/main.py
+++ b/main.py
@@ -5160,14 +5160,18 @@ def process_single_action(ai_response, phone_number, incoming_msg):
             if not list_name:
                 item_valid_check, item_result_check = validate_item_text(item_text)
                 if item_valid_check:
-                    lists = get_lists(phone_number)
-                    if len(lists) == 1:
+                    from routes.handlers.lists import get_all_lists_with_shared
+                    all_lists = get_all_lists_with_shared(phone_number)
+                    if len(all_lists) == 1:
                         # Only one list, use it directly
-                        list_name = lists[0][1]
-                    elif len(lists) > 1:
-                        # Multiple lists, ask which one
+                        list_name = all_lists[0]['list_name']
+                    elif len(all_lists) > 1:
+                        # Multiple lists, ask which one — include shared in the menu
                         create_or_update_user(phone_number, pending_list_item=item_result_check, pending_delete=False)
-                        list_options = "\n".join([f"{i+1}. {l[1]}" for i, l in enumerate(lists)])
+                        list_options = "\n".join(
+                            f"{i+1}. {'[Shared] ' if l['is_shared'] else ''}{l['list_name']}"
+                            for i, l in enumerate(all_lists)
+                        )
                         reply_text = f"Which list would you like to add these to?\n\n{list_options}\n\nReply with a number:"
                         log_interaction(phone_number, incoming_msg, reply_text, "add_to_list", True)
                         list_selection_handled = True
@@ -5234,8 +5238,11 @@ def process_single_action(ai_response, phone_number, incoming_msg):
 
                         log_interaction(phone_number, incoming_msg, reply_text, "add_to_shared_list", True)
 
-                # Auto-create list if it doesn't exist (and not a shared list)
-                if not list_info and not shared_list_match:
+                # Three paths: shared list already handled, auto-create, or owned add
+                if shared_list_match:
+                    # Already handled in the shared-list branch above; skip the owned/auto-create logic
+                    pass
+                elif not list_info:
                     from services.tier_service import (
                         can_create_list, get_tier_limits, get_user_tier,
                         format_list_limit_message, format_list_item_limit_message,
@@ -5324,63 +5331,72 @@ def process_single_action(ai_response, phone_number, incoming_msg):
 
         elif ai_response["action"] == "add_item_ask_list":
             item_text = ai_response.get("item_text")
-            lists = get_lists(phone_number)
-            if len(lists) == 1:
-                # Only one list, add directly with multi-item parsing
-                list_id = lists[0][0]
-                list_name = lists[0][1]
+            from routes.handlers.lists import get_all_lists_with_shared
+            all_lists = get_all_lists_with_shared(phone_number)
+            if len(all_lists) == 1:
+                # Only one list total (owned or shared) — add directly
+                only = all_lists[0]
+                list_id = only['list_id']
+                list_name = only['list_name']
+                is_shared = only['is_shared']
+                owner_phone = only['owner_phone']
 
                 # Parse multiple items
                 items_to_add = parse_list_items(item_text, phone_number)
 
-                # Check tier limit for items per list
                 from services.tier_service import (
                     can_add_list_item, get_tier_limits, get_user_tier,
                     format_list_item_limit_message, add_list_item_counter_to_message
                 )
-                allowed, limit_msg = can_add_list_item(phone_number, list_id)
+                if is_shared:
+                    read_only, _ = is_shared_list_read_only(list_id)
+                    if read_only:
+                        reply_text = f"The shared list '{list_name}' is currently read-only because the owner's Premium plan has expired."
+                        log_interaction(phone_number, incoming_msg, reply_text, "add_item_ask_list", False)
+                        resp = MessagingResponse()
+                        resp.message(staging_prefix(reply_text))
+                        return Response(content=str(resp), media_type="application/xml")
+
+                # Tier limits follow the list owner for shared lists
+                limit_phone = owner_phone if is_shared else phone_number
+                allowed, _ = can_add_list_item(limit_phone, list_id)
                 if not allowed:
-                    # List is full - use Level 4 formatter
                     reply_text = format_list_item_limit_message(
-                        phone_number, list_name, items_to_add, 0
+                        limit_phone, list_name, items_to_add, 0
                     )
                 else:
-                    tier_limits = get_tier_limits(get_user_tier(phone_number))
+                    tier_limits = get_tier_limits(get_user_tier(limit_phone))
                     max_items = tier_limits['max_items_per_list']
                     item_count = get_item_count(list_id)
                     available_slots = max_items - item_count
 
-                    # Add items up to the limit
                     added_items = []
                     for item in items_to_add:
                         if len(added_items) < available_slots:
                             add_list_item(list_id, phone_number, item)
                             added_items.append(item)
 
-                    # Track last active list
                     create_or_update_user(phone_number, last_active_list=list_name)
 
-                    # Handle partial or full adds with progressive education
                     if len(added_items) < len(items_to_add):
-                        # Some items skipped - use Level 4 formatter
                         reply_text = format_list_item_limit_message(
-                            phone_number, list_name, items_to_add, len(added_items)
+                            limit_phone, list_name, items_to_add, len(added_items)
                         )
                     else:
-                        # All items added successfully
+                        display = f"shared list '{list_name}'" if is_shared else f"your {list_name}"
                         if len(added_items) == 1:
-                            base_reply = f"Added {added_items[0]} to your {list_name}"
+                            base_reply = f"Added {added_items[0]} to {display}"
                         else:
-                            base_reply = f"Added {len(added_items)} items to your {list_name}: {', '.join(added_items)}"
+                            base_reply = f"Added {len(added_items)} items to {display}: {', '.join(added_items)}"
+                        reply_text = base_reply if is_shared else add_list_item_counter_to_message(phone_number, list_id, base_reply)
 
-                        # Add progressive counter
-                        reply_text = add_list_item_counter_to_message(phone_number, list_id, base_reply)
-
-            elif len(lists) > 1:
-                # Multiple lists, ask which one (store original text for parsing later)
-                # Clear pending_delete flag to avoid blocking the list selection handler
+            elif len(all_lists) > 1:
+                # Multiple lists, ask which one — include shared lists in the menu
                 create_or_update_user(phone_number, pending_list_item=item_text, pending_delete=False)
-                list_options = "\n".join([f"{i+1}. {l[1]}" for i, l in enumerate(lists)])
+                list_options = "\n".join(
+                    f"{i+1}. {'[Shared] ' if l['is_shared'] else ''}{l['list_name']}"
+                    for i, l in enumerate(all_lists)
+                )
                 reply_text = f"Which list would you like to add these to?\n\n{list_options}\n\nReply with a number:"
             else:
                 reply_text = "You don't have any lists yet. Try 'Create a grocery list' first!"

--- a/tests/test_shared_lists.py
+++ b/tests/test_shared_lists.py
@@ -919,6 +919,24 @@ class TestSharedListEditPaths:
         # Items still there
         assert len(get_list_items(accepted_share["list_id"])) == 2
 
+    @pytest.mark.asyncio
+    async def test_end_to_end_add_to_shared_list_via_sms(self, accepted_share, simulator, ai_mock):
+        """End-to-end via the SMS webhook — catches inline-dispatch bugs in main.py.
+
+        Regression guard for a crash where main.py's add_to_list inline logic fell into
+        an else branch that indexed list_info[0] while list_info was None (shared-list
+        match had been stored in a separate variable).
+        """
+        ai_mock.set_response("add cheese to grocery list", {
+            "action": "add_to_list",
+            "list_name": "Grocery List",
+            "item_text": "cheese",
+        })
+        result = await simulator.send_message(PHONE_SHARED, "Add cheese to Grocery List")
+        out = result["output"].lower()
+        assert "something went wrong" not in out, f"Handler crashed: {result['output']}"
+        assert "cheese" in out, f"Item not added: {result['output']}"
+
     def test_ai_context_includes_shared_lists(self, accepted_share):
         """AI prompt must include shared lists so the model can route messages to them."""
         from services.ai_service import process_with_ai


### PR DESCRIPTION
## Summary
Heather reported \`\"Hmm, something went wrong...\"\` when adding an item to a shared list. Root cause: \`main.py\` has a parallel inline implementation of \`add_to_list\` (at line 5135) that PR #242's handler fixes didn't reach. That inline code had a latent structural bug — when a shared list matched, it fell into an \`else\` branch and indexed \`list_info[0]\` while \`list_info\` was \`None\`, raising \`TypeError\`.

Also fixes the inline \`add_item_ask_list\` path (and the no-list-name selection branch) to include shared lists in disambiguation menus.

## Test plan
- [x] New end-to-end SMS integration test via \`ConversationSimulator\` — catches inline-dispatch bugs the handler unit tests miss
- [x] \`pytest tests/test_shared_lists.py\` — 59/59 pass
- [ ] Post-merge: Heather retries \"Add cheese to Sam's list\" — expect \"Added cheese to shared list 'Sam's list'\"

## Followup
The routes/handlers/lists.py handlers aren't actually wired into main.py's dispatch — it uses inline code instead. Worth consolidating in a future pass so the audit pattern is one-to-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)