### PR TITLE
Fix admin dashboard delete button for recurring reminders

### DIFF
--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -8311,7 +8311,7 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
                     <td style="font-size: 0.85em;">${{nextStr}}</td>
                     <td>
                         ${{toggleBtn}}
-                        <button class="btn btn-danger" style="padding: 4px 8px; font-size: 0.8em;" onclick="deleteRecurring(${{r.id}}, '${{r.text.replace(/'/g, "\\'").substring(0, 30)}}')">Delete</button>
+                        <button class="btn btn-danger" style="padding: 4px 8px; font-size: 0.8em;" onclick="deleteRecurring(${{r.id}})">Delete</button>
                     </td>
                 `;
             }}
@@ -8347,8 +8347,10 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
             }}
         }}
 
-        async function deleteRecurring(id, text) {{
-            if (!confirm(`Delete recurring reminder "${{text}}"? This cannot be undone.`)) return;
+        async function deleteRecurring(id) {{
+            const recurring = allRecurring.find(r => r.id === id);
+            const preview = recurring ? recurring.text.substring(0, 30) : '';
+            if (!confirm(`Delete recurring reminder "${{preview}}"? This cannot be undone.`)) return;
             try {{
                 const response = await fetch(`/admin/recurring/${{id}}`, {{ method: 'DELETE' }});
                 const data = await response.json();


### PR DESCRIPTION
## Summary
- The Delete button in the admin dashboard's Recurring Reminders section threw `Uncaught SyntaxError: missing ) after argument list` and did nothing when clicked.
- Root cause: the inline `onclick` attempted to escape the reminder text into an HTML-attribute-embedded JS string using `replace(/'/g, "\'").substring(0, 30)`. If the 30-char truncation cut right after the injected `\`, the closing quote got escaped and the JS parse failed.
- Fix: pass only the id to `deleteRecurring(id)` and look the text up from the already-loaded `allRecurring` array for the confirm dialog. No inline escaping of user-controlled strings.

## Test plan
- [ ] Load `/admin` dashboard, scroll to Recurring Reminders section
- [ ] Click Delete on any recurring reminder → confirm dialog appears with the text preview
- [ ] Confirm → row deletes, table refreshes
- [ ] Cancel → no action
- [ ] Verify with a reminder whose text contains an apostrophe

🤖 Generated with [Claude Code](https://claude.com/claude-code)