### PR TITLE
Fix Delete/Check N by number for shared lists

### DIFF
--- a/main.py
+++ b/main.py
@@ -2592,29 +2592,38 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             # UX PRIORITY: If user is viewing a specific list, ONLY delete from that list
             # Don't show options from reminders/memories - that's confusing
             if last_active and last_active not in ("__RECURRING__", "__REMINDERS__", "__LISTS__", "__MEMORIES__"):
-                # User is viewing a specific list - delete directly from it
-                list_info = get_list_by_name(phone_number, last_active)
-                if list_info:
-                    list_id = list_info[0]
-                    list_name = list_info[1]
+                # User is viewing a specific list (owned or shared) - delete directly from it
+                accessible = get_accessible_list_by_name(phone_number, last_active)
+                if accessible:
+                    list_id, list_name, is_shared, _owner_phone = accessible
+                    if is_shared:
+                        read_only, _ = is_shared_list_read_only(list_id)
+                        if read_only:
+                            resp = MessagingResponse()
+                            resp.message(f"The shared list '{list_name}' is currently read-only because the owner's Premium plan has expired.")
+                            return Response(content=str(resp), media_type="application/xml")
                     items = get_list_items(list_id)
                     if items and 1 <= item_num <= len(items):
                         item_id, item_text, _ = items[item_num - 1]
-                        # Single item from active list - ask for confirmation
+                        # Single item from active list - ask for confirmation.
+                        # Include list_id + is_shared so the YES handler dispatches to the right list.
                         confirm_data = json.dumps({
                             'awaiting_confirmation': True,
                             'type': 'list_item',
                             'list_name': list_name,
-                            'text': item_text
+                            'list_id': list_id,
+                            'is_shared': is_shared,
+                            'text': item_text,
                         })
                         create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
+                        display = f"shared list '{list_name}'" if is_shared else list_name
                         resp = MessagingResponse()
-                        resp.message(f"Remove '{item_text}' from {list_name}?\n\nReply YES to confirm or CANCEL to keep it.")
+                        resp.message(f"Remove '{item_text}' from {display}?\n\nReply YES to confirm or CANCEL to keep it.")
                         log_interaction(phone_number, incoming_msg, "Delete from active list", "delete_list_item_confirm", True)
                         return Response(content=str(resp), media_type="application/xml")
                     else:
                         resp = MessagingResponse()
-                        resp.message(f"Your {list_name} doesn't have an item #{item_num}.")
+                        resp.message(f"{list_name} doesn't have an item #{item_num}.")
                         return Response(content=str(resp), media_type="application/xml")
 
             # No active list context - show options from all types
@@ -2635,19 +2644,24 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                     'display': f"Reminder: {display_prefix}{reminder[2][:40]}"
                 })
 
-            # Check all lists for items at this position
-            all_lists = get_lists(phone_number)
+            # Check all lists (owned + accepted shared) for items at this position
+            from routes.handlers.lists import get_all_lists_with_shared
+            all_lists = get_all_lists_with_shared(phone_number)
             for lst in all_lists:
-                list_id = lst[0]
-                list_name = lst[1]
+                list_id = lst['list_id']
+                list_name = lst['list_name']
+                is_shared = lst['is_shared']
                 items = get_list_items(list_id)
                 if items and 1 <= item_num <= len(items):
                     item_id, item_text, _ = items[item_num - 1]
+                    display_list = f"shared list '{list_name}'" if is_shared else list_name
                     delete_options.append({
                         'type': 'list_item',
                         'list_name': list_name,
+                        'list_id': list_id,
+                        'is_shared': is_shared,
                         'text': item_text,
-                        'display': f"'{item_text}' from {list_name}"
+                        'display': f"'{item_text}' from {display_list}",
                     })
 
             # Check for memory at this position
@@ -2695,15 +2709,21 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
         if check_match:
             item_num = int(check_match.group(1))
             last_active = get_last_active_list(phone_number)
-            if last_active:
-                list_info = get_list_by_name(phone_number, last_active)
-                if list_info:
-                    list_id = list_info[0]
-                    list_name = list_info[1]
+            if last_active and last_active not in ("__RECURRING__", "__REMINDERS__", "__LISTS__", "__MEMORIES__"):
+                accessible = get_accessible_list_by_name(phone_number, last_active)
+                if accessible:
+                    list_id, list_name, is_shared, _owner_phone = accessible
+                    if is_shared:
+                        read_only, _ = is_shared_list_read_only(list_id)
+                        if read_only:
+                            resp = MessagingResponse()
+                            resp.message(f"The shared list '{list_name}' is currently read-only because the owner's Premium plan has expired.")
+                            return Response(content=str(resp), media_type="application/xml")
                     items = get_list_items(list_id)
                     if items and 1 <= item_num <= len(items):
                         item_id, item_text, _ = items[item_num - 1]
-                        if mark_item_complete(phone_number, list_name, item_text):
+                        from models.list_model import mark_item_complete_by_list_id
+                        if mark_item_complete_by_list_id(list_id, item_text):
                             reply_msg = f"Checked off '{item_text}'"
                         else:
                             reply_msg = f"Couldn't check off item #{item_num}"
