### PR TITLE
Threaded analytics chat: claude.ai-style planning conversations

### DIFF
--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -4085,6 +4085,102 @@ async def ai_analytics_query(request: Request, admin: str = Depends(verify_admin
 
 
 # =====================================================
+# THREADED ANALYTICS CHAT
+# =====================================================
+
+@router.get("/admin/analytics/conversations")
+async def list_analytics_conversations(
+    include_archived: bool = False,
+    limit: int = 50,
+    admin: str = Depends(verify_admin),
+):
+    from services.analytics_summary_service import list_conversations
+    items = list_conversations(include_archived=include_archived, limit=min(limit, 200))
+    return JSONResponse(content={"conversations": items, "count": len(items)})
+
+
+@router.post("/admin/analytics/conversations")
+async def create_analytics_conversation(request: Request, admin: str = Depends(verify_admin)):
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    title = (body.get("title") or "").strip() or None
+    from services.analytics_summary_service import create_conversation
+    result = create_conversation(admin_user=admin, title=title)
+    if result.get("error"):
+        return JSONResponse(content={"error": result["error"]}, status_code=500)
+    return JSONResponse(content=result, status_code=201)
+
+
+@router.get("/admin/analytics/conversations/{conv_id}")
+async def get_analytics_conversation(conv_id: int, admin: str = Depends(verify_admin)):
+    from services.analytics_summary_service import get_conversation_with_messages
+    conv = get_conversation_with_messages(conv_id)
+    if not conv:
+        return JSONResponse(content={"error": "Not found"}, status_code=404)
+    return JSONResponse(content=conv)
+
+
+@router.patch("/admin/analytics/conversations/{conv_id}")
+async def rename_analytics_conversation(
+    conv_id: int, request: Request, admin: str = Depends(verify_admin)
+):
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(content={"error": "Invalid JSON body"}, status_code=400)
+    title = (body.get("title") or "").strip()
+    if not title:
+        return JSONResponse(content={"error": "Title is required"}, status_code=400)
+    from services.analytics_summary_service import rename_conversation
+    ok = rename_conversation(conv_id, title)
+    if not ok:
+        return JSONResponse(content={"error": "Not found or rename failed"}, status_code=404)
+    return JSONResponse(content={"status": "success", "id": conv_id, "title": title[:200]})
+
+
+@router.delete("/admin/analytics/conversations/{conv_id}")
+async def delete_analytics_conversation(conv_id: int, admin: str = Depends(verify_admin)):
+    from services.analytics_summary_service import delete_conversation
+    ok = delete_conversation(conv_id)
+    if not ok:
+        return JSONResponse(content={"error": "Not found"}, status_code=404)
+    return JSONResponse(content={"status": "success", "id": conv_id})
+
+
+@router.post("/admin/analytics/conversations/{conv_id}/messages")
+async def post_analytics_message(
+    conv_id: int, request: Request, admin: str = Depends(verify_admin)
+):
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(content={"error": "Invalid JSON body"}, status_code=400)
+
+    question = (body.get("question") or "").strip()
+    if not question:
+        return JSONResponse(content={"error": "Question is required"}, status_code=400)
+    if len(question) > 4000:
+        return JSONResponse(content={"error": "Question too long (max 4000 chars)"}, status_code=400)
+
+    model_choice = body.get("model", "haiku")
+    effort = body.get("effort", "medium")
+
+    from services.analytics_summary_service import send_message_in_conversation
+    result = send_message_in_conversation(
+        conv_id=conv_id,
+        question=question,
+        model_choice=model_choice,
+        effort=effort,
+    )
+    if result.get("error"):
+        status = 404 if result["error"] == "Conversation not found" else 400
+        return JSONResponse(content={"error": result["error"]}, status_code=status)
+    return JSONResponse(content={"status": "success", **result})
+
+
+# =====================================================
 # PRODUCT METRICS ENDPOINT
 # =====================================================
 
@@ -5917,49 +6013,66 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
                 <div id="aiHistoryList"></div>
             </div>
 
-            <!-- Ask AI Panel -->
-            <div style="background: white; border-radius: 8px; padding: 24px; margin-top: 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
-                <h3 style="color: #2c3e50; margin: 0 0 6px 0;">Ask a question about this data</h3>
-                <p style="color: #7f8c8d; font-size: 0.9em; margin: 0 0 16px 0;">
-                    Claude answers against the most recent GA4 + Search Console pull (re-pulled if &gt; 1 hour old).
-                </p>
-
-                <div style="display: flex; flex-wrap: wrap; gap: 12px; align-items: end; margin-bottom: 12px;">
-                    <div style="flex: 1; min-width: 200px;">
-                        <label style="display: block; font-size: 0.85em; color: #7f8c8d; margin-bottom: 4px;">Model</label>
-                        <select id="aiQueryModel" onchange="updateAiQueryModelUI()" style="width: 100%; padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px;">
-                            <option value="haiku">Haiku 4.5 — fastest, cheapest</option>
-                            <option value="sonnet">Sonnet 4.6 — balanced</option>
-                            <option value="opus">Opus 4.7 — most capable</option>
-                        </select>
-                    </div>
-                    <div id="aiQueryEffortWrap" style="flex: 1; min-width: 200px; display: none;">
-                        <label style="display: block; font-size: 0.85em; color: #7f8c8d; margin-bottom: 4px;">Effort (Opus only)</label>
-                        <select id="aiQueryEffort" style="width: 100%; padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px;">
-                            <option value="low">Low — quick</option>
-                            <option value="medium" selected>Medium — balanced</option>
-                            <option value="high">High — thorough</option>
-                            <option value="xhigh">X-High — deep reasoning</option>
-                            <option value="max">Max — ceiling (slow, $$$)</option>
-                        </select>
-                    </div>
-                    <div style="color: #95a5a6; font-size: 0.8em; min-width: 180px;" id="aiQueryCostHint">
-                        ~$0.007 / query
-                    </div>
+            <!-- Threaded Analytics Chat -->
+            <div style="background: white; border-radius: 8px; padding: 0; margin-top: 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); overflow: hidden;">
+                <div style="padding: 20px 24px 12px 24px; border-bottom: 1px solid #eee;">
+                    <h3 style="color: #2c3e50; margin: 0 0 6px 0;">Planning conversations</h3>
+                    <p style="color: #7f8c8d; font-size: 0.9em; margin: 0;">
+                        Ongoing chats with Claude about this data. Pick up where you left off across days.
+                    </p>
                 </div>
 
-                <textarea id="aiQueryInput" placeholder="e.g. Which landing pages have the best engagement rate? What's driving the drop in sessions?" rows="3" style="width: 100%; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; font-family: inherit; font-size: 0.95em; box-sizing: border-box; resize: vertical;"></textarea>
-
-                <div style="display: flex; gap: 10px; align-items: center; margin-top: 10px;">
-                    <button class="btn btn-primary" id="aiQueryAskBtn" style="padding: 8px 18px;" onclick="askAiQuery()">Ask</button>
-                    <span id="aiQueryStatus" style="color: #7f8c8d; font-size: 0.9em;"></span>
-                </div>
-
-                <div id="aiQueryAnswerWrap" style="display: none; margin-top: 20px; padding: 18px; background: #f8f9fa; border-left: 4px solid #3498db; border-radius: 4px;">
-                    <div style="font-size: 0.85em; color: #7f8c8d; margin-bottom: 8px;">
-                        <span id="aiQueryAnswerMeta"></span>
+                <div style="display: flex; min-height: 500px;">
+                    <!-- Sidebar: conversation list -->
+                    <div style="width: 260px; border-right: 1px solid #eee; display: flex; flex-direction: column; background: #fafafa;">
+                        <div style="padding: 12px;">
+                            <button class="btn btn-primary" style="width: 100%; padding: 8px;" onclick="newChatConversation()">+ New conversation</button>
+                        </div>
+                        <div id="chatConvList" style="flex: 1; overflow-y: auto; max-height: 520px;">
+                            <div style="padding: 20px; color: #95a5a6; text-align: center; font-size: 0.9em;">Loading...</div>
+                        </div>
                     </div>
-                    <div id="aiQueryAnswerText" style="color: #2c3e50; white-space: pre-wrap; line-height: 1.6;"></div>
+
+                    <!-- Main: active conversation -->
+                    <div style="flex: 1; display: flex; flex-direction: column; min-width: 0;">
+                        <div id="chatHeader" style="padding: 12px 20px; border-bottom: 1px solid #eee; display: none; align-items: center; gap: 8px;">
+                            <span id="chatTitle" style="font-weight: 600; color: #2c3e50; flex: 1; cursor: text;" onclick="renameActiveChat()" title="Click to rename"></span>
+                            <button class="btn btn-danger" style="padding: 4px 10px; font-size: 0.85em;" onclick="deleteActiveChat()">Delete</button>
+                        </div>
+
+                        <div id="chatMessages" style="flex: 1; overflow-y: auto; max-height: 440px; padding: 20px;">
+                            <div style="color: #95a5a6; text-align: center; padding: 40px 20px;">
+                                Select a conversation on the left, or start a new one.
+                            </div>
+                        </div>
+
+                        <div id="chatInputWrap" style="padding: 12px 20px 20px 20px; border-top: 1px solid #eee; display: none;">
+                            <div style="display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-bottom: 8px; font-size: 0.85em;">
+                                <label style="color: #7f8c8d;">Model:</label>
+                                <select id="chatModel" onchange="updateChatModelUI()" style="padding: 4px 8px; border: 1px solid #ddd; border-radius: 4px;">
+                                    <option value="haiku">Haiku 4.5</option>
+                                    <option value="sonnet">Sonnet 4.6</option>
+                                    <option value="opus">Opus 4.7</option>
+                                </select>
+                                <span id="chatEffortWrap" style="display: none;">
+                                    <label style="color: #7f8c8d;">Effort:</label>
+                                    <select id="chatEffort" onchange="updateChatModelUI()" style="padding: 4px 8px; border: 1px solid #ddd; border-radius: 4px;">
+                                        <option value="low">Low</option>
+                                        <option value="medium" selected>Medium</option>
+                                        <option value="high">High</option>
+                                        <option value="xhigh">X-High</option>
+                                        <option value="max">Max</option>
+                                    </select>
+                                </span>
+                                <span id="chatCostHint" style="color: #95a5a6; margin-left: auto;">~$0.007 / msg</span>
+                            </div>
+                            <div style="display: flex; gap: 8px; align-items: flex-end;">
+                                <textarea id="chatInput" placeholder="Ask a question or follow up..." rows="2" style="flex: 1; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; font-family: inherit; font-size: 0.95em; resize: vertical;" onkeydown="handleChatKey(event)"></textarea>
+                                <button class="btn btn-primary" id="chatSendBtn" style="padding: 10px 18px;" onclick="sendChatMessage()">Send</button>
+                            </div>
+                            <div id="chatStatus" style="color: #7f8c8d; font-size: 0.85em; margin-top: 6px; min-height: 1em;"></div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -9533,94 +9646,259 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
             }}
         }}
 
