### PR TITLE
Cascade-delete recurring parent in AI delete_reminder handler

### DIFF
--- a/routes/handlers/reminders.py
+++ b/routes/handlers/reminders.py
@@ -14,7 +14,7 @@ from models.user import create_or_update_user, get_user_timezone
 from models.reminder import (
     save_reminder, save_reminder_with_local_time, get_user_reminders,
     save_recurring_reminder, delete_reminder as db_delete_reminder,
-    search_pending_reminders, update_reminder_time
+    delete_recurring_reminder, search_pending_reminders, update_reminder_time
 )
 from utils.timezone import get_user_current_time
 from utils.validation import detect_sensitive_data, get_sensitive_data_warning
@@ -425,18 +425,26 @@ def handle_delete_reminder(
         reminders = get_user_reminders(phone_number)
         reminder_match = next((r for r in reminders if r[0] == reminder_id), None)
         if reminder_match:
+            text = reminder_match[2]
+            recurring_id = reminder_match[3]
             db_delete_reminder(phone_number, reminder_id)
-            reply_text = f"Deleted reminder: {reminder_match[1]}"
+            reply_text = f"Deleted reminder: {text}"
+            if recurring_id and delete_recurring_reminder(recurring_id, phone_number):
+                reply_text += " (and its recurring schedule)"
         else:
             reply_text = "I couldn't find that reminder."
     elif reminder_number:
         # Delete by list number
         reminders = get_user_reminders(phone_number)
         if 1 <= reminder_number <= len(reminders):
-            reminder_id = reminders[reminder_number - 1][0]
-            text = reminders[reminder_number - 1][1]
+            selected = reminders[reminder_number - 1]
+            reminder_id = selected[0]
+            text = selected[2]
+            recurring_id = selected[3]
             db_delete_reminder(phone_number, reminder_id)
             reply_text = f"Deleted reminder: {text}"
+            if recurring_id and delete_recurring_reminder(recurring_id, phone_number):
+                reply_text += " (and its recurring schedule)"
         else:
             reply_text = f"Invalid reminder number. You have {len(reminders)} reminders."
     elif search_term:


### PR DESCRIPTION
## Summary
- Customer reported they could not stop a recurring reminder through SMS — every time they deleted it, it came back. Root cause: when the AI classifies a natural-language delete (e.g. *"delete my daily reminder about X"*) as `delete_reminder`, `handle_delete_reminder` in `routes/handlers/reminders.py` only removed the one-off `reminders` row and left the `recurring_reminders` parent alive. The hourly Celery generator (`tasks/reminder_tasks.py:generate_recurring_reminders`) then recreated the next occurrence, so the reminder kept firing.
- Fix: when the matched row has a `recurring_id`, also call `delete_recurring_reminder` and append `"(and its recurring schedule)"` to the confirmation. This matches the behavior already present in the keyword-driven YES-confirmation paths in `main.py:1935-1944` and `main.py:1998-2007`.
- Also fixes two index bugs in the same handler: `reminder_match[1]` and `reminders[n][1]` returned `reminder_date` (the datetime at tuple index 1); the text lives at index 2. Confirmation messages now show the reminder text instead of a timestamp.

## Test plan
- [x] `python run_tests.py --reminders` — 22 passed
- [ ] As a user with a recurring reminder, say "delete my daily reminder about X" — confirm the message includes the text and "(and its recurring schedule)"
- [ ] Verify the `recurring_reminders` row is gone from the DB
- [ ] Verify no new occurrences are generated on the next hourly Celery run
- [ ] Keyword paths (`MY RECURRING` → number, `DELETE REMINDERS` → pick `[R]` item → YES) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)