### PR TITLE
Notify admin on UPGRADE and shared-list mentions

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,6 +81,10 @@ MAX_ITEMS_PER_LIST = 40
 ADMIN_USERNAME = os.environ.get("ADMIN_USERNAME", "admin")
 ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD")
 
+# Admin notification phone — receives alerts for high-signal user events
+# (e.g. UPGRADE keyword, shared-list mentions). Empty = notifications disabled.
+ADMIN_NOTIFICATION_PHONE = os.environ.get("ADMIN_NOTIFICATION_PHONE", "+18593935374")
+
 # Customer Service Portal Authentication
 # Falls back to admin credentials if not set
 CS_USERNAME = os.environ.get("CS_USERNAME", ADMIN_USERNAME)

--- a/main.py
+++ b/main.py
@@ -480,6 +480,27 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
         increment_message_count(phone_number)
 
         # ==========================================
+        # ADMIN NOTIFICATIONS (high-signal user events)
+        # ==========================================
+        # Fire-and-forget — never blocks user handling.
+        try:
+            from config import ADMIN_NOTIFICATION_PHONE
+            if ADMIN_NOTIFICATION_PHONE and phone_number != ADMIN_NOTIFICATION_PHONE:
+                msg_stripped_upper = incoming_msg.strip().upper()
+                trigger = None
+                if msg_stripped_upper in ("UPGRADE", "SUBSCRIBE", "PREMIUM", "PRICING"):
+                    trigger = "upgrade"
+                elif "shared list" in incoming_msg.lower():
+                    trigger = "shared list"
+                if trigger:
+                    from services.sms_service import notify_admin
+                    last4 = phone_number[-4:] if phone_number else "?"
+                    preview = incoming_msg.strip()[:120]
+                    notify_admin(f"[Remyndrs] {trigger} trigger from ...{last4}: {preview}")
+        except Exception as e:
+            logger.warning(f"Admin notification hook error: {e}")
+
+        # ==========================================
         # DELETE ACCOUNT COMMAND (two-step confirmation)
         # ==========================================
         if incoming_msg.upper() in ("DELETE ACCOUNT", "CANCEL ACCOUNT", "CANCEL MY ACCOUNT", "DELETE MY ACCOUNT", "REMOVE MY ACCOUNT", "CLOSE MY ACCOUNT"):

--- a/services/sms_service.py
+++ b/services/sms_service.py
@@ -97,3 +97,15 @@ def send_sms(to_number, message, media_url=None, message_type="other"):
     except Exception as e:
         logger.error(f"Error sending SMS to {to_number}: {e}")
         raise  # Re-raise so callers can handle/retry
+
+
+def notify_admin(message):
+    """Send an admin notification SMS. Never raises — failure is logged and swallowed
+    so user-facing request handling is never blocked by a notification error."""
+    from config import ADMIN_NOTIFICATION_PHONE
+    if not ADMIN_NOTIFICATION_PHONE:
+        return
+    try:
+        send_sms(ADMIN_NOTIFICATION_PHONE, message, message_type="admin_notification")
+    except Exception as e:
+        logger.warning(f"Admin notification to {ADMIN_NOTIFICATION_PHONE} failed: {e}")


### PR DESCRIPTION
## Summary
Adds visibility into two high-signal user events that previously had no notification path.

**Triggers** (fired from `/sms` in `main.py` right after rate-limit + activity tracking, before any keyword dispatch):
- Exact-match `UPGRADE`, `SUBSCRIBE`, `PREMIUM`, or `PRICING`
- Any incoming message containing the substring `"shared list"` (case-insensitive) — covers beta opt-in keywords (`JOIN SHARED LISTS`, `LEAVE SHARED LISTS`, etc.) and natural-language mentions

**Notification destination:** `ADMIN_NOTIFICATION_PHONE` env var, defaulting to `+18593935374`. Set to empty string in Render to disable.

**Safety:**
- Notifications are wrapped in try/except — a Twilio error in the notification path never blocks the user's request
- Self-pings avoided (skipped when sender phone equals `ADMIN_NOTIFICATION_PHONE`)
- Only fires for messages that pass Twilio signature validation, MessageSid dedup, staging/prod routing, and rate-limiting

**Message shape:**
```
[Remyndrs] upgrade trigger from ...1234: UPGRADE
[Remyndrs] shared list trigger from ...5678: JOIN SHARED LISTS
```

## Expected noise level
Once beta users are actively using shared lists, everyday operations like *"add milk to my shared list"* will also notify. If that becomes too noisy, we can narrow the shared-list trigger to the beta opt-in keywords only.

## Test plan
- [x] `python -m pytest tests/test_reminders.py tests/test_prelaunch_checklist.py` — 22 passed
- [x] `python -m pytest tests/test_shared_lists.py` — 72 passed
- [ ] Post-deploy: text `UPGRADE` from a test number → confirm admin receives SMS
- [ ] Post-deploy: text `JOIN SHARED LISTS` from a test number → confirm admin receives SMS
- [ ] Post-deploy: text from the admin phone itself → confirm no self-ping
- [ ] Post-deploy: `curl` a Twilio webhook with a clearly spam/rate-limited pattern → confirm no notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)