### PR TITLE
Attach images to analytics chat messages

### DIFF
--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -10,8 +10,8 @@ import time
 from datetime import datetime, timedelta
 from html import escape as html_escape
 import pytz
-from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Request
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Request, Form, File, UploadFile
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel
 from typing import Optional
@@ -4151,33 +4151,54 @@ async def delete_analytics_conversation(conv_id: int, admin: str = Depends(verif
 
 @router.post("/admin/analytics/conversations/{conv_id}/messages")
 async def post_analytics_message(
-    conv_id: int, request: Request, admin: str = Depends(verify_admin)
+    conv_id: int,
+    question: str = Form(""),
+    model: str = Form("haiku"),
+    effort: str = Form("medium"),
+    files: list[UploadFile] = File(default=[]),
+    admin: str = Depends(verify_admin),
 ):
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse(content={"error": "Invalid JSON body"}, status_code=400)
-
-    question = (body.get("question") or "").strip()
-    if not question:
-        return JSONResponse(content={"error": "Question is required"}, status_code=400)
-    if len(question) > 4000:
-        return JSONResponse(content={"error": "Question too long (max 4000 chars)"}, status_code=400)
-
-    model_choice = body.get("model", "haiku")
-    effort = body.get("effort", "medium")
+    """Multipart endpoint: accepts `question` + optional image `files[]`."""
+    image_files = []
+    for f in files or []:
+        if not f or not getattr(f, "filename", None):
+            continue
+        data = await f.read()
+        image_files.append({
+            "filename": f.filename,
+            "mime_type": f.content_type or "application/octet-stream",
+            "data": data,
+        })
 
     from services.analytics_summary_service import send_message_in_conversation
     result = send_message_in_conversation(
         conv_id=conv_id,
         question=question,
-        model_choice=model_choice,
+        model_choice=model,
         effort=effort,
+        image_files=image_files,
     )
     if result.get("error"):
         status = 404 if result["error"] == "Conversation not found" else 400
         return JSONResponse(content={"error": result["error"]}, status_code=status)
     return JSONResponse(content={"status": "success", **result})
+
+
+@router.get("/admin/analytics/conversations/{conv_id}/attachments/{att_id}")
+async def get_analytics_attachment(conv_id: int, att_id: int, admin: str = Depends(verify_admin)):
+    """Serve an image attachment's raw bytes. Validates that the attachment belongs to the given conversation."""
+    from services.analytics_summary_service import get_attachment_bytes, get_conversation_with_messages
+    data, mime, filename, message_id = get_attachment_bytes(att_id)
+    if not data:
+        return JSONResponse(content={"error": "Not found"}, status_code=404)
+    # Verify the attachment's message belongs to this conversation
+    conv = get_conversation_with_messages(conv_id)
+    if not conv or not any(m["id"] == message_id for m in conv.get("messages", [])):
+        return JSONResponse(content={"error": "Not found"}, status_code=404)
+    headers = {"Cache-Control": "private, max-age=3600"}
+    if filename:
+        headers["Content-Disposition"] = f'inline; filename="{filename}"'
+    return Response(content=data, media_type=mime, headers=headers)
 
 
 # =====================================================
@@ -6066,9 +6087,17 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
                                 </span>
                                 <span id="chatCostHint" style="color: #95a5a6; margin-left: auto;">~$0.007 / msg</span>
                             </div>
-                            <div style="display: flex; gap: 8px; align-items: flex-end;">
-                                <textarea id="chatInput" placeholder="Ask a question or follow up..." rows="2" style="flex: 1; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; font-family: inherit; font-size: 0.95em; resize: vertical;" onkeydown="handleChatKey(event)"></textarea>
-                                <button class="btn btn-primary" id="chatSendBtn" style="padding: 10px 18px;" onclick="sendChatMessage()">Send</button>
+
+                            <!-- Staged attachments (before send) -->
+                            <div id="chatStagedFiles" style="display: none; gap: 8px; flex-wrap: wrap; margin-bottom: 8px;"></div>
+
+                            <div id="chatDropZone" style="display: flex; gap: 8px; align-items: flex-end; border: 2px dashed transparent; border-radius: 4px; transition: border-color 0.15s;">
+                                <textarea id="chatInput" placeholder="Ask a question, follow up, or drop an image..." rows="2" style="flex: 1; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; font-family: inherit; font-size: 0.95em; resize: vertical;" onkeydown="handleChatKey(event)"></textarea>
+                                <div style="display: flex; flex-direction: column; gap: 6px;">
+                                    <button type="button" class="btn btn-secondary" style="padding: 8px 14px; font-size: 0.85em;" onclick="document.getElementById('chatFileInput').click()" title="Attach image (max 3, 5MB each)">+ Image</button>
+                                    <button class="btn btn-primary" id="chatSendBtn" style="padding: 8px 14px;" onclick="sendChatMessage()">Send</button>
+                                </div>
+                                <input type="file" id="chatFileInput" accept="image/jpeg,image/png,image/gif,image/webp" multiple style="display: none;" onchange="handleChatFilesPicked(event)">
                             </div>
                             <div id="chatStatus" style="color: #7f8c8d; font-size: 0.85em; margin-top: 6px; min-height: 1em;"></div>
                         </div>
@@ -9661,6 +9690,10 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
 
         let chatActiveConvId = null;
         let chatConversations = [];
+        let chatStagedFiles = [];
+        const CHAT_MAX_IMAGES = 3;
+        const CHAT_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+        const CHAT_ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 
         function updateChatModelUI() {{
             const model = document.getElementById('chatModel').value;
@@ -9778,15 +9811,121 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
                     meta.push((m.input_tokens || 0) + ' in / ' + (m.output_tokens || 0) + ' out');
                 }}
                 if (m.cache_read_input_tokens) meta.push(m.cache_read_input_tokens + ' cached');
+
+                let attachmentsHtml = '';
+                if (m.attachments && m.attachments.length) {{
+                    attachmentsHtml = '<div style="display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 6px;">' +
+                        m.attachments.map(att => {{
+                            const url = '/admin/analytics/conversations/' + chatActiveConvId + '/attachments/' + att.id;
+                            return `<a href="${{url}}" target="_blank" title="${{escapeHtmlChat(att.filename || '')}}"><img src="${{url}}" style="max-width: 180px; max-height: 140px; border-radius: 6px; border: 1px solid #ddd;"></a>`;
+                        }}).join('') +
+                        '</div>';
+                }}
+
                 return `
                     <div style="display: flex; justify-content: ${{align}}; margin-bottom: 14px;">
                         <div style="max-width: 85%;">
-                            <div style="background: ${{bg}}; color: ${{color}}; padding: 10px 14px; border-radius: 10px; white-space: pre-wrap; line-height: 1.5;">${{escapeHtmlChat(m.content)}}</div>
+                            ${{attachmentsHtml}}
+                            ${{m.content ? `<div style="background: ${{bg}}; color: ${{color}}; padding: 10px 14px; border-radius: 10px; white-space: pre-wrap; line-height: 1.5;">${{escapeHtmlChat(m.content)}}</div>` : ''}}
                             ${{!isUser && meta.length ? `<div style="font-size: 0.75em; color: #95a5a6; margin-top: 4px;">${{escapeHtmlChat(meta.join(' · '))}}</div>` : ''}}
                         </div>
                     </div>`;
             }}).join('');
             messagesEl.scrollTop = messagesEl.scrollHeight;