@@ -2713,7 +2733,7 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                         return Response(content=str(resp), media_type="application/xml")
                     else:
                         resp = MessagingResponse()
-                        resp.message(f"Item #{item_num} not found. Your {list_name} has {len(items)} items.")
+                        resp.message(f"Item #{item_num} not found. {list_name} has {len(items)} items.")
                         return Response(content=str(resp), media_type="application/xml")
 
         # ==========================================

--- a/routes/handlers/pending_states.py
+++ b/routes/handlers/pending_states.py
@@ -134,7 +134,16 @@ def handle_pending_delete(
                         reply_msg = "Couldn't delete that reminder."
 
                 elif delete_type == 'list_item':
-                    if delete_list_item(phone_number, selected['list_name'], selected['text']):
+                    list_id = selected.get('list_id')
+                    is_shared = selected.get('is_shared', False)
+                    if list_id is not None:
+                        from models.list_model import delete_list_item_by_list_id
+                        if delete_list_item_by_list_id(list_id, selected['text']):
+                            display = f"shared list '{selected['list_name']}'" if is_shared else selected['list_name']
+                            reply_msg = f"Removed '{selected['text']}' from {display}"
+                        else:
+                            reply_msg = "Couldn't delete that list item."
+                    elif delete_list_item(phone_number, selected['list_name'], selected['text']):
                         reply_msg = f"Removed '{selected['text']}' from {selected['list_name']}"
                     else:
                         reply_msg = "Couldn't delete that list item."

--- a/tests/test_shared_lists.py
+++ b/tests/test_shared_lists.py
@@ -920,6 +920,42 @@ class TestSharedListEditPaths:
         assert len(get_list_items(accepted_share["list_id"])) == 2
 
     @pytest.mark.asyncio
+    async def test_show_then_delete_by_number_targets_shared_list(self, accepted_share, simulator, ai_mock):
+        """After 'Show <shared>', 'Delete N' should target the shared list, not fall back to
+        a cross-type disambiguation menu. Regression for Heather's screenshot bug."""
+        ai_mock.set_response("show grocery list", {
+            "action": "show_list",
+            "list_name": "Grocery List",
+        })
+        await simulator.send_message(PHONE_SHARED, "Show Grocery List")
+
+        result = await simulator.send_message(PHONE_SHARED, "Delete 1")
+        out = result["output"].lower()
+        assert "what would you like to delete" not in out, (
+            f"Delete-by-number lost shared-list context. Got: {result['output']}"
+        )
+        # Should ask for YES/CANCEL confirmation targeted at the shared list
+        assert "milk" in out and ("yes" in out or "remove" in out), (
+            f"Expected confirmation prompt for Milk from shared list. Got: {result['output']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_check_by_number_targets_shared_list(self, accepted_share, simulator, ai_mock):
+        """After 'Show <shared>', 'Check 1' should check off item on the shared list."""
+        from models.list_model import get_list_items
+        ai_mock.set_response("show grocery list", {
+            "action": "show_list",
+            "list_name": "Grocery List",
+        })
+        await simulator.send_message(PHONE_SHARED, "Show Grocery List")
+
+        result = await simulator.send_message(PHONE_SHARED, "Check 1")
+        out = result["output"].lower()
+        assert "checked off" in out, f"Check-by-number failed on shared list. Got: {result['output']}"
+        completed = [i for i in get_list_items(accepted_share["list_id"]) if i[2]]
+        assert any("milk" in item[1].lower() for item in completed)
+
+    @pytest.mark.asyncio
     async def test_end_to_end_add_to_shared_list_via_sms(self, accepted_share, simulator, ai_mock):
         """End-to-end via the SMS webhook — catches inline-dispatch bugs in main.py.
 


### PR DESCRIPTION
## Summary
Heather's screenshot: \`Show Sam's list\` then \`Delete 4\` fell through to a cross-type disambiguation menu (showing her honey-do-list items) instead of targeting the shared list she was looking at.

Root cause: \`last_active_list\` was correctly set to \"Sam's list\" by the show handler, but the delete-by-number logic at \`main.py:2596\` (and the sibling check-by-number at :2713) looked it up with \`get_list_by_name\` (owned-only). Non-owner -> no match -> fallback menu. Same pattern as the prior fixes.

## Changes
- **\`main.py\`** delete-by-number: \`get_accessible_list_by_name\` + \`list_id\`/\`is_shared\` in the pending confirm payload. Fallback menu iterates \`get_all_lists_with_shared\`.
- **\`main.py\`** check-by-number: mirrors the same shared-list lookup + read-only guard + \`mark_item_complete_by_list_id\`.
- **\`routes/handlers/pending_states.py\`**: number-selected deletion uses \`delete_list_item_by_list_id\` when the option carries \`list_id\`.
- **\`tests/test_shared_lists.py\`**: 2 new integration tests via ConversationSimulator — show-then-delete-N and show-then-check-N.

## Test plan
- [x] \`pytest tests/test_shared_lists.py\` — 61/61 pass
- [ ] Post-merge: Heather redo \"Show Sam's list\" then \"Delete 4\" — expect \"Remove 'cheese' from shared list 'Sam's list'? Reply YES...\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)