### PR TITLE
Add AI Q&A panel to the analytics dashboard

### DIFF
--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -4052,6 +4052,38 @@ async def generate_ai_analytics_summary(admin: str = Depends(verify_admin)):
         return JSONResponse(content={"error": str(e)}, status_code=500)
 
 
+@router.post("/admin/analytics/ai-query")
+async def ai_analytics_query(request: Request, admin: str = Depends(verify_admin)):
+    """Answer an ad-hoc question about the analytics data using Claude."""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(content={"error": "Invalid JSON body"}, status_code=400)
+
+    question = (body.get("question") or "").strip()
+    if not question:
+        return JSONResponse(content={"error": "Question is required"}, status_code=400)
+    if len(question) > 2000:
+        return JSONResponse(content={"error": "Question too long (max 2000 chars)"}, status_code=400)
+
+    model_choice = body.get("model", "haiku")
+    effort = body.get("effort", "medium")
+
+    try:
+        from services.analytics_summary_service import answer_analytics_question
+        result = answer_analytics_question(
+            question=question,
+            model_choice=model_choice,
+            effort=effort,
+        )
+        if result.get("error"):
+            return JSONResponse(content={"status": "error", "error": result["error"]}, status_code=400)
+        return JSONResponse(content={"status": "success", **result})
+    except Exception as e:
+        logger.error(f"Error answering analytics question: {e}")
+        return JSONResponse(content={"error": str(e)}, status_code=500)
+
+
 # =====================================================
 # PRODUCT METRICS ENDPOINT
 # =====================================================
@@ -5883,6 +5915,52 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
             <div id="aiSummaryHistory" style="display: none;">
                 <h3 style="color: #2c3e50; margin-bottom: 15px;">Summary History</h3>
                 <div id="aiHistoryList"></div>
+            </div>
+
+            <!-- Ask AI Panel -->
+            <div style="background: white; border-radius: 8px; padding: 24px; margin-top: 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+                <h3 style="color: #2c3e50; margin: 0 0 6px 0;">Ask a question about this data</h3>
+                <p style="color: #7f8c8d; font-size: 0.9em; margin: 0 0 16px 0;">
+                    Claude answers against the most recent GA4 + Search Console pull (re-pulled if &gt; 1 hour old).
+                </p>
+
+                <div style="display: flex; flex-wrap: wrap; gap: 12px; align-items: end; margin-bottom: 12px;">
+                    <div style="flex: 1; min-width: 200px;">
+                        <label style="display: block; font-size: 0.85em; color: #7f8c8d; margin-bottom: 4px;">Model</label>
+                        <select id="aiQueryModel" onchange="updateAiQueryModelUI()" style="width: 100%; padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px;">
+                            <option value="haiku">Haiku 4.5 — fastest, cheapest</option>
+                            <option value="sonnet">Sonnet 4.6 — balanced</option>
+                            <option value="opus">Opus 4.7 — most capable</option>
+                        </select>
+                    </div>
+                    <div id="aiQueryEffortWrap" style="flex: 1; min-width: 200px; display: none;">
+                        <label style="display: block; font-size: 0.85em; color: #7f8c8d; margin-bottom: 4px;">Effort (Opus only)</label>
+                        <select id="aiQueryEffort" style="width: 100%; padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px;">
+                            <option value="low">Low — quick</option>
+                            <option value="medium" selected>Medium — balanced</option>
+                            <option value="high">High — thorough</option>
+                            <option value="xhigh">X-High — deep reasoning</option>
+                            <option value="max">Max — ceiling (slow, $$$)</option>
+                        </select>
+                    </div>
+                    <div style="color: #95a5a6; font-size: 0.8em; min-width: 180px;" id="aiQueryCostHint">
+                        ~$0.007 / query
+                    </div>
+                </div>
+
+                <textarea id="aiQueryInput" placeholder="e.g. Which landing pages have the best engagement rate? What's driving the drop in sessions?" rows="3" style="width: 100%; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; font-family: inherit; font-size: 0.95em; box-sizing: border-box; resize: vertical;"></textarea>
+
+                <div style="display: flex; gap: 10px; align-items: center; margin-top: 10px;">
+                    <button class="btn btn-primary" id="aiQueryAskBtn" style="padding: 8px 18px;" onclick="askAiQuery()">Ask</button>
+                    <span id="aiQueryStatus" style="color: #7f8c8d; font-size: 0.9em;"></span>
+                </div>
+
+                <div id="aiQueryAnswerWrap" style="display: none; margin-top: 20px; padding: 18px; background: #f8f9fa; border-left: 4px solid #3498db; border-radius: 4px;">
+                    <div style="font-size: 0.85em; color: #7f8c8d; margin-bottom: 8px;">
+                        <span id="aiQueryAnswerMeta"></span>
+                    </div>
+                    <div id="aiQueryAnswerText" style="color: #2c3e50; white-space: pre-wrap; line-height: 1.6;"></div>
+                </div>
             </div>
         </div>
     </div>