+        }}
+
+        // ---- File staging + drag-and-drop ----
+        function fmtChatBytes(n) {{
+            if (n < 1024) return n + ' B';
+            if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
+            return (n / (1024 * 1024)).toFixed(1) + ' MB';
+        }}
+
+        function renderStagedFiles() {{
+            const el = document.getElementById('chatStagedFiles');
+            if (chatStagedFiles.length === 0) {{
+                el.style.display = 'none';
+                el.innerHTML = '';
+                return;
+            }}
+            el.style.display = 'flex';
+            el.innerHTML = chatStagedFiles.map((f, idx) => {{
+                const url = URL.createObjectURL(f.file);
+                return `
+                    <div style="position: relative; width: 80px; height: 80px; border-radius: 6px; overflow: hidden; border: 1px solid #ddd; background: #f0f0f0;">
+                        <img src="${{url}}" style="width: 100%; height: 100%; object-fit: cover;">
+                        <button type="button" onclick="removeStagedFile(${{idx}})" title="Remove" style="position: absolute; top: 2px; right: 2px; background: rgba(0,0,0,0.6); color: white; border: none; border-radius: 50%; width: 22px; height: 22px; cursor: pointer; font-size: 14px; line-height: 1; padding: 0;">×</button>
+                        <div style="position: absolute; bottom: 0; left: 0; right: 0; background: rgba(0,0,0,0.6); color: white; font-size: 0.7em; padding: 2px 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">${{escapeHtmlChat(fmtChatBytes(f.file.size))}}</div>
+                    </div>`;
+            }}).join('');
+        }}
+
+        function removeStagedFile(idx) {{
+            chatStagedFiles.splice(idx, 1);
+            renderStagedFiles();
+        }}
+
+        function addStagedFiles(fileList) {{
+            const status = document.getElementById('chatStatus');
+            const incoming = Array.from(fileList || []);
+            const errors = [];
+            for (const f of incoming) {{
+                if (chatStagedFiles.length >= CHAT_MAX_IMAGES) {{
+                    errors.push('Max ' + CHAT_MAX_IMAGES + ' images per message');
+                    break;
+                }}
+                if (!CHAT_ALLOWED_MIME.includes(f.type)) {{
+                    errors.push(f.name + ': unsupported type (' + (f.type || 'unknown') + ')');
+                    continue;
+                }}
+                if (f.size > CHAT_MAX_IMAGE_BYTES) {{
+                    errors.push(f.name + ': too large (' + fmtChatBytes(f.size) + ')');
+                    continue;
+                }}
+                chatStagedFiles.push({{ file: f }});
+            }}
+            renderStagedFiles();
+            status.textContent = errors.length ? errors.join(' · ') : '';
+        }}
+
+        function handleChatFilesPicked(ev) {{
+            addStagedFiles(ev.target.files);
+            // Allow picking the same file twice in a row
+            ev.target.value = '';
+        }}
+
+        function setupChatDropZone() {{
+            const zone = document.getElementById('chatDropZone');
+            if (!zone || zone.dataset.dropWired === '1') return;
+            zone.dataset.dropWired = '1';
+            ['dragenter', 'dragover'].forEach(evt => {{
+                zone.addEventListener(evt, (e) => {{
+                    e.preventDefault();
+                    zone.style.borderColor = '#3498db';
+                }});
+            }});
+            ['dragleave', 'drop'].forEach(evt => {{
+                zone.addEventListener(evt, (e) => {{
+                    e.preventDefault();
+                    zone.style.borderColor = 'transparent';
+                }});
+            }});
+            zone.addEventListener('drop', (e) => {{
+                const files = e.dataTransfer && e.dataTransfer.files;
+                if (files && files.length) addStagedFiles(files);
+            }});
+            // Paste-to-attach from clipboard
+            document.getElementById('chatInput').addEventListener('paste', (e) => {{
+                const items = (e.clipboardData && e.clipboardData.items) || [];
+                const imgs = [];
+                for (const it of items) {{
+                    if (it.type && it.type.startsWith('image/')) {{
+                        const f = it.getAsFile();
+                        if (f) imgs.push(f);
+                    }}
+                }}
+                if (imgs.length) addStagedFiles(imgs);
+            }});
         }}
 
         function handleChatKey(e) {{
@@ -9803,7 +9942,7 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
             }}
             const inputEl = document.getElementById('chatInput');
             const question = (inputEl.value || '').trim();
