### PR TITLE
Fix referral attribution for new marketing-site SMS CTA bodies

### DIFF
--- a/main.py
+++ b/main.py
@@ -894,6 +894,14 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             msg_lower = incoming_msg.lower().strip()
             referral_source = REFERRAL_MESSAGES.get(msg_lower)
 
+            # Prefix match for marketing-site CTAs that send "<keyword>! Start my Remyndrs trial →".
+            # Keeps bare "Hello"/"GO" working while tagging the longer body correctly.
+            if not referral_source:
+                if re.match(r'^hello\b', msg_lower):
+                    referral_source = "website-ios"
+                elif re.match(r'^go\b', msg_lower):
+                    referral_source = "facebook"
+
             # Fuzzy fallback: check if message contains key phrases
             if not referral_source:
                 for keyword, source, condition in REFERRAL_FUZZY:


### PR DESCRIPTION
## Summary
- Marketing site (`remyndrs.com` commit `b55f18d`) now pre-fills SMS with `"Hello! Start my Remyndrs trial →"` / `"GO! Start my Remyndrs trial →"` instead of bare `Hello` / `GO`.
- Activation itself was unaffected — `main.py:940-941` routes any first message from a non-onboarded user to `handle_onboarding`.
- However, referral source tagging at `main.py:895` used exact-match `REFERRAL_MESSAGES.get(msg_lower)`, so the new longer bodies fell through to `sms-organic`, silently under-counting `website-ios` and `facebook` channels in product metrics.
- Added a prefix/word-boundary check between the exact-match and fuzzy fallback so both the bare keyword and the longer body tag correctly. `\b` prevents false matches like "goldfish" or "hellokitty".

## Test plan
- [x] `Hello` / `GO` (bare) still tag as `website-ios` / `facebook` via existing exact-match path
- [x] `Hello! Start my Remyndrs trial →` tags as `website-ios` via new prefix match
- [x] `GO! Start my Remyndrs trial →` tags as `facebook` via new prefix match
- [x] Case-insensitive (`msg_lower` already lowercased at line 894)
- [x] Whitespace / CR-LF handled by existing `.strip()`
- [x] `→` (U+2192) unicode-safe
- [x] `Goldfish crackers` rejected by `\b` (next char `l` is a word char)
- [x] Existing onboarded users unaffected (guarded by `is_user_onboarded`)
- [x] `python -c "import ast; ast.parse(...)"` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)