@@ -9454,6 +9532,96 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
                 statusEl.textContent = 'Failed: ' + e.message;
             }}
         }}
+
+        // Cost hints keyed on model+effort (rough; 4K input + 500-8K output).
+        const AI_QUERY_COST_HINTS = {{
+            haiku: '~$0.007 / query',
+            sonnet: '~$0.02 / query',
+            'opus-low': '~$0.03 / query',
+            'opus-medium': '~$0.08 / query',
+            'opus-high': '~$0.15 / query',
+            'opus-xhigh': '~$0.25 / query',
+            'opus-max': '~$0.40+ / query',
+        }};
+
+        function updateAiQueryModelUI() {{
+            const model = document.getElementById('aiQueryModel').value;
+            const effortWrap = document.getElementById('aiQueryEffortWrap');
+            const costHint = document.getElementById('aiQueryCostHint');
+            if (model === 'opus') {{
+                effortWrap.style.display = 'block';
+                const effort = document.getElementById('aiQueryEffort').value;
+                costHint.textContent = AI_QUERY_COST_HINTS['opus-' + effort] || '';
+            }} else {{
+                effortWrap.style.display = 'none';
+                costHint.textContent = AI_QUERY_COST_HINTS[model] || '';
+            }}
+        }}
+
+        async function askAiQuery() {{
+            const input = document.getElementById('aiQueryInput');
+            const btn = document.getElementById('aiQueryAskBtn');
+            const status = document.getElementById('aiQueryStatus');
+            const answerWrap = document.getElementById('aiQueryAnswerWrap');
+            const answerText = document.getElementById('aiQueryAnswerText');
+            const answerMeta = document.getElementById('aiQueryAnswerMeta');
+
+            const question = (input.value || '').trim();
+            if (!question) {{
+                status.textContent = 'Enter a question first.';
+                return;
+            }}
+
+            const model = document.getElementById('aiQueryModel').value;
+            const effort = document.getElementById('aiQueryEffort').value;
+
+            btn.disabled = true;
+            btn.textContent = 'Thinking...';
+            status.textContent = '';
+
+            try {{
+                const response = await fetch('/admin/analytics/ai-query', {{
+                    method: 'POST',
+                    headers: {{ 'Content-Type': 'application/json' }},
+                    body: JSON.stringify({{ question, model, effort }}),
+                }});
+                const data = await response.json();
+
+                if (!response.ok || data.error) {{
+                    status.textContent = 'Error: ' + (data.error || response.statusText);
+                    return;
+                }}
+
+                answerText.textContent = data.answer || '(no answer returned)';
+                const metaParts = [data.model];
+                if (data.effort) metaParts.push('effort: ' + data.effort);
+                if (data.data_source === 'cache' && data.data_age_hours != null) {{
+                    metaParts.push('data ' + data.data_age_hours + 'h old');
+                }} else if (data.data_source === 'fresh') {{
+                    metaParts.push('freshly pulled');
+                }}
+                if (data.usage) {{
+                    const u = data.usage;
+                    if (u.input_tokens != null || u.output_tokens != null) {{
+                        metaParts.push((u.input_tokens || 0) + ' in / ' + (u.output_tokens || 0) + ' out tokens');
+                    }}
+                }}
+                answerMeta.textContent = metaParts.join(' · ');
+                answerWrap.style.display = 'block';
+            }} catch (e) {{
+                status.textContent = 'Failed: ' + e.message;
+            }} finally {{
+                btn.disabled = false;
+                btn.textContent = 'Ask';
+            }}
+        }}
+
+        // Wire up effort-change cost hint update
+        document.addEventListener('DOMContentLoaded', function() {{
+            const effortSel = document.getElementById('aiQueryEffort');
+            if (effortSel) effortSel.addEventListener('change', updateAiQueryModelUI);
+            updateAiQueryModelUI();
+        }});
 
         async function loadAISummaryHistory() {{
             const history = document.getElementById('aiSummaryHistory');

--- a/services/analytics_summary_service.py
+++ b/services/analytics_summary_service.py
@@ -335,6 +335,176 @@ def _parse_claude_response(response_text: str) -> tuple:
     return summary_text, trends
 
 
+_MODEL_ID_BY_CHOICE = {
+    "haiku": "claude-haiku-4-5",
+    "sonnet": "claude-sonnet-4-6",
+    "opus": "claude-opus-4-7",
+}
+
+_VALID_OPUS_EFFORTS = ("low", "medium", "high", "xhigh", "max")
+
+
+def _get_latest_raw_data(max_age_hours: int = 1) -> tuple:
+    """Return (raw_data, period_days, summary_date, age_hours) for the most recent summary,
+    or (None, None, None, None) if none exists or the latest is older than max_age_hours."""
+    try:
+        with get_db_cursor() as cur:
+            cur.execute("""
+                SELECT raw_data, period_days, summary_date, created_at
+                FROM analytics_summaries
+                ORDER BY created_at DESC
+                LIMIT 1
+            """)
+            row = cur.fetchone()
+            if not row:
+                return None, None, None, None
+            raw_data, period_days, summary_date, created_at = row
+            if isinstance(raw_data, str):
+                try:
+                    raw_data = json.loads(raw_data)
+                except (json.JSONDecodeError, TypeError):
+                    return None, None, None, None
+            age = datetime.utcnow() - (created_at.replace(tzinfo=None) if created_at.tzinfo else created_at)
+            age_hours = age.total_seconds() / 3600
+            if age_hours > max_age_hours:
+                return None, period_days, summary_date, age_hours
+            return raw_data, period_days, summary_date, age_hours
+    except Exception as e:
+        logger.error(f"Error fetching latest raw_data: {e}")
+        return None, None, None, None
+
+
+def answer_analytics_question(
+    question: str,
+    model_choice: str = "haiku",
+    effort: str = "medium",
+    period_days: int = 7,
+) -> dict:
+    """Answer an ad-hoc question about the website analytics data using Claude.
+
+    Args:
+        question: Admin's natural language question.
+        model_choice: "haiku" | "sonnet" | "opus".
+        effort: "low" | "medium" | "high" | "xhigh" | "max". Only applied to Opus.
+        period_days: Window used when the raw data needs to be re-pulled.
+
+    Returns dict with keys:
+        answer (str), model (str), effort (str|None), data_source (str),
+        usage (dict), error (str, only on failure).
+    """
+    if not question or not question.strip():
+        return {"error": "Question is required"}
+
+    model_key = (model_choice or "haiku").lower()
+    if model_key not in _MODEL_ID_BY_CHOICE:
+        return {"error": f"Invalid model choice '{model_choice}'"}
+    model_id = _MODEL_ID_BY_CHOICE[model_key]
+
+    effort_to_send = None
+    if model_key == "opus":
+        effort_normalized = (effort or "medium").lower()
+        if effort_normalized not in _VALID_OPUS_EFFORTS:
+            return {"error": f"Invalid effort '{effort}'"}
+        effort_to_send = effort_normalized
+
+    # Try to reuse recently stored raw data; fall back to a fresh pull.
+    raw_data, stored_period_days, summary_date, age_hours = _get_latest_raw_data(max_age_hours=1)
+    data_source = "cache"
+    if not raw_data:
+        try:
+            from services.analytics_service import get_ga4_data, get_search_console_data
+        except ImportError as e:
+            return {"error": f"Analytics service unavailable: {e}"}
+        ga4 = get_ga4_data(period_days)
+        if ga4.get("error"):
+            return {"error": f"GA4 data unavailable: {ga4['error']}"}
+        sc = get_search_console_data(period_days)
+        raw_data = {"ga4": ga4, "search_console": sc}
+        stored_period_days = period_days
+        summary_date = datetime.utcnow().date()
+        data_source = "fresh"
+
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        return {"error": "anthropic package not installed"}
+
+    import os
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return {"error": "ANTHROPIC_API_KEY not set in environment"}
+
+    client = Anthropic()
+
+    ga4 = raw_data.get("ga4", {})
+    sc = raw_data.get("search_console", {})
+
+    data_payload = {
+        "period_days": stored_period_days,
+        "summary_date": str(summary_date) if summary_date else None,
+        "totals": ga4.get("totals", {}),
+        "daily_trend": ga4.get("daily_trend", []),
+        "traffic_sources": ga4.get("traffic_sources", [])[:10],
+        "landing_pages": ga4.get("landing_pages", [])[:10],
+        "devices": ga4.get("devices", [])[:5],
+        "key_events": ga4.get("key_events", []),
+        "ab_variants": ga4.get("ab_variants", []),
+        "search_top_queries": sc.get("top_queries", [])[:10] if not sc.get("error") else [],
+        "search_top_pages": sc.get("top_pages", [])[:5] if not sc.get("error") else [],
+    }
+
+    system_prompt = (
+        "You are an analytics expert for Remyndrs, an SMS-based AI memory and reminder service. "
+        "Answer the admin's question using the provided website analytics data (Google Analytics 4 + "
+        "Search Console). Be concise, cite specific numbers from the data, and flag any limitations "
+        "in what the data can tell us. If the data does not contain what the admin asked about, say so."
+    )
+
+    user_content = (
+        f"DATA (JSON):\n{json.dumps(data_payload, indent=2)}\n\n"
+        f"QUESTION: {question.strip()}"
+    )
+
+    kwargs = {
+        "model": model_id,
+        "max_tokens": 2048,
+        "system": system_prompt,
+        "messages": [{"role": "user", "content": user_content}],
+    }
+    if model_key == "opus":
+        kwargs["thinking"] = {"type": "adaptive"}
+        kwargs["output_config"] = {"effort": effort_to_send}
+        # Opus 4.7 can return very long outputs at high effort — give it room.
+        if effort_to_send in ("high", "xhigh", "max"):
+            kwargs["max_tokens"] = 8192
+
+    try:
+        response = client.messages.create(**kwargs)
+    except Exception as e:
+        logger.error(f"Claude API error answering analytics question: {e}")
+        return {"error": f"Claude API call failed: {e}"}
+
+    answer_text = next(
+        (b.text for b in response.content if getattr(b, "type", None) == "text"),
+        "",
+    ).strip()
+
+    usage = getattr(response, "usage", None)
+    usage_dict = {
+        "input_tokens": getattr(usage, "input_tokens", None),
+        "output_tokens": getattr(usage, "output_tokens", None),
+        "cache_read_input_tokens": getattr(usage, "cache_read_input_tokens", None),
+    } if usage else {}
+
+    return {
+        "answer": answer_text,
+        "model": model_id,
+        "effort": effort_to_send,
+        "data_source": data_source,
+        "data_age_hours": round(age_hours, 2) if age_hours is not None else None,
+        "usage": usage_dict,
+    }
+
+
 def _store_summary(
     summary_date, period_days: int, raw_data: dict,
     summary_text: str, trends: dict, metrics_snapshot: dict


### PR DESCRIPTION
## Summary
Adds an "Ask a question about this data" panel to the existing AI Analytics Summary section. Admins can ask ad-hoc questions like *"which landing page converts best?"* or *"what's driving the drop in sessions?"* against the same GA4 + Search Console data the existing summary uses.

**Model selector:**
- Haiku 4.5 — fastest, cheapest (~$0.007/query)
- Sonnet 4.6 — balanced (~$0.02/query)
- Opus 4.7 — most capable, with effort dropdown (Low / Medium / High / X-High / Max)

**Opus 4.7 specifics** (per Anthropic API spec):
- Uses `thinking: {type: "adaptive"}` + `output_config: {effort}`. `budget_tokens` is removed on Opus 4.7, so we use effort as the depth control.
- Haiku 4.5 does **not** support `effort` — omitted entirely when Haiku is chosen (would 400 otherwise).
- Sonnet 4.6 is locked to plain call per the agreed spec (no effort selector).

**Data reuse:** reads `raw_data` JSONB from the latest `analytics_summaries` row when < 1 hour old, otherwise re-pulls GA4/SC fresh. The UI surfaces which it used.

**Safety / UX:**
- Admin-only endpoint
- Stateless — no Q&A history persisted
- Per-query cost hint updates live as model/effort change
- 2000-char question cap
- Answer block shows model, effort, token usage, and data source

## Test plan
- [x] `python -m pytest tests/test_reminders.py tests/test_shared_lists.py` — 94 passed
- [x] Service-layer validation paths (bad model, empty question, bad effort) return clean error dicts without making network calls
- [x] `admin_dashboard.py` imports cleanly; route registers
- [ ] Post-deploy: ask a Haiku question → answer renders, meta line shows "claude-haiku-4-5"
- [ ] Post-deploy: ask an Opus High question → effort shown in meta, longer latency, deeper answer
- [ ] Post-deploy: switch model/effort → cost hint updates correctly; effort dropdown hides for non-Opus
- [ ] Post-deploy: verify no crash when no prior summary exists (cold start — should re-pull)

🤖 Generated with [Claude Code](https://claude.com/claude-code)