-            if (!question) return;
+            if (!question && chatStagedFiles.length === 0) return;
 
             const model = document.getElementById('chatModel').value;
             const effort = document.getElementById('chatEffort').value;
@@ -9814,33 +9953,41 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
             btn.textContent = 'Thinking...';
             status.textContent = '';
 
-            // Optimistically append the user message
-            const messagesEl = document.getElementById('chatMessages');
+            // Optimistically append the user message (no thumbnails for staged files yet — keep it simple)
             const r0 = await fetch('/admin/analytics/conversations/' + chatActiveConvId);
             let existing = [];
             if (r0.ok) {{
                 const c = await r0.json();
                 existing = c.messages || [];
             }}
-            renderChatMessages([...existing, {{ role: 'user', content: question }}]);
+            const optimisticAttachments = chatStagedFiles.map(s => ({{
+                filename: s.file.name,
+                mime_type: s.file.type,
+            }}));
+            renderChatMessages([...existing, {{ role: 'user', content: question, attachments: [] }}]);
 
             try {{
+                const fd = new FormData();
+                fd.append('question', question);
+                fd.append('model', model);
+                fd.append('effort', effort);
+                for (const s of chatStagedFiles) fd.append('files', s.file, s.file.name);
+
                 const r = await fetch('/admin/analytics/conversations/' + chatActiveConvId + '/messages', {{
                     method: 'POST',
-                    headers: {{ 'Content-Type': 'application/json' }},
-                    body: JSON.stringify({{ question, model, effort }}),
+                    body: fd,
                 }});
                 const data = await r.json();
 
                 if (!r.ok || data.error) {{
                     status.textContent = 'Error: ' + (data.error || r.statusText);
-                    // Restore prior state (drop optimistic user msg)
                     renderChatMessages(existing);
                     return;
                 }}
 
                 inputEl.value = '';
-                // Reload the conversation to get the canonical message list
+                chatStagedFiles = [];
+                renderStagedFiles();
                 await openChatConversation(chatActiveConvId);
             }} catch (e) {{
                 status.textContent = 'Failed: ' + e.message;
@@ -9899,6 +10046,7 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
         document.addEventListener('DOMContentLoaded', function() {{
             updateChatModelUI();
             loadChatConversations();
+            setupChatDropZone();
         }});
 
         async function loadAISummaryHistory() {{

--- a/database.py
+++ b/database.py
@@ -675,6 +675,17 @@ def init_db():
             )""",
             "CREATE INDEX IF NOT EXISTS idx_analytics_messages_conv ON analytics_messages(conversation_id, created_at)",
             "CREATE INDEX IF NOT EXISTS idx_analytics_conversations_active ON analytics_conversations(archived, last_active_at DESC)",
+            # Attachments (images) uploaded to analytics chat messages
+            """CREATE TABLE IF NOT EXISTS analytics_attachments (
+                id SERIAL PRIMARY KEY,
+                message_id INTEGER NOT NULL REFERENCES analytics_messages(id) ON DELETE CASCADE,
+                filename TEXT,
+                mime_type TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL,
+                data BYTEA NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_analytics_attachments_message ON analytics_attachments(message_id)",
             # Nudge tracking for pending onboarding users
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS last_nudged_at TIMESTAMP",
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS nudge_count_24h INTEGER DEFAULT 0",

--- a/services/analytics_summary_service.py
+++ b/services/analytics_summary_service.py
@@ -4,9 +4,12 @@ Uses Claude API to generate daily analytics summaries with trend analysis
 from Google Analytics 4 and Search Console data.
 """
 
+import base64
 import json
 import logging
 from datetime import datetime, timedelta
+
+import psycopg2
 
 from database import get_db_cursor
 
@@ -505,6 +508,113 @@ def answer_analytics_question(
     }
 
 
+# Image attachment policy
+MAX_IMAGES_PER_MESSAGE = 3
+MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB
+ALLOWED_IMAGE_MIME_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+# Only include image BYTES on the last N user turns when calling Claude; older
+# turns keep their text so the model remembers the conversation, but the bytes
+# are dropped to keep long threads affordable.
+RECENT_IMAGE_TURN_LIMIT = 3
+
+
+def _validate_image(filename: str, mime_type: str, data: bytes) -> str:
+    """Return an error string if invalid, or None if OK."""
+    if not data:
+        return f"{filename or 'attachment'}: empty file"
+    if mime_type not in ALLOWED_IMAGE_MIME_TYPES:
+        return f"{filename or 'attachment'}: unsupported type '{mime_type}' (allowed: JPEG/PNG/GIF/WEBP)"
+    if len(data) > MAX_IMAGE_BYTES:
+        return f"{filename or 'attachment'}: too large ({len(data)} bytes; max {MAX_IMAGE_BYTES})"
+    return None
+
+
+def _insert_attachment(message_id: int, filename: str, mime_type: str, data: bytes) -> int:
+    with get_db_cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO analytics_attachments (message_id, filename, mime_type, size_bytes, data)
+            VALUES (%s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (message_id, filename, mime_type, len(data), psycopg2.Binary(data)),
+        )
+        return cur.fetchone()[0]
+
+
+def _get_attachments_metadata_by_message(message_ids: list) -> dict:
+    """Return {message_id: [ {id, filename, mime_type, size_bytes}, ... ]} for the given message ids."""
+    if not message_ids:
+        return {}
+    try:
+        with get_db_cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, message_id, filename, mime_type, size_bytes
+                FROM analytics_attachments
+                WHERE message_id = ANY(%s)
+                ORDER BY id ASC
+                """,
+                (list(message_ids),),
+            )
+            rows = cur.fetchall()
+        out = {}
+        for r in rows:
+            out.setdefault(r[1], []).append({
+                "id": r[0],
+                "filename": r[2],
+                "mime_type": r[3],
+                "size_bytes": r[4],
+            })
+        return out
+    except Exception as e:
+        logger.error(f"Error fetching attachment metadata: {e}")
+        return {}
+
+
+def get_attachment_bytes(att_id: int) -> tuple:
+    """Fetch raw attachment bytes for serving. Returns (bytes, mime_type, filename, message_id) or (None, None, None, None)."""
+    try:
+        with get_db_cursor() as cur:
+            cur.execute(
+                "SELECT data, mime_type, filename, message_id FROM analytics_attachments WHERE id = %s",
+                (att_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None, None, None, None
+            data = row[0]
+            if isinstance(data, memoryview):
+                data = bytes(data)
+            return data, row[1], row[2], row[3]
+    except Exception as e:
+        logger.error(f"Error fetching attachment {att_id}: {e}")
+        return None, None, None, None
+
+
+def _fetch_attachment_data_batch(att_ids: list) -> dict:
+    """Return {attachment_id: (bytes, mime_type)} for the given ids."""
+    if not att_ids:
+        return {}
+    try:
+        with get_db_cursor() as cur:
+            cur.execute(
+                "SELECT id, data, mime_type FROM analytics_attachments WHERE id = ANY(%s)",
+                (list(att_ids),),
+            )
+            rows = cur.fetchall()
+        out = {}
+        for r in rows:
+            data = r[1]
+            if isinstance(data, memoryview):
+                data = bytes(data)
+            out[r[0]] = (data, r[2])
+        return out
+    except Exception as e:
+        logger.error(f"Error batch-fetching attachments: {e}")
+        return {}
+
+
 _CONVERSATION_SYSTEM_PROMPT = (
     "You are an analytics expert for Remyndrs, an SMS-based AI memory and reminder service. "
     "You are in an ongoing planning conversation with the admin about website analytics and "
@@ -643,6 +753,8 @@ def get_conversation_with_messages(conv_id: int) -> dict:
                 (conv_id,),
             )
             msgs = cur.fetchall()
+        message_ids = [m[0] for m in msgs]
+        attachments_by_msg = _get_attachments_metadata_by_message(message_ids)
         conv["messages"] = [
             {
                 "id": m[0],
@@ -655,6 +767,7 @@ def get_conversation_with_messages(conv_id: int) -> dict:
                 "output_tokens": m[7],
                 "cache_read_input_tokens": m[8],
                 "created_at": m[9].isoformat() if m[9] else None,
+                "attachments": attachments_by_msg.get(m[0], []),
             }
             for m in msgs
         ]
@@ -722,17 +835,31 @@ def send_message_in_conversation(
     model_choice: str = "haiku",
     effort: str = "medium",
     period_days: int = 7,
+    image_files: list = None,
 ) -> dict:
     """Append a user message to a conversation, call Claude with full history, store the reply.
+
+    image_files: optional list of dicts with keys {filename, mime_type, data (bytes)} — attached
+    to the outgoing user message.
 
     Returns dict with keys:
         user_message (dict), assistant_message (dict), conversation (dict), error (on failure).
     """
     question = (question or "").strip()
-    if not question:
-        return {"error": "Question is required"}
+    image_files = image_files or []
+
+    # Allow image-only messages (common claude.ai pattern: drop an image, ask "thoughts?")
+    if not question and not image_files:
+        return {"error": "Question or at least one image is required"}
     if len(question) > 4000:
         return {"error": "Question too long (max 4000 chars)"}
+
+    if len(image_files) > MAX_IMAGES_PER_MESSAGE:
+        return {"error": f"Too many images (max {MAX_IMAGES_PER_MESSAGE} per message)"}
+    for f in image_files:
+        err = _validate_image(f.get("filename"), f.get("mime_type"), f.get("data"))
+        if err:
+            return {"error": err}
 
     model_key = (model_choice or "haiku").lower()
     if model_key not in _MODEL_ID_BY_CHOICE:
@@ -791,10 +918,65 @@ def send_message_in_conversation(
         },
     ]
 
+    # Decide which prior user turns should carry image bytes. Keep bytes on the most recent
+    # RECENT_IMAGE_TURN_LIMIT user turns (counting the new one being sent); older user turns
+    # drop image bytes but keep their text for conversational continuity.
+    prior_user_turns_with_images = []
+    for m in conv["messages"]:
+        if m["role"] == "user" and m.get("attachments"):
+            prior_user_turns_with_images.append(m["id"])
+    # Current turn occupies one slot
+    slots_for_prior = max(0, RECENT_IMAGE_TURN_LIMIT - 1)
+    include_image_ids_for_messages = set(prior_user_turns_with_images[-slots_for_prior:]) if slots_for_prior else set()
+
+    # Batch-fetch bytes for the attachments we actually need
+    att_ids_to_fetch = []
+    for m in conv["messages"]:
+        if m["id"] in include_image_ids_for_messages:
+            att_ids_to_fetch.extend([a["id"] for a in m.get("attachments", [])])
+    attachment_bytes = _fetch_attachment_data_batch(att_ids_to_fetch)
+
     messages = []
     for m in conv["messages"]:
-        messages.append({"role": m["role"], "content": m["content"]})
-    messages.append({"role": "user", "content": question})
+        if m["role"] == "user" and m["id"] in include_image_ids_for_messages and m.get("attachments"):
+            content = []
+            for att in m["attachments"]:
+                entry = attachment_bytes.get(att["id"])
+                if not entry:
+                    continue
+                data, mime = entry
+                content.append({
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime,
+                        "data": base64.b64encode(data).decode("ascii"),
+                    },
+                })
+            if m["content"]:
+                content.append({"type": "text", "text": m["content"]})
+            messages.append({"role": "user", "content": content or [{"type": "text", "text": ""}]})
+        else:
+            messages.append({"role": m["role"], "content": m["content"]})
+
+    # Build the new user message content (current turn includes its images)
+    new_user_content = []
+    for f in image_files:
+        new_user_content.append({
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": f["mime_type"],
+                "data": base64.b64encode(f["data"]).decode("ascii"),
+            },
+        })
+    if question:
+        new_user_content.append({"type": "text", "text": question})
+    if len(new_user_content) == 1 and new_user_content[0]["type"] == "text":
+        # Collapse single-text content to a string for API simplicity
+        messages.append({"role": "user", "content": question})
+    else:
+        messages.append({"role": "user", "content": new_user_content})
 
     kwargs = {
         "model": model_id,
@@ -827,6 +1009,7 @@ def send_message_in_conversation(
     cache_read = getattr(usage, "cache_read_input_tokens", None) if usage else None
 
     # Persist both turns and bump last_active_at. Auto-title on first user turn.
+    stored_attachments = []
     try:
         with get_db_cursor() as cur:
             is_first = len(conv["messages"]) == 0
@@ -834,6 +1017,14 @@ def send_message_in_conversation(
                 conv_id, "user", question,
                 model=model_id, effort=effort_to_send, data_source=data_source,
             )
+            for f in image_files:
+                att_id = _insert_attachment(user_msg_id, f.get("filename"), f["mime_type"], f["data"])
+                stored_attachments.append({
+                    "id": att_id,
+                    "filename": f.get("filename"),
+                    "mime_type": f["mime_type"],
+                    "size_bytes": len(f["data"]),
+                })
             assistant_msg_id = _insert_message(
                 conv_id, "assistant", answer_text,
                 model=model_id, effort=effort_to_send, data_source=data_source,
@@ -841,9 +1032,10 @@ def send_message_in_conversation(
                 cache_read_input_tokens=cache_read,
             )
             if is_first and (conv["title"] in (None, "", "New conversation")):
+                title_source = question if question else (image_files[0].get("filename") or "Image review")
                 cur.execute(
                     "UPDATE analytics_conversations SET title = %s, last_active_at = CURRENT_TIMESTAMP WHERE id = %s",
-                    (_auto_title(question), conv_id),
+                    (_auto_title(title_source), conv_id),
                 )
             else:
                 cur.execute(
@@ -861,6 +1053,7 @@ def send_message_in_conversation(
             "content": question,
             "model": model_id,
             "effort": effort_to_send,
+            "attachments": stored_attachments,
         },
         "assistant_message": {
             "id": assistant_msg_id,


### PR DESCRIPTION
## ⚠️ Stacked on #255
This PR's base is \`feature/threaded-analytics-chat\` (PR #255), not \`main\`. Merge #255 first, then this one will auto-retarget to \`main\` showing a clean image-only diff.

## Summary
Adds image attachments to the threaded analytics chat so you can share screenshots of landing pages, ad creatives, heatmaps, dashboards, etc. with Claude as part of an ongoing planning conversation — the same workflow you use on claude.ai. All three models (Haiku 4.5, Sonnet 4.6, Opus 4.7) support vision; Opus 4.7 has high-res (2576px long edge) so design mockups are read at pixel fidelity.

## Limits
- Max **3** images per message
- Max **5 MB** per image
- Formats: JPEG, PNG, GIF, WEBP

## Cost control
Only the last **3 user turns** send image bytes to Claude. Older turns keep their text for conversational continuity but drop the bytes — keeps long threads affordable. No client-side config needed; this is automatic.

## UI
- File picker button (\`+ Image\`) next to Send
- Drag-and-drop zone on the input area
- Clipboard paste (screenshot → Ctrl+V)
- Staged thumbnails with remove (×) before send
- Inline thumbnails in message history, click to open full-size

## Storage
Postgres \`BYTEA\` column (new \`analytics_attachments\` table). No filesystem config, no S3 bucket. Served back via admin-authed \`GET /admin/analytics/conversations/{conv_id}/attachments/{att_id}\` scoped to the owning conversation.

## Schema changes
- New \`analytics_attachments\` table in \`database.py\` init_db()
- Index on \`message_id\`
- Cascade-deletes when the parent message is deleted

## Test plan
- [x] \`python -m pytest tests/test_reminders.py tests/test_shared_lists.py\` — 94 passed
- [x] Validation paths (too many, oversize, bad mime, empty) return clean errors before any Claude call
- [x] \`admin_dashboard.py\` imports cleanly; 104 routes registered
- [ ] Post-deploy: upload a landing-page screenshot, ask "what would you change visually?" — verify image shown in message bubble and Claude references specific UI elements
- [ ] Post-deploy: follow up with a second screenshot in the same thread, verify Claude compares to the first
- [ ] Post-deploy: after 4+ turns with images, verify old image bytes are dropped from the Claude payload but old messages still show thumbnails in the UI
- [ ] Post-deploy: try uploading a PDF → expect clean error
- [ ] Post-deploy: try uploading 5 images → expect clean error about max 3
- [ ] Post-deploy: delete a conversation → verify attachment rows cascade-delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)