### PR TITLE
Add Investment Health admin dashboard

### DIFF
--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -4920,6 +4920,7 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
         <span class="nav-title">Remyndrs Dashboard</span>
         <button onclick="showRecentMessages()" style="padding: 8px 16px; background: #9b59b6; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9em; font-weight: 500;">Recent Messages</button>
         <a href="/admin/monitoring" style="padding: 8px 16px; background: #27ae60; color: white; border: none; border-radius: 4px; text-decoration: none; font-size: 0.9em; font-weight: 500;">Monitoring</a>
+        <a href="/admin/investment-health" style="padding: 8px 16px; background: #2c3e50; color: white; border: none; border-radius: 4px; text-decoration: none; font-size: 0.9em; font-weight: 500;">Investment Health</a>
         <a href="#overview">Overview</a>
         <a href="#broadcast">Broadcast</a>
         <a href="#support">Support Tickets</a>
@@ -10112,6 +10113,454 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
         // Load AI summary on page load
         loadAISummary();
 
+    </script>
+</body>
+</html>
+    """
+
+    return HTMLResponse(content=html)
+
+
+# =====================================================
+# INVESTMENT HEALTH DASHBOARD
+# =====================================================
+
+@router.get("/admin/investment-health/data")
+async def admin_investment_health_data(admin: str = Depends(verify_admin)):
+    """Live Stripe-derived inputs for the Investment Health page."""
+    from services.stripe_service import get_investment_health_metrics
+    from services.investment_health import DEFAULT_INPUTS
+
+    live = get_investment_health_metrics()
+    return JSONResponse({
+        "live": live,
+        "manual_defaults": {
+            "cac": DEFAULT_INPUTS["cac"],
+            "monthly_burn": DEFAULT_INPUTS["monthly_burn"],
+        },
+    })
+
+
+@router.get("/admin/investment-health", response_class=HTMLResponse)
+async def admin_investment_health(admin: str = Depends(verify_admin)):
+    """Interactive investment-health decision tool — live Stripe metrics with
+    manual override per input, reactive verdict card, and 6 health checks."""
+    html = """
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Investment Health · Remyndrs Admin</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: #f5f5f5;
+            padding: 20px;
+            color: #333;
+        }
+        h1 { margin-bottom: 8px; color: #2c3e50; }
+        h2 { margin: 24px 0 12px; color: #34495e; font-size: 1.2em; }
+        .subhead { color: #7f8c8d; margin-bottom: 20px; font-size: 0.95em; }
+
+        .nav-menu {
+            position: sticky; top: 0; background: white;
+            padding: 12px 20px; margin: -20px -20px 20px -20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            z-index: 100; display: flex; gap: 8px; flex-wrap: wrap; align-items: center;
+        }
+        .nav-menu a {
+            padding: 8px 16px; background: #f8f9fa; border-radius: 4px;
+            text-decoration: none; color: #2c3e50; font-size: 0.9em;
+            font-weight: 500; transition: all 0.2s; border: 1px solid #e0e0e0;
+        }
+        .nav-menu a:hover { background: #3498db; color: white; border-color: #3498db; }
+        .nav-menu .nav-title { font-weight: bold; color: #2c3e50; margin-right: 10px; }
+
+        .header-row {
+            display: flex; justify-content: space-between; align-items: center;
+            flex-wrap: wrap; gap: 12px; margin-bottom: 20px;
+        }
+        .reset-btn {
+            padding: 10px 20px; background: #3498db; color: white;
+            border: none; border-radius: 4px; cursor: pointer;
+            font-size: 0.95em; font-weight: 500;
+        }
+        .reset-btn:hover { background: #2980b9; }
+        .reset-btn:disabled { background: #bdc3c7; cursor: not-allowed; }
+        .last-synced { color: #95a5a6; font-size: 0.85em; }
+
+        .inputs-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 15px; margin-bottom: 30px;
+        }
+        .input-card {
+            background: white; padding: 18px; border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .input-label {
+            font-size: 0.9em; color: #7f8c8d; margin-bottom: 8px;
+            display: flex; justify-content: space-between; align-items: center;
+        }
+        .badge {
+            font-size: 0.7em; padding: 2px 8px; border-radius: 10px;
+            font-weight: 600; cursor: pointer; user-select: none;
+        }
+        .badge.live { background: #d5f5e3; color: #27ae60; }
+        .badge.manual { background: #fdebd0; color: #e67e22; }
+        .badge.manual-only { background: #ecf0f1; color: #7f8c8d; cursor: default; }
+        .input-row { display: flex; align-items: center; gap: 10px; }
+        .input-row input[type="number"] {
+            flex: 1; padding: 8px 10px; font-size: 1.3em;
+            border: 1px solid #e0e0e0; border-radius: 4px; font-weight: 600;
+            color: #2c3e50; background: white;
+        }
+        .input-row input[type="number"]:focus { outline: none; border-color: #3498db; }
+        .input-prefix { font-size: 1.3em; color: #95a5a6; font-weight: 600; }
+        .input-suffix { font-size: 1.1em; color: #95a5a6; font-weight: 500; }
+
+        .verdict-card {
+            padding: 24px 28px; border-radius: 8px; color: white;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.15); margin-bottom: 30px;
+        }
+        .verdict-card.green { background: linear-gradient(135deg, #27ae60, #229954); }
+        .verdict-card.yellow { background: linear-gradient(135deg, #f39c12, #d68910); }
+        .verdict-card.red { background: linear-gradient(135deg, #e74c3c, #c0392b); }
+        .verdict-title { font-size: 1.6em; font-weight: 700; margin-bottom: 8px; }
+        .verdict-message { font-size: 1em; line-height: 1.5; opacity: 0.95; }
+
+        .checks-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 15px;
+        }
+        .check-card {
+            background: white; padding: 18px; border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .check-header {
+            display: flex; align-items: center; gap: 8px; margin-bottom: 10px;
+        }
+        .status-dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
+        .status-dot.green { background: #27ae60; }
+        .status-dot.yellow { background: #f39c12; }
+        .status-dot.red { background: #e74c3c; }
+        .check-label { color: #7f8c8d; font-size: 0.9em; font-weight: 500; }
+        .check-value {
+            font-size: 1.8em; font-weight: bold; color: #2c3e50; margin-bottom: 4px;
+        }
+        .check-context { font-size: 0.8em; color: #95a5a6; }
+
+        .loading-overlay {
+            position: fixed; inset: 0; background: rgba(255,255,255,0.85);
+            display: flex; align-items: center; justify-content: center;
+            font-size: 1.1em; color: #7f8c8d; z-index: 200;
+        }
+    </style>
+</head>
+<body>
+    <div class="nav-menu">
+        <span class="nav-title">Remyndrs Dashboard</span>
+        <a href="/admin/dashboard">Back to Dashboard</a>
+        <a href="/admin/monitoring" style="background: #27ae60; color: white; border-color: #27ae60;">Monitoring</a>
+    </div>
+
+    <h1>Investment Health</h1>
+    <p class="subhead">Decision-support tool: should we keep investing? Pulls live Stripe metrics; click any "live" badge to switch to manual entry for "what if" scenarios.</p>
+
+    <div class="header-row">
+        <button class="reset-btn" id="resetBtn" onclick="resetToLive()">Reset to live data</button>
+        <span class="last-synced" id="lastSynced">Loading…</span>
+    </div>
+
+    <div id="loadingOverlay" class="loading-overlay">Loading live Stripe data…</div>
+
+    <h2>Inputs</h2>
+    <div class="inputs-grid" id="inputsGrid"></div>
+
+    <div class="verdict-card yellow" id="verdictCard">
+        <div class="verdict-title" id="verdictTitle">—</div>
+        <div class="verdict-message" id="verdictMessage">Computing…</div>
+    </div>
+
+    <h2>Health checks</h2>
+    <div class="checks-grid" id="checksGrid"></div>
+
+    <script>
+        // ------- input definitions -------
+        const INPUTS = [
+            {key: 'current_users', label: 'Current paid users', live: true, type: 'int'},
+            {key: 'net_now',       label: 'Net new paid this month', live: true, type: 'int'},
+            {key: 'net_3mo',       label: 'Net new paid 3 months ago', live: true, type: 'int'},
+            {key: 'churn_rate',    label: 'Monthly churn rate', live: true, type: 'percent', min: 1, step: 0.1},
+            {key: 'cac',           label: 'Blended CAC', live: false, type: 'currency', min: 0},
+            {key: 'arpu',          label: 'Net revenue per user', live: true, type: 'currency', min: 0, step: 0.5},
+            {key: 'monthly_burn',  label: 'Monthly burn', live: false, type: 'currency', min: 0},
+        ];
+
+        // state.values holds the *current* shown value (live or manual)
+        // state.live holds the most recent live data
+        // state.mode[key] is 'live' or 'manual'
+        const state = { values: {}, live: {}, mode: {} };
+
+        // ------- math (mirrors services/investment_health.py) -------
+        function clampChurn(p) { return Math.max(p, 1.0); }
+
+        function computeDerived(v) {
+            const churn_d = clampChurn(v.churn_rate) / 100.0;
+            let ltv, ltv_cac, payback, breakeven_users;
+            if (v.arpu <= 0) {
+                ltv = 0; ltv_cac = 0; payback = Infinity; breakeven_users = Infinity;
+            } else {
+                ltv = v.arpu / churn_d;
+                ltv_cac = v.cac > 0 ? ltv / v.cac : Infinity;
+                payback = v.cac / v.arpu;
+                breakeven_users = v.monthly_burn / v.arpu;
+            }
+            const gross_adds = Math.max(0, v.net_now + v.current_users * churn_d);
+            const steady_state = churn_d > 0 ? gross_adds / churn_d : Infinity;
+            const can_reach = steady_state >= breakeven_users;
+
+            let months_to_breakeven = null;
+            if (v.current_users >= breakeven_users) {
+                months_to_breakeven = 0;
+            } else if (can_reach && v.net_now > 0) {
+                let u = v.current_users, m = 0;
+                while (u < breakeven_users && m < 240) {
+                    u = u * (1 - churn_d) + gross_adds;
+                    m += 1;
+                }
+                months_to_breakeven = m < 240 ? m : null;
+            }
+
+            return {
+                ltv, ltv_cac, payback, breakeven_users,
+                gross_adds, steady_state, can_reach, months_to_breakeven,
+                growth_delta: v.net_now - v.net_3mo,
+            };
+        }
+
+        function statusOf(metric, v, d) {
+            if (metric === 'churn') {
+                if (v.churn_rate < 7) return 'green';
+                if (v.churn_rate <= 10) return 'yellow';
+                return 'red';
+            }
+            if (metric === 'growth') {
+                if (v.net_now <= 0) return 'red';
+                return d.growth_delta >= -3 ? 'green' : 'yellow';
+            }
+            if (metric === 'ltv_cac') {
+                if (d.ltv_cac >= 3.0) return 'green';
+                if (d.ltv_cac >= 1.5) return 'yellow';
+                return 'red';
+            }
+            if (metric === 'payback') {
+                if (d.payback < 12) return 'green';
+                if (d.payback <= 24) return 'yellow';
+                return 'red';
+            }
+            if (metric === 'breakeven') {
+                if (d.months_to_breakeven === null) return 'red';
+                if (d.months_to_breakeven <= 12) return 'green';
+                if (d.months_to_breakeven <= 24) return 'yellow';
+                return 'red';
+            }
+            if (metric === 'steady_state') {
+                if (d.breakeven_users <= 0 || !isFinite(d.breakeven_users)) return 'red';
+                const r = d.steady_state / d.breakeven_users;
+                if (r >= 1.3) return 'green';
+                if (r >= 1.0) return 'yellow';
+                return 'red';
+            }
+        }
+
+        function verdictFor(checks) {
+            const primary = ['churn', 'growth', 'ltv_cac', 'breakeven'].map(k => checks[k]);
+            const red_count = primary.filter(s => s === 'red').length;
+            const green_count = primary.filter(s => s === 'green').length;
+            const critical_red = checks.churn === 'red' || checks.ltv_cac === 'red';
+
+            if (critical_red || red_count >= 2) {
+                return {
+                    color: 'red', title: 'Stop or restructure',
+                    message: red_count + " critical fail(s). Unit economics or product stickiness won't fix themselves with more ad spend. Cut burn, fix retention or pricing, or wind down before adding more capital.",
+                };
+            }
+            if (green_count >= 3) {
+                return {
+                    color: 'green', title: 'Continue investing',
+                    message: green_count + " of 4 health checks pass. Slower ramp than original target is fine — the underlying business works. Keep optimizing creative, conversion, and the upgrade flow.",
+                };
+            }
+            return {
+                color: 'yellow', title: 'Pivot before reinvesting',
+                message: green_count + " of 4 pass, " + red_count + " fail. Fixable problem in one dimension. Address the weak metric before adding more spend — don't double down on a leak.",
+            };
+        }
+
+        // ------- formatting -------
+        const fmtCurrency = n => '$' + Math.round(n).toLocaleString();
+        const fmtCount = n => Math.round(n).toLocaleString();
+        const fmtPercent = n => n.toFixed(1) + '%';
+        const fmtRatio = n => isFinite(n) ? n.toFixed(1) + 'x' : '∞';
+        const fmtMonths = m => m === null ? 'Never' : (m >= 240 ? '>20 yr' : m + ' mo');
+
+        // ------- rendering -------
+        function renderInputs() {
+            const grid = document.getElementById('inputsGrid');
+            grid.innerHTML = '';
+            INPUTS.forEach(inp => {
+                const card = document.createElement('div');
+                card.className = 'input-card';
+
+                let badge;
+                if (!inp.live) {
+                    badge = '<span class="badge manual-only">manual</span>';
+                } else {
+                    const m = state.mode[inp.key] || 'live';
+                    badge = `<span class="badge ${m}" onclick="toggleMode('${inp.key}')" title="Click to ${m === 'live' ? 'override manually' : 'restore live value'}">${m}</span>`;
+                }
+
+                let prefix = '', suffix = '', step = inp.step || 1, min = inp.min;
+                if (inp.type === 'currency') prefix = '$';
+                if (inp.type === 'percent') suffix = '%';
+
+                card.innerHTML = `
+                    <div class="input-label">
+                        <span>${inp.label}</span>
+                        ${badge}
+                    </div>
+                    <div class="input-row">
+                        ${prefix ? '<span class="input-prefix">' + prefix + '</span>' : ''}
+                        <input type="number" id="input_${inp.key}" value="${state.values[inp.key]}" step="${step}" ${min !== undefined ? 'min="' + min + '"' : ''} oninput="onInput('${inp.key}', this.value)">
+                        ${suffix ? '<span class="input-suffix">' + suffix + '</span>' : ''}
+                    </div>
+                `;
+                grid.appendChild(card);
+            });
+        }
+
+        function renderResults() {
+            const v = state.values;
+            const d = computeDerived(v);
+            const checks = {
+                churn: statusOf('churn', v, d),
+                growth: statusOf('growth', v, d),
+                ltv_cac: statusOf('ltv_cac', v, d),
+                payback: statusOf('payback', v, d),
+                breakeven: statusOf('breakeven', v, d),
+                steady_state: statusOf('steady_state', v, d),
+            };
+            const verdict = verdictFor(checks);
+
+            const card = document.getElementById('verdictCard');
+            card.className = 'verdict-card ' + verdict.color;
+            document.getElementById('verdictTitle').textContent = verdict.title;
+            document.getElementById('verdictMessage').textContent = verdict.message;
+
+            const cardDefs = [
+                {k: 'churn',        label: 'Monthly churn',     value: fmtPercent(v.churn_rate), context: 'trailing 90 days'},
+                {k: 'growth',       label: 'Growth trend',      value: (d.growth_delta >= 0 ? '+' : '') + Math.round(d.growth_delta), context: Math.round(v.net_now) + ' now vs ' + Math.round(v.net_3mo) + ' three months ago'},
+                {k: 'ltv_cac',      label: 'LTV / CAC',         value: fmtRatio(d.ltv_cac), context: 'LTV ' + fmtCurrency(d.ltv) + ' / CAC ' + fmtCurrency(v.cac)},
+                {k: 'payback',      label: 'CAC payback',       value: isFinite(d.payback) ? d.payback.toFixed(1) + ' mo' : '∞', context: 'months to recover acquisition cost'},
+                {k: 'breakeven',    label: 'Months to breakeven', value: fmtMonths(d.months_to_breakeven), context: 'need ' + fmtCount(d.breakeven_users) + ' paid users'},
+                {k: 'steady_state', label: 'Steady-state ceiling', value: fmtCount(d.steady_state), context: 'breakeven needs ' + fmtCount(d.breakeven_users)},
+            ];
+
+            const grid = document.getElementById('checksGrid');
+            grid.innerHTML = cardDefs.map(c => `
+                <div class="check-card">
+                    <div class="check-header">
+                        <span class="status-dot ${checks[c.k]}"></span>
+                        <span class="check-label">${c.label}</span>
+                    </div>
+                    <div class="check-value">${c.value}</div>
+                    <div class="check-context">${c.context}</div>
+                </div>
+            `).join('');
+        }
+
+        // ------- event handlers -------
+        function onInput(key, raw) {
+            const inp = INPUTS.find(i => i.key === key);
+            let val = parseFloat(raw);
+            if (isNaN(val)) val = 0;
+            if (inp.min !== undefined && val < inp.min) val = inp.min;
+            state.values[key] = val;
+            if (inp.live) state.mode[key] = 'manual';
+            renderInputs();
+            // re-focus the changed input so the user can keep typing
+            const el = document.getElementById('input_' + key);
+            if (el) { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }
+            renderResults();
+        }
+
+        function toggleMode(key) {
+            const inp = INPUTS.find(i => i.key === key);
+            if (!inp.live) return;
+            if (state.mode[key] === 'manual') {
+                // restore live
+                state.mode[key] = 'live';
+                state.values[key] = state.live[key];
+            } else {
+                // switch to manual (keeps current value)
+                state.mode[key] = 'manual';
+            }
+            renderInputs();
+            renderResults();
+        }
+
+        function resetToLive() {
+            INPUTS.forEach(inp => {
+                if (inp.live) {
+                    state.mode[inp.key] = 'live';
+                    state.values[inp.key] = state.live[inp.key];
+                }
+            });
+            renderInputs();
+            renderResults();
+        }
+
+        async function loadLive() {
+            try {
+                const res = await fetch('/admin/investment-health/data', {credentials: 'same-origin'});
+                if (!res.ok) throw new Error('HTTP ' + res.status);
+                const data = await res.json();
+                const live = data.live || {};
+                const manual_defaults = data.manual_defaults || {};
+
+                state.live = {
+                    current_users: live.current_users ?? 0,
+                    net_now: live.net_now ?? 0,
+                    net_3mo: live.net_3mo ?? 0,
+                    churn_rate: live.churn_rate ?? 7,
+                    arpu: live.arpu ?? 8,
+                };
+                state.values = {
+                    ...state.live,
+                    cac: manual_defaults.cac ?? 60,
+                    monthly_burn: manual_defaults.monthly_burn ?? 4167,
+                };
+                INPUTS.forEach(i => { if (i.live) state.mode[i.key] = 'live'; });
+
+                const ts = live.fetched_at ? new Date(live.fetched_at).toLocaleString() : 'unknown';
+                let label = 'Live data synced ' + ts;
+                if (live.error) label += ' · ' + live.error + ' (using fallback values)';
+                document.getElementById('lastSynced').textContent = label;
+            } catch (e) {
+                document.getElementById('lastSynced').textContent = 'Could not load live data: ' + e.message + ' (using defaults)';
+                state.live = { current_users: 0, net_now: 0, net_3mo: 0, churn_rate: 7, arpu: 8 };
+                state.values = { ...state.live, cac: 60, monthly_burn: 4167 };
+                INPUTS.forEach(i => { if (i.live) state.mode[i.key] = 'live'; });
+            } finally {
+                document.getElementById('loadingOverlay').style.display = 'none';
+                renderInputs();
+                renderResults();
+            }
+        }
+
+        loadLive();
     </script>
 </body>
 </html>

--- a/services/investment_health.py
+++ b/services/investment_health.py
@@ -1,0 +1,362 @@
+"""
+Investment Health calculations.
+
+Pure functions that turn 7 business inputs (users, growth, churn, CAC, ARPU,
+burn) into SaaS unit economics + a green/yellow/red verdict for the admin
+"keep investing?" dashboard.
+
+No I/O — every input is passed in, every output is returned. Stripe and HTTP
+live in admin_dashboard.py. Tests live in tests/test_investment_health.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Defaults — used when Stripe is unreachable or returns no data, and as the
+# initial values for the two manual-only inputs (CAC, burn).
+# ---------------------------------------------------------------------------
+
+DEFAULT_INPUTS = {
+    "current_users": 0,
+    "net_now": 0,
+    "net_3mo": 0,
+    "churn_rate": 7.0,        # percent
+    "cac": 60.0,              # dollars (manual only)
+    "arpu": 8.0,              # dollars (net of $1 SMS cost)
+    "monthly_burn": 4167.0,   # dollars (manual only)
+}
+
+# SMS cost subtracted from gross ARPU when computing net revenue per user.
+SMS_COST_PER_USER = 1.0
+
+# Below this churn rate the LTV math explodes — clamp to keep numbers honest.
+MIN_CHURN_PERCENT = 1.0
+
+# Hard cap on the "months to breakeven" simulation loop.
+MAX_BREAKEVEN_MONTHS = 240
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class HealthCheck:
+    metric: str
+    value: float
+    display: str
+    status: str       # "green" | "yellow" | "red"
+    context: str = ""
+
+
+@dataclass
+class HealthReport:
+    inputs: dict
+    derived: dict
+    checks: dict[str, HealthCheck]
+    verdict: str          # "Continue investing" | "Pivot before reinvesting" | "Stop or restructure"
+    verdict_color: str    # "green" | "yellow" | "red"
+    message: str
+
+    def to_dict(self) -> dict:
+        return {
+            "inputs": self.inputs,
+            "derived": self.derived,
+            "checks": {k: asdict(v) for k, v in self.checks.items()},
+            "verdict": self.verdict,
+            "verdict_color": self.verdict_color,
+            "message": self.message,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core math
+# ---------------------------------------------------------------------------
+
+def _clamp_churn(churn_percent: float) -> float:
+    return max(churn_percent, MIN_CHURN_PERCENT)
+
+
+def compute_derived(
+    current_users: float,
+    net_now: float,
+    net_3mo: float,
+    churn_rate: float,
+    cac: float,
+    arpu: float,
+    monthly_burn: float,
+) -> dict:
+    """Compute everything downstream from the 7 inputs.
+
+    `churn_rate` is a percent (e.g. 7 means 7%). All currency values are
+    monthly dollars.
+    """
+    churn_d = _clamp_churn(churn_rate) / 100.0
+
+    # Avoid divide-by-zero on the rare case where someone enters arpu=0 in
+    # the UI. Treat 0 ARPU as "infinite payback / unreachable breakeven".
+    if arpu <= 0:
+        ltv = 0.0
+        ltv_cac = 0.0
+        cac_payback_months = float("inf")
+        breakeven_users = float("inf")
+    else:
+        ltv = arpu / churn_d
+        ltv_cac = ltv / cac if cac > 0 else float("inf")
+        cac_payback_months = cac / arpu
+        breakeven_users = monthly_burn / arpu
+
+    # gross_adds = net adds + users that churned this month. Floor at 0 so
+    # a shrinking month doesn't produce negative acquisition.
+    gross_adds = max(0.0, net_now + current_users * churn_d)
+
+    # Steady-state user base: where the population plateaus given current
+    # acquisition rate and churn. gross_adds / churn_d.
+    steady_state = gross_adds / churn_d if churn_d > 0 else float("inf")
+
+    can_reach_breakeven = steady_state >= breakeven_users
+
+    # Months to breakeven — simulate month-by-month because net adds
+    # decline as the base grows (more users, more churn).
+    months_to_breakeven: Optional[int]
+    if can_reach_breakeven and net_now > 0 and current_users < breakeven_users:
+        u = float(current_users)
+        m = 0
+        while u < breakeven_users and m < MAX_BREAKEVEN_MONTHS:
+            u = u * (1 - churn_d) + gross_adds
+            m += 1
+        months_to_breakeven = m if m < MAX_BREAKEVEN_MONTHS else None
+    elif current_users >= breakeven_users:
+        months_to_breakeven = 0
+    else:
+        months_to_breakeven = None
+
+    return {
+        "ltv": ltv,
+        "ltv_cac": ltv_cac,
+        "cac_payback_months": cac_payback_months,
+        "breakeven_users": breakeven_users,
+        "gross_adds": gross_adds,
+        "steady_state": steady_state,
+        "can_reach_breakeven": can_reach_breakeven,
+        "months_to_breakeven": months_to_breakeven,
+        "growth_delta": net_now - net_3mo,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Status thresholds
+# ---------------------------------------------------------------------------
+
+def churn_status(churn_percent: float) -> str:
+    if churn_percent < 7:
+        return "green"
+    if churn_percent <= 10:
+        return "yellow"
+    return "red"
+
+
+def growth_status(net_now: float, net_3mo: float) -> str:
+    """Green if growing, holding, or only mildly decelerating; red if net adds
+    have stopped or gone negative."""
+    if net_now <= 0:
+        return "red"
+    delta = net_now - net_3mo
+    if delta >= -3:
+        return "green"
+    return "yellow"
+
+
+def ltv_cac_status(ratio: float) -> str:
+    if ratio >= 3.0:
+        return "green"
+    if ratio >= 1.5:
+        return "yellow"
+    return "red"
+
+
+def cac_payback_status(months: float) -> str:
+    if months < 12:
+        return "green"
+    if months <= 24:
+        return "yellow"
+    return "red"
+
+
+def breakeven_months_status(months: Optional[int]) -> str:
+    if months is None:
+        return "red"
+    if months <= 12:
+        return "green"
+    if months <= 24:
+        return "yellow"
+    return "red"
+
+
+def steady_state_status(steady_state: float, breakeven_users: float) -> str:
+    if breakeven_users <= 0 or breakeven_users == float("inf"):
+        return "red"
+    ratio = steady_state / breakeven_users
+    if ratio >= 1.3:
+        return "green"
+    if ratio >= 1.0:
+        return "yellow"
+    return "red"
+
+
+# ---------------------------------------------------------------------------
+# Display helpers
+# ---------------------------------------------------------------------------
+
+def _format_breakeven(months: Optional[int]) -> str:
+    if months is None:
+        return "Never"
+    if months >= MAX_BREAKEVEN_MONTHS:
+        return ">20 yr"
+    return f"{months} mo"
+
+
+def _format_currency(amount: float) -> str:
+    return f"${round(amount):,}"
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+def _verdict(checks: dict[str, HealthCheck]) -> tuple[str, str, str]:
+    """Returns (verdict, color, message). Uses only the 4 primary checks:
+    churn, growth_trend, ltv_cac, breakeven_months. CAC payback and
+    steady-state are diagnostic only."""
+    primary = [
+        checks["churn"].status,
+        checks["growth_trend"].status,
+        checks["ltv_cac"].status,
+        checks["breakeven_months"].status,
+    ]
+    red_count = sum(1 for s in primary if s == "red")
+    green_count = sum(1 for s in primary if s == "green")
+
+    critical_red = checks["churn"].status == "red" or checks["ltv_cac"].status == "red"
+
+    if critical_red or red_count >= 2:
+        return (
+            "Stop or restructure",
+            "red",
+            f"{red_count} critical fail(s). Unit economics or product stickiness "
+            f"won't fix themselves with more ad spend. Cut burn, fix retention or "
+            f"pricing, or wind down before adding more capital.",
+        )
+    if green_count >= 3:
+        return (
+            "Continue investing",
+            "green",
+            f"{green_count} of 4 health checks pass. Slower ramp than original "
+            f"target is fine — the underlying business works. Keep optimizing "
+            f"creative, conversion, and the upgrade flow.",
+        )
+    return (
+        "Pivot before reinvesting",
+        "yellow",
+        f"{green_count} of 4 pass, {red_count} fail. Fixable problem in one "
+        f"dimension. Address the weak metric before adding more spend — "
+        f"don't double down on a leak.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+def evaluate(
+    current_users: float,
+    net_now: float,
+    net_3mo: float,
+    churn_rate: float,
+    cac: float,
+    arpu: float,
+    monthly_burn: float,
+) -> HealthReport:
+    """Run the full pipeline: derive metrics, score each check, compute verdict."""
+    derived = compute_derived(
+        current_users, net_now, net_3mo, churn_rate, cac, arpu, monthly_burn
+    )
+
+    checks: dict[str, HealthCheck] = {}
+
+    checks["churn"] = HealthCheck(
+        metric="Monthly churn",
+        value=churn_rate,
+        display=f"{churn_rate:.1f}%",
+        status=churn_status(churn_rate),
+        context="trailing 90 days",
+    )
+
+    growth_delta = derived["growth_delta"]
+    sign = "+" if growth_delta >= 0 else ""
+    checks["growth_trend"] = HealthCheck(
+        metric="Growth trend",
+        value=growth_delta,
+        display=f"{sign}{round(growth_delta)}",
+        status=growth_status(net_now, net_3mo),
+        context=f"{round(net_now)} now vs {round(net_3mo)} three months ago",
+    )
+
+    checks["ltv_cac"] = HealthCheck(
+        metric="LTV / CAC",
+        value=derived["ltv_cac"],
+        display=f"{derived['ltv_cac']:.1f}x",
+        status=ltv_cac_status(derived["ltv_cac"]),
+        context=f"LTV {_format_currency(derived['ltv'])} / CAC {_format_currency(cac)}",
+    )
+
+    checks["cac_payback"] = HealthCheck(
+        metric="CAC payback",
+        value=derived["cac_payback_months"],
+        display=(
+            f"{derived['cac_payback_months']:.1f} mo"
+            if derived["cac_payback_months"] != float("inf")
+            else "∞"
+        ),
+        status=cac_payback_status(derived["cac_payback_months"]),
+        context="months to recover acquisition cost",
+    )
+
+    checks["breakeven_months"] = HealthCheck(
+        metric="Months to breakeven",
+        value=derived["months_to_breakeven"] if derived["months_to_breakeven"] is not None else -1,
+        display=_format_breakeven(derived["months_to_breakeven"]),
+        status=breakeven_months_status(derived["months_to_breakeven"]),
+        context=f"need {round(derived['breakeven_users']):,} paid users",
+    )
+
+    checks["steady_state"] = HealthCheck(
+        metric="Steady-state ceiling",
+        value=derived["steady_state"],
+        display=f"{round(derived['steady_state']):,}",
+        status=steady_state_status(derived["steady_state"], derived["breakeven_users"]),
+        context=f"breakeven needs {round(derived['breakeven_users']):,}",
+    )
+
+    verdict, color, message = _verdict(checks)
+
+    return HealthReport(
+        inputs={
+            "current_users": current_users,
+            "net_now": net_now,
+            "net_3mo": net_3mo,
+            "churn_rate": churn_rate,
+            "cac": cac,
+            "arpu": arpu,
+            "monthly_burn": monthly_burn,
+        },
+        derived=derived,
+        checks=checks,
+        verdict=verdict,
+        verdict_color=color,
+        message=message,
+    )

--- a/services/stripe_service.py
+++ b/services/stripe_service.py
@@ -4,7 +4,7 @@ Handles all Stripe payment and subscription operations
 """
 
 import stripe
-from datetime import datetime
+from datetime import datetime, timedelta
 from database import get_db_connection, return_db_connection
 from config import (
     logger, STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET,
@@ -618,3 +618,192 @@ def get_upgrade_message(phone_number: str) -> str:
 - Cancel anytime
 
 Text PREMIUM to get your upgrade link."""
+
+
+# =====================================================
+# INVESTMENT HEALTH METRICS
+# =====================================================
+# One fetch of all subscriptions powers five metrics. Cached briefly so the
+# admin page can be opened repeatedly without re-paginating Stripe.
+
+_INVESTMENT_METRICS_CACHE: dict = {"data": None, "fetched_at": 0.0}
+_INVESTMENT_METRICS_TTL = 300  # 5 minutes
+
+
+def _normalized_monthly_amount(subscription) -> float:
+    """Return the monthly USD amount for a subscription, normalizing yearly to /12."""
+    try:
+        items = subscription.get('items', {}).get('data', [])
+        if not items:
+            return 0.0
+        price = items[0].get('price', {}) or {}
+        amount_cents = price.get('unit_amount') or 0
+        recurring = price.get('recurring', {}) or {}
+        interval = recurring.get('interval', 'month')
+        interval_count = recurring.get('interval_count') or 1
+        amount = amount_cents / 100.0
+        if interval == 'year':
+            return amount / (12 * interval_count)
+        if interval == 'month':
+            return amount / interval_count
+        if interval == 'week':
+            return amount * (52 / 12) / interval_count
+        if interval == 'day':
+            return amount * (365 / 12) / interval_count
+        return amount
+    except Exception:
+        return 0.0
+
+
+def get_investment_health_metrics(force_refresh: bool = False) -> dict:
+    """
+    Fetch and compute the live inputs for the Investment Health dashboard.
+
+    Returns a dict with:
+      - current_users: count of active subscriptions
+      - net_now: new subs minus cancellations, this calendar month to date (UTC)
+      - net_3mo: same metric, full calendar month from 3 months ago
+      - churn_rate: trailing 90-day avg monthly churn (%)
+      - arpu: avg MRR per active sub minus $1 SMS cost
+      - fetched_at: ISO timestamp
+      - error: optional error message (other fields still set to defaults)
+
+    Falls back to defaults from services.investment_health.DEFAULT_INPUTS if
+    Stripe is unavailable or returns no data.
+    """
+    import time
+    from services.investment_health import DEFAULT_INPUTS, SMS_COST_PER_USER
+
+    now_ts = time.time()
+    if (
+        not force_refresh
+        and _INVESTMENT_METRICS_CACHE["data"] is not None
+        and now_ts - _INVESTMENT_METRICS_CACHE["fetched_at"] < _INVESTMENT_METRICS_TTL
+    ):
+        return _INVESTMENT_METRICS_CACHE["data"]
+
+    fallback = {
+        "current_users": DEFAULT_INPUTS["current_users"],
+        "net_now": DEFAULT_INPUTS["net_now"],
+        "net_3mo": DEFAULT_INPUTS["net_3mo"],
+        "churn_rate": DEFAULT_INPUTS["churn_rate"],
+        "arpu": DEFAULT_INPUTS["arpu"],
+        "fetched_at": datetime.utcnow().isoformat() + "Z",
+    }
+
+    if not STRIPE_ENABLED:
+        fallback["error"] = "Stripe not configured"
+        return fallback
+
+    try:
+        # Pull all subscriptions ever created (active + canceled). For an
+        # account with hundreds of subs this is a few paginated calls.
+        subs = list(stripe.Subscription.list(status='all', limit=100).auto_paging_iter())
+    except stripe.error.StripeError as e:
+        logger.error(f"Investment Health: Stripe fetch failed: {e}")
+        fallback["error"] = str(e)
+        return fallback
+    except Exception as e:
+        logger.error(f"Investment Health: unexpected error fetching subs: {e}")
+        fallback["error"] = str(e)
+        return fallback
+
+    now = datetime.utcnow()
+    start_of_this_month = datetime(now.year, now.month, 1)
+
+    # 3 months ago: full calendar month
+    three_months_ago_year = now.year
+    three_months_ago_month = now.month - 3
+    while three_months_ago_month <= 0:
+        three_months_ago_month += 12
+        three_months_ago_year -= 1
+    start_of_3mo = datetime(three_months_ago_year, three_months_ago_month, 1)
+    # Start of the month after the 3-months-ago month
+    next_month = three_months_ago_month + 1
+    next_year = three_months_ago_year
+    if next_month > 12:
+        next_month = 1
+        next_year += 1
+    end_of_3mo = datetime(next_year, next_month, 1)
+
+    # Active count + ARPU
+    active_subs = [s for s in subs if s.get('status') in ('active', 'trialing')]
+    current_users = len(active_subs)
+    if active_subs:
+        total_monthly = sum(_normalized_monthly_amount(s) for s in active_subs)
+        arpu_gross = total_monthly / len(active_subs)
+        arpu = max(0.0, arpu_gross - SMS_COST_PER_USER)
+    else:
+        arpu = DEFAULT_INPUTS["arpu"]
+
+    def _ts_to_dt(ts):
+        return datetime.utcfromtimestamp(ts) if ts else None
+
+    def _net_new_in_range(start_dt: datetime, end_dt: datetime) -> int:
+        """New subs in [start, end) minus cancellations in [start, end)."""
+        new_count = 0
+        cancelled_count = 0
+        for s in subs:
+            created = _ts_to_dt(s.get('created'))
+            if created and start_dt <= created < end_dt:
+                new_count += 1
+            cancelled_at = _ts_to_dt(s.get('canceled_at'))
+            if cancelled_at and start_dt <= cancelled_at < end_dt:
+                cancelled_count += 1
+        return new_count - cancelled_count
+
+    net_now = _net_new_in_range(start_of_this_month, now + timedelta(seconds=1))
+    net_3mo = _net_new_in_range(start_of_3mo, end_of_3mo)
+
+    # Trailing 90-day average monthly churn rate
+    # For each of the 3 prior full calendar months, churn = cancellations
+    # during the month / active subs at start of the month.
+    churn_samples = []
+    cursor_year = now.year
+    cursor_month = now.month
+    for _ in range(3):
+        cursor_month -= 1
+        if cursor_month <= 0:
+            cursor_month += 12
+            cursor_year -= 1
+        month_start = datetime(cursor_year, cursor_month, 1)
+        nm = cursor_month + 1
+        ny = cursor_year
+        if nm > 12:
+            nm = 1
+            ny += 1
+        month_end = datetime(ny, nm, 1)
+
+        # Subs active at month_start: created before month_start AND
+        # (not canceled OR canceled on/after month_start)
+        active_at_start = 0
+        cancelled_in_month = 0
+        for s in subs:
+            created = _ts_to_dt(s.get('created'))
+            cancelled_at = _ts_to_dt(s.get('canceled_at'))
+            if created and created < month_start and (cancelled_at is None or cancelled_at >= month_start):
+                active_at_start += 1
+            if cancelled_at and month_start <= cancelled_at < month_end:
+                cancelled_in_month += 1
+
+        if active_at_start > 0:
+            churn_samples.append(100.0 * cancelled_in_month / active_at_start)
+
+    if churn_samples:
+        churn_rate = sum(churn_samples) / len(churn_samples)
+    else:
+        churn_rate = DEFAULT_INPUTS["churn_rate"]
+
+    result = {
+        "current_users": current_users,
+        "net_now": net_now,
+        "net_3mo": net_3mo,
+        "churn_rate": round(churn_rate, 2),
+        "arpu": round(arpu, 2),
+        "fetched_at": now.isoformat() + "Z",
+    }
+
+    _INVESTMENT_METRICS_CACHE["data"] = result
+    _INVESTMENT_METRICS_CACHE["fetched_at"] = now_ts
+
+    return result

--- a/tests/test_investment_health.py
+++ b/tests/test_investment_health.py
@@ -1,0 +1,193 @@
+"""
+Unit tests for services/investment_health.py.
+
+The three sanity tests come straight from the prompt's acceptance criteria —
+they pin the verdict logic against known-good inputs.
+"""
+
+from services.investment_health import (
+    evaluate,
+    compute_derived,
+    churn_status,
+    growth_status,
+    ltv_cac_status,
+    cac_payback_status,
+    breakeven_months_status,
+    steady_state_status,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sanity tests from the prompt
+# ---------------------------------------------------------------------------
+
+def test_sanity_yellow_pivot():
+    """users=250, net_now=40, net_3mo=30, churn=7, cac=60, arpu=8, burn=4167
+    → Pivot before reinvesting (yellow)."""
+    r = evaluate(
+        current_users=250, net_now=40, net_3mo=30,
+        churn_rate=7, cac=60, arpu=8, monthly_burn=4167,
+    )
+    assert r.verdict == "Pivot before reinvesting"
+    assert r.verdict_color == "yellow"
+
+    assert r.checks["churn"].status == "yellow"
+    assert r.checks["ltv_cac"].status == "yellow"
+    assert r.checks["growth_trend"].status == "green"
+    assert r.checks["breakeven_months"].status == "green"
+
+    # LTV/CAC ≈ 1.9x
+    assert abs(r.derived["ltv_cac"] - (8 / 0.07) / 60) < 0.01
+    # breakeven ≈ 521 users
+    assert round(r.derived["breakeven_users"]) == 521
+    # months_to_breakeven ≈ 9
+    assert r.derived["months_to_breakeven"] is not None
+    assert r.derived["months_to_breakeven"] <= 12
+
+
+def test_sanity_green_continue():
+    """users=500, net_now=50, net_3mo=40, churn=5, cac=40, arpu=8, burn=4167
+    → Continue investing (green) with all 4 primary checks green."""
+    r = evaluate(
+        current_users=500, net_now=50, net_3mo=40,
+        churn_rate=5, cac=40, arpu=8, monthly_burn=4167,
+    )
+    assert r.verdict == "Continue investing"
+    assert r.verdict_color == "green"
+
+    assert r.checks["churn"].status == "green"
+    assert r.checks["growth_trend"].status == "green"
+    assert r.checks["ltv_cac"].status == "green"
+    assert r.checks["breakeven_months"].status == "green"
+
+
+def test_sanity_red_stop():
+    """users=200, net_now=15, net_3mo=35, churn=12, cac=80, arpu=8, burn=4167
+    → Stop or restructure (red). Churn red, LTV/CAC red, breakeven unreachable."""
+    r = evaluate(
+        current_users=200, net_now=15, net_3mo=35,
+        churn_rate=12, cac=80, arpu=8, monthly_burn=4167,
+    )
+    assert r.verdict == "Stop or restructure"
+    assert r.verdict_color == "red"
+
+    assert r.checks["churn"].status == "red"
+    assert r.checks["ltv_cac"].status == "red"
+    assert r.checks["breakeven_months"].status == "red"
+    # Steady state below breakeven — can't reach
+    assert r.derived["months_to_breakeven"] is None
+    assert not r.derived["can_reach_breakeven"]
+
+
+# ---------------------------------------------------------------------------
+# Status threshold edge cases
+# ---------------------------------------------------------------------------
+
+def test_churn_thresholds():
+    assert churn_status(6.99) == "green"
+    assert churn_status(7.0) == "yellow"
+    assert churn_status(10.0) == "yellow"
+    assert churn_status(10.01) == "red"
+
+
+def test_ltv_cac_thresholds():
+    assert ltv_cac_status(3.0) == "green"
+    assert ltv_cac_status(2.99) == "yellow"
+    assert ltv_cac_status(1.5) == "yellow"
+    assert ltv_cac_status(1.49) == "red"
+
+
+def test_cac_payback_thresholds():
+    assert cac_payback_status(11.99) == "green"
+    assert cac_payback_status(12.0) == "yellow"
+    assert cac_payback_status(24.0) == "yellow"
+    assert cac_payback_status(24.01) == "red"
+
+
+def test_breakeven_months_thresholds():
+    assert breakeven_months_status(12) == "green"
+    assert breakeven_months_status(13) == "yellow"
+    assert breakeven_months_status(24) == "yellow"
+    assert breakeven_months_status(25) == "red"
+    assert breakeven_months_status(None) == "red"
+
+
+def test_steady_state_thresholds():
+    # ratio = 1.3+ green, 1.0-1.3 yellow, <1.0 red
+    assert steady_state_status(130, 100) == "green"
+    assert steady_state_status(100, 100) == "yellow"
+    assert steady_state_status(99, 100) == "red"
+
+
+def test_growth_status_negative_net_is_red():
+    assert growth_status(0, 10) == "red"
+    assert growth_status(-5, 10) == "red"
+    assert growth_status(10, 10) == "green"
+    assert growth_status(8, 10) == "green"     # delta -2 >= -3
+    assert growth_status(5, 10) == "yellow"    # delta -5 < -3 but net_now > 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases from acceptance criteria
+# ---------------------------------------------------------------------------
+
+def test_zero_net_adds_means_never_reaches_breakeven():
+    d = compute_derived(
+        current_users=100, net_now=0, net_3mo=10,
+        churn_rate=7, cac=60, arpu=8, monthly_burn=4167,
+    )
+    assert d["months_to_breakeven"] is None
+
+
+def test_churn_clamped_to_one_percent():
+    # churn=0 would divide by zero in LTV calc; should clamp to 1% floor
+    d = compute_derived(
+        current_users=100, net_now=10, net_3mo=10,
+        churn_rate=0, cac=60, arpu=8, monthly_burn=4167,
+    )
+    # ltv = 8 / 0.01 = 800 (not infinity)
+    assert d["ltv"] == 800.0
+
+
+def test_already_at_breakeven_is_zero_months():
+    d = compute_derived(
+        current_users=10000, net_now=10, net_3mo=10,
+        churn_rate=5, cac=60, arpu=8, monthly_burn=4167,
+    )
+    assert d["months_to_breakeven"] == 0
+
+
+def test_simulation_caps_at_max_months():
+    # Tiny growth with high churn — would take forever, must not hang
+    d = compute_derived(
+        current_users=10, net_now=1, net_3mo=1,
+        churn_rate=10, cac=60, arpu=8, monthly_burn=4167,
+    )
+    # Either reachable in <240 mo or returns None — must not hang
+    assert d["months_to_breakeven"] is None or d["months_to_breakeven"] < 240
+
+
+def test_growth_delta_sign_in_display():
+    r = evaluate(
+        current_users=250, net_now=40, net_3mo=30,
+        churn_rate=7, cac=60, arpu=8, monthly_burn=4167,
+    )
+    assert r.checks["growth_trend"].display.startswith("+")
+
+    r2 = evaluate(
+        current_users=250, net_now=20, net_3mo=30,
+        churn_rate=7, cac=60, arpu=8, monthly_burn=4167,
+    )
+    assert r2.checks["growth_trend"].display.startswith("-")
+
+
+def test_to_dict_serializable():
+    r = evaluate(
+        current_users=250, net_now=40, net_3mo=30,
+        churn_rate=7, cac=60, arpu=8, monthly_burn=4167,
+    )
+    import json
+    # Should round-trip through JSON without error (no infinities for these inputs)
+    payload = json.dumps(r.to_dict())
+    assert "verdict" in payload
+    assert "checks" in payload


### PR DESCRIPTION
## Summary
- New `/admin/investment-health` page: SaaS unit-economics decision tool with green/yellow/red verdict (Continue investing / Pivot / Stop or restructure)
- Pulls 5 live inputs from Stripe (active subs, net-new this month, net-new 3mo ago, trailing-90d churn, ARPU); 2 manual-only (CAC, burn). Each input toggles live ↔ manual via a badge for what-if scenarios
- Pure-Python math module at `services/investment_health.py` with 15 unit tests covering the 3 sanity cases from the spec; equivalent JS in the page renders the verdict instantly without server round-trips

## Test plan
- [x] `python -m pytest tests/test_investment_health.py` — 15/15 passing including yellow/green/red verdict sanity cases
- [x] JS verdict logic cross-checked against Python on the same 3 input sets
- [x] Both routes (`/admin/investment-health`, `/admin/investment-health/data`) render and return well-formed payloads when Stripe is unconfigured (graceful fallback to defaults)
- [ ] Open the page in production with real Stripe data and sanity-check the live values look right
- [ ] Toggle each input live ↔ manual and verify the verdict updates
- [ ] Click "Reset to live data" and verify all 5 live-capable inputs restore (CAC and burn unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)