### PR TITLE
Disclose upcoming tip series in onboarding completion message

### DIFF
--- a/services/onboarding_service.py
+++ b/services/onboarding_service.py
@@ -321,13 +321,17 @@ Last question: ZIP code?
                     shared_note += f"\n(Plus {len(accepted_lists) - 1} more shared list{'s' if len(accepted_lists) > 2 else ''}!)"
                 resp.message(f"""You're all set, {first_name}! 🎉
 
-You have full Premium access until {trial_end_str} — unlimited reminders, lists & memories. After that, the core service is free forever — no credit card ever needed.{shared_note}""")
+You have full Premium access until {trial_end_str} — unlimited reminders, lists & memories. After that, the core service is free forever — no credit card ever needed.{shared_note}
+
+Keep an eye out for a quick morning tip over the next week or so — I'll show you what else I can do.""")
             else:
                 resp.message(f"""Perfect! You're all set, {first_name}! 🎉
 
 You have full Premium access until {trial_end_str} — unlimited reminders, lists & memories. After that, the core service is free forever — no credit card ever needed.
 
 I just saved your first memory: "{first_memory}"
+
+Keep an eye out for a quick morning tip over the next week or so — I'll show you what else I can do.
 
 Try asking me: "What do I have saved?" """)
 


### PR DESCRIPTION
## Summary
- Adds a single vague, warm line to the end of the onboarding completion message: *"Keep an eye out for a quick morning tip over the next week or so — I'll show you what else I can do."*
- Sets expectations that new users will receive a short daily education series (Day 1, Day 2, Day 3 nudges, and any future ones on lists / memories / shared lists) so those messages read as a welcome curriculum rather than unsolicited SMS.
- Vague timeframe (\"week or so\") lets us grow the series without revising onboarding copy.
- Applied to both completion-message branches: shared-list signup and solo signup.

## Test plan
- [ ] Complete a fresh onboarding on the test line and confirm the new line appears in the completion message.
- [ ] Complete a shared-list-invite onboarding and confirm the new line appears after the shared-list note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)