### PR TITLE
Add self-serve shared lists beta opt-in for Premium users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,8 @@ Optional AES-256-GCM encryption for PII (names, emails). Enabled via `ENCRYPTION
 ### Shared Lists
 Premium-only feature allowing users to share lists with up to 4 non-premium users. Sharing is tracked in `list_shares` table with pending/accepted/declined status. Non-owners can add/remove/complete items but cannot delete, rename, or share the list. Key functions in `models/list_model.py`: `share_list()`, `accept_share()`, `get_accessible_list_by_name()`, `can_user_access_list()`. Handlers in `routes/handlers/lists.py`. Config: `SHARED_LIST_MAX_MEMBERS=4`, `SHARED_LIST_MAX_PER_USER=3`, `SHARED_LIST_MAX_RECEIVED=5`. ACCEPT/DECLINE keywords handled before AI processing. See `docs/shared-lists.md` for full scope.
 
+**Beta gating:** `can_share_list()` in `services/tier_service.py` enforces Premium tier AND (phone in `SHARED_LISTS_BETA_PHONES` env allowlist OR `users.shared_lists_beta_opt_in = TRUE`). Users self-enroll via `JOIN SHARED LISTS` keyword (Premium-only; free-tier users get an upgrade message). `LEAVE SHARED LISTS` clears the flag. Keyword handlers live in `main.py` near the smart nudge block. When the allowlist env var is empty, the gate is a no-op and any Premium user can share.
+
 ### Smart Nudges
 Proactive AI intelligence layer — sends ONE contextual insight per day. 8 nudge types, tier-gated. OFF by default. See `docs/changelog.md` for full implementation details.
 

--- a/database.py
+++ b/database.py
@@ -666,6 +666,9 @@ def init_db():
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS pending_share_name TEXT",
             # Shared lists: owner-assigned name for the person they shared with
             "ALTER TABLE list_shares ADD COLUMN IF NOT EXISTS shared_with_name TEXT",
+            # Shared lists beta: user-initiated opt-in (Premium-only feature, but any user can opt in)
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS shared_lists_beta_opt_in BOOLEAN DEFAULT FALSE",
+            "UPDATE users SET shared_lists_beta_opt_in = FALSE WHERE shared_lists_beta_opt_in IS NULL",
         ]
 
         # Create indexes on phone_hash columns for efficient lookups

--- a/main.py
+++ b/main.py
@@ -3447,6 +3447,75 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             return Response(content=str(resp), media_type="application/xml")
 
         # ==========================================
+        # SHARED LISTS BETA OPT-IN
+        # ==========================================
+
+        if msg_upper in [
+            "JOIN SHARED LISTS BETA", "JOIN SHARED LISTS", "SHARED LISTS BETA",
+            "BETA SHARED LISTS", "JOIN BETA", "JOIN SHARED LIST BETA",
+        ]:
+            from services.tier_service import get_user_tier
+            from config import TIER_PREMIUM, TIER_FAMILY, PREMIUM_MONTHLY_PRICE
+            from models.user import get_shared_lists_beta_opt_in
+
+            tier = get_user_tier(phone_number)
+            if tier not in (TIER_PREMIUM, TIER_FAMILY):
+                resp = MessagingResponse()
+                resp.message(staging_prefix(
+                    f"Shared lists are a Premium feature. Text UPGRADE to unlock them ({PREMIUM_MONTHLY_PRICE}/mo), "
+                    "then text JOIN SHARED LISTS to join the beta."
+                ))
+                log_interaction(phone_number, incoming_msg, "Shared lists beta: non-premium", "shared_lists_beta_blocked", False)
+                return Response(content=str(resp), media_type="application/xml")
+
+            if get_shared_lists_beta_opt_in(phone_number):
+                resp = MessagingResponse()
+                resp.message(staging_prefix(
+                    "You're already in the shared lists beta!\n\n"
+                    "Share a list: SHARE [list] WITH [phone]\n"
+                    "Report a bug: BUG [what happened]\n"
+                    "Send feedback: FEEDBACK [thoughts]\n\n"
+                    "Leave beta: LEAVE SHARED LISTS"
+                ))
+                log_interaction(phone_number, incoming_msg, "Already in shared lists beta", "shared_lists_beta_already", True)
+                return Response(content=str(resp), media_type="application/xml")
+
+            create_or_update_user(phone_number, shared_lists_beta_opt_in=True)
+            resp = MessagingResponse()
+            resp.message(staging_prefix(
+                "Thanks for joining the shared lists beta!\n\n"
+                "Share a list: SHARE [list] WITH [phone]\n"
+                "(e.g. SHARE groceries WITH 5551234567)\n\n"
+                "Hit a bug? Text BUG [what went wrong]\n"
+                "Got feedback? Text FEEDBACK [your thoughts]\n\n"
+                "We rely on testers like you to tell us what's broken or confusing.\n\n"
+                "Leave beta: LEAVE SHARED LISTS"
+            ))
+            log_interaction(phone_number, incoming_msg, "Joined shared lists beta", "shared_lists_beta_join", True)
+            return Response(content=str(resp), media_type="application/xml")
+
+        if msg_upper in [
+            "LEAVE SHARED LISTS BETA", "LEAVE SHARED LISTS", "LEAVE BETA",
+            "EXIT SHARED LISTS BETA", "OPT OUT SHARED LISTS",
+        ]:
+            from models.user import get_shared_lists_beta_opt_in
+
+            if not get_shared_lists_beta_opt_in(phone_number):
+                resp = MessagingResponse()
+                resp.message(staging_prefix("You're not currently in the shared lists beta."))
+                log_interaction(phone_number, incoming_msg, "Not in shared lists beta", "shared_lists_beta_leave_noop", True)
+                return Response(content=str(resp), media_type="application/xml")
+
+            create_or_update_user(phone_number, shared_lists_beta_opt_in=False)
+            resp = MessagingResponse()
+            resp.message(staging_prefix(
+                "You've left the shared lists beta. Existing shared lists still work; you just can't create new ones.\n\n"
+                "To rejoin: JOIN SHARED LISTS"
+            ))
+            log_interaction(phone_number, incoming_msg, "Left shared lists beta", "shared_lists_beta_leave", True)
+            return Response(content=str(resp), media_type="application/xml")
+
+        # ==========================================
         # TIMEZONE COMMANDS
         # ==========================================
 

--- a/models/user.py
+++ b/models/user.py
@@ -49,6 +49,7 @@ ALLOWED_USER_FIELDS = {
     'free_tier_version',
     # Shared lists
     'pending_share_name',
+    'shared_lists_beta_opt_in',
 }
 
 
@@ -1068,6 +1069,34 @@ def get_pending_nudge_response(phone_number: str) -> Optional[dict[str, Any]]:
     except Exception as e:
         logger.error(f"Error getting pending nudge response: {e}")
         return None
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def get_shared_lists_beta_opt_in(phone_number: str) -> bool:
+    """Check if user has opted into the shared lists beta."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        if ENCRYPTION_ENABLED:
+            from utils.encryption import hash_phone
+            phone_hash = hash_phone(phone_number)
+            c.execute('SELECT shared_lists_beta_opt_in FROM users WHERE phone_hash = %s', (phone_hash,))
+            result = c.fetchone()
+            if not result:
+                c.execute('SELECT shared_lists_beta_opt_in FROM users WHERE phone_number = %s', (phone_number,))
+                result = c.fetchone()
+        else:
+            c.execute('SELECT shared_lists_beta_opt_in FROM users WHERE phone_number = %s', (phone_number,))
+            result = c.fetchone()
+
+        return bool(result[0]) if result else False
+    except Exception as e:
+        logger.error(f"Error getting shared lists beta opt-in: {e}")
+        return False
     finally:
         if conn:
             return_db_connection(conn)

--- a/services/tier_service.py
+++ b/services/tier_service.py
@@ -385,10 +385,15 @@ def can_create_list(phone_number: str) -> tuple[bool, str | None]:
 
 
 def can_share_list(phone_number: str) -> tuple[bool, str | None]:
-    """Check if user can share a list (must be Premium, and in beta whitelist if set)."""
+    """Check if user can share a list (must be Premium + in beta whitelist OR opted-in)."""
     from config import SHARED_LISTS_BETA_PHONES
-    if SHARED_LISTS_BETA_PHONES and phone_number not in SHARED_LISTS_BETA_PHONES:
-        return (False, "Shared lists aren't available for your account yet. Stay tuned!")
+    from models.user import get_shared_lists_beta_opt_in
+
+    if SHARED_LISTS_BETA_PHONES:
+        allowlisted = phone_number in SHARED_LISTS_BETA_PHONES
+        opted_in = get_shared_lists_beta_opt_in(phone_number)
+        if not (allowlisted or opted_in):
+            return (False, "Shared lists are in beta. Text JOIN SHARED LISTS to opt in.")
 
     tier = get_user_tier(phone_number)
     if tier not in (TIER_PREMIUM, TIER_FAMILY):

--- a/tests/test_shared_lists.py
+++ b/tests/test_shared_lists.py
@@ -296,6 +296,102 @@ class TestShareListTierGating:
         assert "premium" in msg.lower() or "upgrade" in msg.lower()
 
 
+class TestSharedListsBetaOptIn:
+    """Tests for the shared lists beta whitelist + opt-in flag."""
+
+    def test_premium_blocked_when_whitelist_set_and_not_opted_in(self, premium_owner):
+        from services.tier_service import can_share_list
+        with patch("config.SHARED_LISTS_BETA_PHONES", ["+15550001111"]):
+            allowed, msg = can_share_list(PHONE_OWNER)
+        assert allowed is False
+        assert "beta" in msg.lower()
+
+    def test_premium_allowed_via_whitelist(self, premium_owner):
+        from services.tier_service import can_share_list
+        with patch("config.SHARED_LISTS_BETA_PHONES", [PHONE_OWNER]):
+            allowed, msg = can_share_list(PHONE_OWNER)
+        assert allowed is True
+
+    def test_premium_allowed_via_opt_in_flag(self, premium_owner):
+        from services.tier_service import can_share_list
+        from models.user import create_or_update_user
+        create_or_update_user(PHONE_OWNER, shared_lists_beta_opt_in=True)
+        with patch("config.SHARED_LISTS_BETA_PHONES", ["+15550001111"]):
+            allowed, msg = can_share_list(PHONE_OWNER)
+        assert allowed is True
+
+    def test_opt_in_does_not_bypass_premium_check(self, free_user):
+        """Free-tier user with opt-in flag still can't share (premium check runs after)."""
+        from services.tier_service import can_share_list
+        from models.user import create_or_update_user
+        create_or_update_user(PHONE_SHARED, shared_lists_beta_opt_in=True)
+        with patch("config.SHARED_LISTS_BETA_PHONES", ["+15550001111"]):
+            allowed, msg = can_share_list(PHONE_SHARED)
+        assert allowed is False
+        assert "premium" in msg.lower() or "upgrade" in msg.lower()
+
+    def test_get_shared_lists_beta_opt_in_defaults_false(self, premium_owner):
+        from models.user import get_shared_lists_beta_opt_in
+        assert get_shared_lists_beta_opt_in(PHONE_OWNER) is False
+
+    def test_get_shared_lists_beta_opt_in_reflects_flag(self, premium_owner):
+        from models.user import create_or_update_user, get_shared_lists_beta_opt_in
+        create_or_update_user(PHONE_OWNER, shared_lists_beta_opt_in=True)
+        assert get_shared_lists_beta_opt_in(PHONE_OWNER) is True
+
+
+class TestSharedListsBetaKeywordHandlers:
+    """Tests for JOIN / LEAVE SHARED LISTS keyword handlers."""
+
+    @pytest.mark.asyncio
+    async def test_premium_can_join(self, simulator, sms_capture, ai_mock, onboarded_user):
+        from models.user import create_or_update_user, get_shared_lists_beta_opt_in
+        phone = onboarded_user['phone']
+        create_or_update_user(phone, premium_status="premium")
+
+        result = await simulator.send_message(phone, "JOIN SHARED LISTS")
+        assert "beta" in result['output'].lower() or "active" in result['output'].lower()
+        assert get_shared_lists_beta_opt_in(phone) is True
+
+    @pytest.mark.asyncio
+    async def test_free_tier_blocked_from_joining(self, simulator, sms_capture, ai_mock, onboarded_user):
+        from models.user import get_shared_lists_beta_opt_in
+        phone = onboarded_user['phone']
+        # onboarded_user defaults to free tier
+
+        result = await simulator.send_message(phone, "JOIN SHARED LISTS")
+        assert "premium" in result['output'].lower() or "upgrade" in result['output'].lower()
+        assert get_shared_lists_beta_opt_in(phone) is False
+
+    @pytest.mark.asyncio
+    async def test_join_twice_is_idempotent(self, simulator, sms_capture, ai_mock, onboarded_user):
+        from models.user import create_or_update_user, get_shared_lists_beta_opt_in
+        phone = onboarded_user['phone']
+        create_or_update_user(phone, premium_status="premium")
+
+        await simulator.send_message(phone, "JOIN SHARED LISTS")
+        result = await simulator.send_message(phone, "JOIN SHARED LISTS")
+        assert "already" in result['output'].lower()
+        assert get_shared_lists_beta_opt_in(phone) is True
+
+    @pytest.mark.asyncio
+    async def test_leave_clears_opt_in(self, simulator, sms_capture, ai_mock, onboarded_user):
+        from models.user import create_or_update_user, get_shared_lists_beta_opt_in
+        phone = onboarded_user['phone']
+        create_or_update_user(phone, premium_status="premium")
+
+        await simulator.send_message(phone, "JOIN SHARED LISTS")
+        result = await simulator.send_message(phone, "LEAVE SHARED LISTS")
+        assert "left" in result['output'].lower() or "leav" in result['output'].lower()
+        assert get_shared_lists_beta_opt_in(phone) is False
+
+    @pytest.mark.asyncio
+    async def test_leave_when_not_opted_in_is_noop(self, simulator, sms_capture, ai_mock, onboarded_user):
+        phone = onboarded_user['phone']
+        result = await simulator.send_message(phone, "LEAVE SHARED LISTS")
+        assert "not" in result['output'].lower()
+
+
 # =====================================================
 # LIMIT ENFORCEMENT TESTS
 # =====================================================


### PR DESCRIPTION
## Summary
- Premium users can now self-enroll in the shared lists beta via `JOIN SHARED LISTS` (and opt out via `LEAVE SHARED LISTS`) instead of needing their phone added to the `SHARED_LISTS_BETA_PHONES` env allowlist. `can_share_list()` accepts either gate.
- New `users.shared_lists_beta_opt_in` column (default FALSE) backs the flag; env allowlist still works unchanged.
- Join confirmation reply now teaches users how to share a list and how to report a bug (`BUG`) or give feedback (`FEEDBACK`) — closes the loop on the "we never hear from beta testers" problem.

## Test plan
- [x] `pytest tests/test_shared_lists.py` — 72/72 pass (11 new tests added)
- [ ] Broadcast message advertising the beta goes out to all users (owner task, not in this PR)
- [ ] Smoke test in production: text `JOIN SHARED LISTS` from a premium number, verify opt-in flag set and confirmation reply received
- [ ] Smoke test from a free-tier number: verify premium-required response and flag NOT set
- [ ] Smoke test `LEAVE SHARED LISTS` clears the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)