-        // Cost hints keyed on model+effort (rough; 4K input + 500-8K output).
-        const AI_QUERY_COST_HINTS = {{
-            haiku: '~$0.007 / query',
-            sonnet: '~$0.02 / query',
-            'opus-low': '~$0.03 / query',
-            'opus-medium': '~$0.08 / query',
-            'opus-high': '~$0.15 / query',
-            'opus-xhigh': '~$0.25 / query',
-            'opus-max': '~$0.40+ / query',
+        // =============================================
+        // Threaded analytics chat
+        // =============================================
+        const CHAT_COST_HINTS = {{
+            haiku: '~$0.007 / msg',
+            sonnet: '~$0.02 / msg',
+            'opus-low': '~$0.03 / msg',
+            'opus-medium': '~$0.08 / msg',
+            'opus-high': '~$0.15 / msg',
+            'opus-xhigh': '~$0.25 / msg',
+            'opus-max': '~$0.40+ / msg',
         }};
 
-        function updateAiQueryModelUI() {{
-            const model = document.getElementById('aiQueryModel').value;
-            const effortWrap = document.getElementById('aiQueryEffortWrap');
-            const costHint = document.getElementById('aiQueryCostHint');
+        let chatActiveConvId = null;
+        let chatConversations = [];
+
+        function updateChatModelUI() {{
+            const model = document.getElementById('chatModel').value;
+            const effortWrap = document.getElementById('chatEffortWrap');
+            const hint = document.getElementById('chatCostHint');
             if (model === 'opus') {{
-                effortWrap.style.display = 'block';
-                const effort = document.getElementById('aiQueryEffort').value;
-                costHint.textContent = AI_QUERY_COST_HINTS['opus-' + effort] || '';
+                effortWrap.style.display = 'inline';
+                const effort = document.getElementById('chatEffort').value;
+                hint.textContent = CHAT_COST_HINTS['opus-' + effort] || '';
             }} else {{
                 effortWrap.style.display = 'none';
-                costHint.textContent = AI_QUERY_COST_HINTS[model] || '';
+                hint.textContent = CHAT_COST_HINTS[model] || '';
             }}
         }}
 
-        async function askAiQuery() {{
-            const input = document.getElementById('aiQueryInput');
-            const btn = document.getElementById('aiQueryAskBtn');
-            const status = document.getElementById('aiQueryStatus');
-            const answerWrap = document.getElementById('aiQueryAnswerWrap');
-            const answerText = document.getElementById('aiQueryAnswerText');
-            const answerMeta = document.getElementById('aiQueryAnswerMeta');
+        function escapeHtmlChat(s) {{
+            const div = document.createElement('div');
+            div.textContent = s == null ? '' : String(s);
+            return div.innerHTML;
+        }}
 
-            const question = (input.value || '').trim();
-            if (!question) {{
-                status.textContent = 'Enter a question first.';
+        function fmtChatRelative(iso) {{
+            if (!iso) return '';
+            const d = new Date(iso);
+            const diff = (Date.now() - d.getTime()) / 1000;
+            if (diff < 60) return 'just now';
+            if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+            if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+            return Math.floor(diff / 86400) + 'd ago';
+        }}
+
+        async function loadChatConversations() {{
+            const list = document.getElementById('chatConvList');
+            try {{
+                const r = await fetch('/admin/analytics/conversations');
+                const data = await r.json();
+                chatConversations = data.conversations || [];
+                if (chatConversations.length === 0) {{
+                    list.innerHTML = '<div style="padding: 20px; color: #95a5a6; text-align: center; font-size: 0.9em;">No conversations yet. Start one above.</div>';
+                    return;
+                }}
+                list.innerHTML = chatConversations.map(c => {{
+                    const active = c.id === chatActiveConvId;
+                    const bg = active ? '#e3f2fd' : 'transparent';
+                    const border = active ? '3px solid #3498db' : '3px solid transparent';
+                    return `
+                        <div onclick="openChatConversation(${{c.id}})" style="padding: 10px 12px; cursor: pointer; border-left: ${{border}}; background: ${{bg}}; border-bottom: 1px solid #eee;">
+                            <div style="font-size: 0.9em; color: #2c3e50; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;" title="${{escapeHtmlChat(c.title)}}">${{escapeHtmlChat(c.title)}}</div>
+                            <div style="font-size: 0.75em; color: #95a5a6; margin-top: 2px;">${{c.message_count}} msgs · ${{fmtChatRelative(c.last_active_at)}}</div>
+                        </div>`;
+                }}).join('');
+            }} catch (e) {{
+                list.innerHTML = '<div style="padding: 20px; color: #e74c3c; text-align: center; font-size: 0.9em;">Failed to load</div>';
+            }}
+        }}
+
+        async function newChatConversation() {{
+            try {{
+                const r = await fetch('/admin/analytics/conversations', {{
+                    method: 'POST',
+                    headers: {{ 'Content-Type': 'application/json' }},
+                    body: JSON.stringify({{}}),
+                }});
+                const data = await r.json();
+                if (data.error) {{ alert('Could not create conversation: ' + data.error); return; }}
+                chatActiveConvId = data.id;
+                await loadChatConversations();
+                await openChatConversation(data.id);
+                document.getElementById('chatInput').focus();
+            }} catch (e) {{
+                alert('Failed to create conversation: ' + e.message);
+            }}
+        }}
+
+        async function openChatConversation(convId) {{
+            chatActiveConvId = convId;
+            const messagesEl = document.getElementById('chatMessages');
+            const header = document.getElementById('chatHeader');
+            const inputWrap = document.getElementById('chatInputWrap');
+            messagesEl.innerHTML = '<div style="color: #95a5a6; text-align: center;">Loading...</div>';
+            header.style.display = 'flex';
+            inputWrap.style.display = 'block';
+
+            try {{
+                const r = await fetch('/admin/analytics/conversations/' + convId);
+                if (r.status === 404) {{
+                    messagesEl.innerHTML = '<div style="color: #e74c3c;">Conversation not found</div>';
+                    return;
+                }}
+                const conv = await r.json();
+                document.getElementById('chatTitle').textContent = conv.title || 'Untitled';
+                renderChatMessages(conv.messages || []);
+                // Refresh list to update highlight
+                loadChatConversations();
+            }} catch (e) {{
+                messagesEl.innerHTML = '<div style="color: #e74c3c;">Failed to load: ' + escapeHtmlChat(e.message) + '</div>';
+            }}
+        }}
+
+        function renderChatMessages(messages) {{
+            const messagesEl = document.getElementById('chatMessages');
+            if (messages.length === 0) {{
+                messagesEl.innerHTML = '<div style="color: #95a5a6; text-align: center; padding: 30px 20px;">Ask your first question below.</div>';
                 return;
             }}
+            messagesEl.innerHTML = messages.map(m => {{
+                const isUser = m.role === 'user';
+                const align = isUser ? 'flex-end' : 'flex-start';
+                const bg = isUser ? '#3498db' : '#ecf0f1';
+                const color = isUser ? 'white' : '#2c3e50';
+                const meta = [];
+                if (m.model) meta.push(m.model);
+                if (m.effort) meta.push('effort: ' + m.effort);
+                if (m.input_tokens != null || m.output_tokens != null) {{
+                    meta.push((m.input_tokens || 0) + ' in / ' + (m.output_tokens || 0) + ' out');
+                }}
+                if (m.cache_read_input_tokens) meta.push(m.cache_read_input_tokens + ' cached');
+                return `
+                    <div style="display: flex; justify-content: ${{align}}; margin-bottom: 14px;">
+                        <div style="max-width: 85%;">
+                            <div style="background: ${{bg}}; color: ${{color}}; padding: 10px 14px; border-radius: 10px; white-space: pre-wrap; line-height: 1.5;">${{escapeHtmlChat(m.content)}}</div>
+                            ${{!isUser && meta.length ? `<div style="font-size: 0.75em; color: #95a5a6; margin-top: 4px;">${{escapeHtmlChat(meta.join(' · '))}}</div>` : ''}}
+                        </div>
+                    </div>`;
+            }}).join('');
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+        }}
 
-            const model = document.getElementById('aiQueryModel').value;
-            const effort = document.getElementById('aiQueryEffort').value;
+        function handleChatKey(e) {{
+            if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {{
+                e.preventDefault();
+                sendChatMessage();
+            }}
+        }}
+
+        async function sendChatMessage() {{
+            if (!chatActiveConvId) {{
+                alert('No conversation selected. Click "+ New conversation" first.');
+                return;
+            }}
+            const inputEl = document.getElementById('chatInput');
+            const question = (inputEl.value || '').trim();
+            if (!question) return;
+
+            const model = document.getElementById('chatModel').value;
+            const effort = document.getElementById('chatEffort').value;
+            const btn = document.getElementById('chatSendBtn');
+            const status = document.getElementById('chatStatus');
 
             btn.disabled = true;
             btn.textContent = 'Thinking...';
             status.textContent = '';
 
+            // Optimistically append the user message
+            const messagesEl = document.getElementById('chatMessages');
+            const r0 = await fetch('/admin/analytics/conversations/' + chatActiveConvId);
+            let existing = [];
+            if (r0.ok) {{
+                const c = await r0.json();
+                existing = c.messages || [];
+            }}
+            renderChatMessages([...existing, {{ role: 'user', content: question }}]);
+
             try {{
-                const response = await fetch('/admin/analytics/ai-query', {{
+                const r = await fetch('/admin/analytics/conversations/' + chatActiveConvId + '/messages', {{
                     method: 'POST',
                     headers: {{ 'Content-Type': 'application/json' }},
                     body: JSON.stringify({{ question, model, effort }}),
                 }});
-                const data = await response.json();
+                const data = await r.json();
 
-                if (!response.ok || data.error) {{
-                    status.textContent = 'Error: ' + (data.error || response.statusText);
+                if (!r.ok || data.error) {{
+                    status.textContent = 'Error: ' + (data.error || r.statusText);
+                    // Restore prior state (drop optimistic user msg)
+                    renderChatMessages(existing);
                     return;
                 }}
 
-                answerText.textContent = data.answer || '(no answer returned)';
-                const metaParts = [data.model];
-                if (data.effort) metaParts.push('effort: ' + data.effort);
-                if (data.data_source === 'cache' && data.data_age_hours != null) {{
-                    metaParts.push('data ' + data.data_age_hours + 'h old');
-                }} else if (data.data_source === 'fresh') {{
-                    metaParts.push('freshly pulled');
-                }}
-                if (data.usage) {{
-                    const u = data.usage;
-                    if (u.input_tokens != null || u.output_tokens != null) {{
-                        metaParts.push((u.input_tokens || 0) + ' in / ' + (u.output_tokens || 0) + ' out tokens');
-                    }}
-                }}
-                answerMeta.textContent = metaParts.join(' · ');
-                answerWrap.style.display = 'block';
+                inputEl.value = '';
+                // Reload the conversation to get the canonical message list
+                await openChatConversation(chatActiveConvId);
             }} catch (e) {{
                 status.textContent = 'Failed: ' + e.message;
+                renderChatMessages(existing);
             }} finally {{
                 btn.disabled = false;
-                btn.textContent = 'Ask';
+                btn.textContent = 'Send';
             }}
         }}
 
-        // Wire up effort-change cost hint update
+        async function renameActiveChat() {{
+            if (!chatActiveConvId) return;
+            const current = document.getElementById('chatTitle').textContent;
+            const next = prompt('Rename conversation:', current);
+            if (next == null) return;
+            const title = next.trim();
+            if (!title || title === current) return;
+            try {{
+                const r = await fetch('/admin/analytics/conversations/' + chatActiveConvId, {{
+                    method: 'PATCH',
+                    headers: {{ 'Content-Type': 'application/json' }},
+                    body: JSON.stringify({{ title }}),
+                }});
+                if (!r.ok) {{
+                    const data = await r.json();
+                    alert('Rename failed: ' + (data.error || r.statusText));
+                    return;
+                }}
+                document.getElementById('chatTitle').textContent = title;
+                loadChatConversations();
+            }} catch (e) {{
+                alert('Rename failed: ' + e.message);
+            }}
+        }}
+
+        async function deleteActiveChat() {{
+            if (!chatActiveConvId) return;
+            if (!confirm('Delete this conversation and all its messages? This cannot be undone.')) return;
+            try {{
+                const r = await fetch('/admin/analytics/conversations/' + chatActiveConvId, {{ method: 'DELETE' }});
+                if (!r.ok) {{
+                    const data = await r.json();
+                    alert('Delete failed: ' + (data.error || r.statusText));
+                    return;
+                }}
+                chatActiveConvId = null;
+                document.getElementById('chatHeader').style.display = 'none';
+                document.getElementById('chatInputWrap').style.display = 'none';
+                document.getElementById('chatMessages').innerHTML = '<div style="color: #95a5a6; text-align: center; padding: 40px 20px;">Select a conversation on the left, or start a new one.</div>';
+                loadChatConversations();
+            }} catch (e) {{
+                alert('Delete failed: ' + e.message);
+            }}
+        }}
+
         document.addEventListener('DOMContentLoaded', function() {{
-            const effortSel = document.getElementById('aiQueryEffort');
-            if (effortSel) effortSel.addEventListener('change', updateAiQueryModelUI);
-            updateAiQueryModelUI();
+            updateChatModelUI();
+            loadChatConversations();
         }});
 
         async function loadAISummaryHistory() {{

--- a/database.py
+++ b/database.py
@@ -651,6 +651,30 @@ def init_db():
             )""",
             "CREATE INDEX IF NOT EXISTS idx_analytics_summaries_date ON analytics_summaries(summary_date DESC)",
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_analytics_summaries_date_period ON analytics_summaries(summary_date, period_days)",
+            # Threaded analytics chat (admin-only): conversations + per-turn messages
+            """CREATE TABLE IF NOT EXISTS analytics_conversations (
+                id SERIAL PRIMARY KEY,
+                title TEXT NOT NULL DEFAULT 'New conversation',
+                admin_user TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_active_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                archived BOOLEAN DEFAULT FALSE
+            )""",
+            """CREATE TABLE IF NOT EXISTS analytics_messages (
+                id SERIAL PRIMARY KEY,
+                conversation_id INTEGER NOT NULL REFERENCES analytics_conversations(id) ON DELETE CASCADE,
+                role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+                content TEXT NOT NULL,
+                model TEXT,
+                effort TEXT,
+                data_source TEXT,
+                input_tokens INTEGER,
+                output_tokens INTEGER,
+                cache_read_input_tokens INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_analytics_messages_conv ON analytics_messages(conversation_id, created_at)",
+            "CREATE INDEX IF NOT EXISTS idx_analytics_conversations_active ON analytics_conversations(archived, last_active_at DESC)",
             # Nudge tracking for pending onboarding users
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS last_nudged_at TIMESTAMP",
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS nudge_count_24h INTEGER DEFAULT 0",

--- a/services/analytics_summary_service.py
+++ b/services/analytics_summary_service.py
@@ -505,6 +505,378 @@ def answer_analytics_question(
     }
 
 
+_CONVERSATION_SYSTEM_PROMPT = (
+    "You are an analytics expert for Remyndrs, an SMS-based AI memory and reminder service. "
+    "You are in an ongoing planning conversation with the admin about website analytics and "
+    "growth strategy. Use the provided Google Analytics 4 + Search Console data to answer. "
+    "Cite specific numbers when relevant. Be concise but substantive. When the admin asks a "
+    "follow-up, remember what you've already discussed and build on it rather than repeating "
+    "yourself. If the data does not contain what they asked about, say so plainly."
+)
+
+
+def _build_data_payload(raw_data: dict, period_days, summary_date) -> dict:
+    ga4 = raw_data.get("ga4", {})
+    sc = raw_data.get("search_console", {})
+    return {
+        "period_days": period_days,
+        "summary_date": str(summary_date) if summary_date else None,
+        "totals": ga4.get("totals", {}),
+        "daily_trend": ga4.get("daily_trend", []),
+        "traffic_sources": ga4.get("traffic_sources", [])[:10],
+        "landing_pages": ga4.get("landing_pages", [])[:10],
+        "devices": ga4.get("devices", [])[:5],
+        "key_events": ga4.get("key_events", []),
+        "ab_variants": ga4.get("ab_variants", []),
+        "search_top_queries": sc.get("top_queries", [])[:10] if not sc.get("error") else [],
+        "search_top_pages": sc.get("top_pages", [])[:5] if not sc.get("error") else [],
+    }
+
+
+def _auto_title(question: str) -> str:
+    """Derive a short conversation title from the first user question."""
+    text = (question or "").strip().split("\n")[0]
+    if len(text) > 60:
+        text = text[:57].rstrip() + "..."
+    return text or "New conversation"
+
+
+def create_conversation(admin_user: str = None, title: str = None) -> dict:
+    try:
+        with get_db_cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO analytics_conversations (title, admin_user)
+                VALUES (%s, %s)
+                RETURNING id, title, admin_user, created_at, last_active_at, archived
+                """,
+                (title or "New conversation", admin_user),
+            )
+            row = cur.fetchone()
+        return {
+            "id": row[0],
+            "title": row[1],
+            "admin_user": row[2],
+            "created_at": row[3].isoformat() if row[3] else None,
+            "last_active_at": row[4].isoformat() if row[4] else None,
+            "archived": row[5],
+        }
+    except Exception as e:
+        logger.error(f"Error creating analytics conversation: {e}")
+        return {"error": str(e)}
+
+
+def list_conversations(include_archived: bool = False, limit: int = 50) -> list:
+    try:
+        with get_db_cursor() as cur:
+            if include_archived:
+                cur.execute(
+                    """
+                    SELECT c.id, c.title, c.admin_user, c.created_at, c.last_active_at, c.archived,
+                           (SELECT COUNT(*) FROM analytics_messages m WHERE m.conversation_id = c.id) AS msg_count
+                    FROM analytics_conversations c
+                    ORDER BY c.last_active_at DESC
+                    LIMIT %s
+                    """,
+                    (limit,),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT c.id, c.title, c.admin_user, c.created_at, c.last_active_at, c.archived,
+                           (SELECT COUNT(*) FROM analytics_messages m WHERE m.conversation_id = c.id) AS msg_count
+                    FROM analytics_conversations c
+                    WHERE c.archived = FALSE
+                    ORDER BY c.last_active_at DESC
+                    LIMIT %s
+                    """,
+                    (limit,),
+                )
+            rows = cur.fetchall()
+        return [
+            {
+                "id": r[0],
+                "title": r[1],
+                "admin_user": r[2],
+                "created_at": r[3].isoformat() if r[3] else None,
+                "last_active_at": r[4].isoformat() if r[4] else None,
+                "archived": r[5],
+                "message_count": r[6],
+            }
+            for r in rows
+        ]
+    except Exception as e:
+        logger.error(f"Error listing analytics conversations: {e}")
+        return []
+
+
+def get_conversation_with_messages(conv_id: int) -> dict:
+    try:
+        with get_db_cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, title, admin_user, created_at, last_active_at, archived
+                FROM analytics_conversations
+                WHERE id = %s
+                """,
+                (conv_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            conv = {
+                "id": row[0],
+                "title": row[1],
+                "admin_user": row[2],
+                "created_at": row[3].isoformat() if row[3] else None,
+                "last_active_at": row[4].isoformat() if row[4] else None,
+                "archived": row[5],
+            }
+            cur.execute(
+                """
+                SELECT id, role, content, model, effort, data_source,
+                       input_tokens, output_tokens, cache_read_input_tokens, created_at
+                FROM analytics_messages
+                WHERE conversation_id = %s
+                ORDER BY id ASC
+                """,
+                (conv_id,),
+            )
+            msgs = cur.fetchall()
+        conv["messages"] = [
+            {
+                "id": m[0],
+                "role": m[1],
+                "content": m[2],
+                "model": m[3],
+                "effort": m[4],
+                "data_source": m[5],
+                "input_tokens": m[6],
+                "output_tokens": m[7],
+                "cache_read_input_tokens": m[8],
+                "created_at": m[9].isoformat() if m[9] else None,
+            }
+            for m in msgs
+        ]
+        return conv
+    except Exception as e:
+        logger.error(f"Error fetching analytics conversation {conv_id}: {e}")
+        return None
+
+
+def rename_conversation(conv_id: int, title: str) -> bool:
+    title = (title or "").strip()
+    if not title:
+        return False
+    if len(title) > 200:
+        title = title[:200]
+    try:
+        with get_db_cursor() as cur:
+            cur.execute(
+                "UPDATE analytics_conversations SET title = %s WHERE id = %s",
+                (title, conv_id),
+            )
+            return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"Error renaming conversation {conv_id}: {e}")
+        return False
+
+
+def delete_conversation(conv_id: int) -> bool:
+    try:
+        with get_db_cursor() as cur:
+            cur.execute(
+                "DELETE FROM analytics_conversations WHERE id = %s",
+                (conv_id,),
+            )
+            return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"Error deleting conversation {conv_id}: {e}")
+        return False
+
+
+def _insert_message(
+    conv_id: int, role: str, content: str,
+    model: str = None, effort: str = None, data_source: str = None,
+    input_tokens: int = None, output_tokens: int = None,
+    cache_read_input_tokens: int = None,
+) -> int:
+    with get_db_cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO analytics_messages
+                (conversation_id, role, content, model, effort, data_source,
+                 input_tokens, output_tokens, cache_read_input_tokens)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (conv_id, role, content, model, effort, data_source,
+             input_tokens, output_tokens, cache_read_input_tokens),
+        )
+        return cur.fetchone()[0]
+
+
+def send_message_in_conversation(
+    conv_id: int,
+    question: str,
+    model_choice: str = "haiku",
+    effort: str = "medium",
+    period_days: int = 7,
+) -> dict:
+    """Append a user message to a conversation, call Claude with full history, store the reply.
+
+    Returns dict with keys:
+        user_message (dict), assistant_message (dict), conversation (dict), error (on failure).
+    """
+    question = (question or "").strip()
+    if not question:
+        return {"error": "Question is required"}
+    if len(question) > 4000:
+        return {"error": "Question too long (max 4000 chars)"}
+
+    model_key = (model_choice or "haiku").lower()
+    if model_key not in _MODEL_ID_BY_CHOICE:
+        return {"error": f"Invalid model choice '{model_choice}'"}
+    model_id = _MODEL_ID_BY_CHOICE[model_key]
+
+    effort_to_send = None
+    if model_key == "opus":
+        effort_normalized = (effort or "medium").lower()
+        if effort_normalized not in _VALID_OPUS_EFFORTS:
+            return {"error": f"Invalid effort '{effort}'"}
+        effort_to_send = effort_normalized
+
+    conv = get_conversation_with_messages(conv_id)
+    if not conv:
+        return {"error": "Conversation not found"}
+
+    # Fetch data — wider cache window for threaded chat so caching pays off across a planning session
+    raw_data, stored_period_days, summary_date, age_hours = _get_latest_raw_data(max_age_hours=24)
+    data_source = "cache"
+    if not raw_data:
+        try:
+            from services.analytics_service import get_ga4_data, get_search_console_data
+        except ImportError as e:
+            return {"error": f"Analytics service unavailable: {e}"}
+        ga4 = get_ga4_data(period_days)
+        if ga4.get("error"):
+            return {"error": f"GA4 data unavailable: {ga4['error']}"}
+        sc = get_search_console_data(period_days)
+        raw_data = {"ga4": ga4, "search_console": sc}
+        stored_period_days = period_days
+        summary_date = datetime.utcnow().date()
+        data_source = "fresh"
+
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        return {"error": "anthropic package not installed"}
+
+    import os
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return {"error": "ANTHROPIC_API_KEY not set in environment"}
+
+    client = Anthropic()
+
+    data_payload = _build_data_payload(raw_data, stored_period_days, summary_date)
+
+    # System = stable instructions + data snapshot. Cache-control marker here makes everything
+    # up through system cacheable across turns — a win once the thread has 2+ messages.
+    system = [
+        {"type": "text", "text": _CONVERSATION_SYSTEM_PROMPT},
+        {
+            "type": "text",
+            "text": f"ANALYTICS DATA (JSON):\n{json.dumps(data_payload, indent=2)}",
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+    messages = []
+    for m in conv["messages"]:
+        messages.append({"role": m["role"], "content": m["content"]})
+    messages.append({"role": "user", "content": question})
+
+    kwargs = {
+        "model": model_id,
+        "max_tokens": 2048,
+        "system": system,
+        "messages": messages,
+    }
+    if model_key == "opus":
+        kwargs["thinking"] = {"type": "adaptive"}
+        kwargs["output_config"] = {"effort": effort_to_send}
+        if effort_to_send in ("high", "xhigh", "max"):
+            kwargs["max_tokens"] = 8192
+
+    try:
+        response = client.messages.create(**kwargs)
+    except Exception as e:
+        logger.error(f"Claude API error in conversation {conv_id}: {e}")
+        return {"error": f"Claude API call failed: {e}"}
+
+    answer_text = next(
+        (b.text for b in response.content if getattr(b, "type", None) == "text"),
+        "",
+    ).strip()
+    if not answer_text:
+        return {"error": "Empty response from Claude"}
+
+    usage = getattr(response, "usage", None)
+    input_tokens = getattr(usage, "input_tokens", None) if usage else None
+    output_tokens = getattr(usage, "output_tokens", None) if usage else None
+    cache_read = getattr(usage, "cache_read_input_tokens", None) if usage else None
+
+    # Persist both turns and bump last_active_at. Auto-title on first user turn.
+    try:
+        with get_db_cursor() as cur:
+            is_first = len(conv["messages"]) == 0
+            user_msg_id = _insert_message(
+                conv_id, "user", question,
+                model=model_id, effort=effort_to_send, data_source=data_source,
+            )
+            assistant_msg_id = _insert_message(
+                conv_id, "assistant", answer_text,
+                model=model_id, effort=effort_to_send, data_source=data_source,
+                input_tokens=input_tokens, output_tokens=output_tokens,
+                cache_read_input_tokens=cache_read,
+            )
+            if is_first and (conv["title"] in (None, "", "New conversation")):
+                cur.execute(
+                    "UPDATE analytics_conversations SET title = %s, last_active_at = CURRENT_TIMESTAMP WHERE id = %s",
+                    (_auto_title(question), conv_id),
+                )
+            else:
+                cur.execute(
+                    "UPDATE analytics_conversations SET last_active_at = CURRENT_TIMESTAMP WHERE id = %s",
+                    (conv_id,),
+                )
+    except Exception as e:
+        logger.error(f"Error persisting conversation {conv_id} messages: {e}")
+        return {"error": f"Failed to save messages: {e}"}
+
+    return {
+        "user_message": {
+            "id": user_msg_id,
+            "role": "user",
+            "content": question,
+            "model": model_id,
+            "effort": effort_to_send,
+        },
+        "assistant_message": {
+            "id": assistant_msg_id,
+            "role": "assistant",
+            "content": answer_text,
+            "model": model_id,
+            "effort": effort_to_send,
+            "data_source": data_source,
+            "data_age_hours": round(age_hours, 2) if age_hours is not None else None,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_read_input_tokens": cache_read,
+        },
+    }
+
+
 def _store_summary(
     summary_date, period_days: int, raw_data: dict,
     summary_text: str, trends: dict, metrics_snapshot: dict


### PR DESCRIPTION
## Summary
Replaces the single-turn "Ask a question" panel with ongoing threaded conversations — same workflow you use on claude.ai for planning, but pointed at your GA4 + Search Console data. Create separate threads per topic (*"Q1 ad planning"*, *"Landing page optimization"*), each thread remembers everything discussed, and you can pick up across days.

## What's new
- **Sidebar** with your conversation list (+ New button). Threads sorted by most recent activity.
- **Chat pane** with message bubbles, click-to-rename title, delete button.
- **Multi-turn memory** — each new question sends the full prior history to Claude, so follow-ups like *"and what about organic search?"* work correctly.
- **Per-message model/effort** — Haiku 4.5 / Sonnet 4.6 / Opus 4.7 with effort slider for Opus (Low → Max).
- **Prompt caching** on system prompt + analytics data payload. Makes long threads cheap: cache reads are 90% off, so a 30-turn Opus thread is ~$0.15/message instead of $1+.
- **Auto-titles** threads from the first question.
- **Ctrl/Cmd+Enter** to send.

## Database
Two new tables added to `database.py` init:
- `analytics_conversations` — thread metadata
- `analytics_messages` — per-turn content + token usage for cost review

Both have appropriate indexes. `init_db()` uses `CREATE TABLE IF NOT EXISTS` so no manual migration step.

## Context limits
See the table in the design discussion — Haiku caps around ~120 turns (200K context), Sonnet/Opus around ~600 turns (1M context). You won't hit this in practice; the softer limit is cost and it's managed by prompt caching.

## Endpoints
- `GET /admin/analytics/conversations` — list
- `POST /admin/analytics/conversations` — create
- `GET /admin/analytics/conversations/{id}` — fetch with messages
- `PATCH /admin/analytics/conversations/{id}` — rename
- `DELETE /admin/analytics/conversations/{id}` — delete (cascades messages)
- `POST /admin/analytics/conversations/{id}/messages` — send message

All admin-authenticated. The previous single-turn `/admin/analytics/ai-query` endpoint remains registered but is no longer used by the UI — kept for backward compatibility.

## Test plan
- [x] `python -m pytest tests/test_reminders.py tests/test_shared_lists.py` — 94 passed
- [x] Validation paths (bad model, empty question, bad effort) return clean errors without hitting Claude
- [x] `admin_dashboard.py` imports cleanly; 103 routes registered (was 97)
- [ ] Post-deploy: create a conversation, send a question on Haiku, verify answer + message saved
- [ ] Post-deploy: ask a follow-up in the same thread, verify AI references the prior question
- [ ] Post-deploy: switch to Opus + High effort on a complex analytical question
- [ ] Post-deploy: rename a thread, delete a thread
- [ ] Post-deploy: open an existing thread from yesterday, verify it loads and new messages append

🤖 Generated with [Claude Code](https://claude.com/claude-code)