### PR TITLE
Add 48h anti-bunching guard between lifecycle messages

### DIFF
--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -3874,6 +3874,42 @@ async def cs_get_customer_nudges(phone_number: str, admin: str = Depends(verify_
         total_30d, distinct_days_30d = c.fetchone()
         days_with_multiple = sum(1 for d in daily_counts if d["count"] > 1)
 
+        # ALL outbound messages (last 30 days) — captures lifecycle, broadcasts,
+        # billing, replies, etc. that wouldn't show in smart_nudges. Critical for
+        # diagnosing "why is this user getting so many messages?" when smart
+        # nudges are OFF but messages are still flowing.
+        c.execute('''
+            SELECT message_type, COUNT(*) AS total,
+                   COUNT(DISTINCT DATE(created_at AT TIME ZONE 'UTC')) AS days,
+                   MAX(created_at) AS last_sent
+            FROM sms_outbound_log
+            WHERE phone_number = %s AND created_at > NOW() - INTERVAL '30 days'
+            GROUP BY message_type ORDER BY total DESC
+        ''', (phone_number,))
+        outbound_by_type = [
+            {
+                "type": r[0],
+                "total": r[1],
+                "distinct_days": r[2],
+                "last_sent": str(r[3]) if r[3] else None,
+            }
+            for r in c.fetchall()
+        ]
+
+        # Per-day outbound history with message types
+        c.execute('''
+            SELECT DATE(created_at AT TIME ZONE 'UTC') AS day,
+                   COUNT(*) AS total,
+                   STRING_AGG(DISTINCT message_type, ', ') AS types
+            FROM sms_outbound_log
+            WHERE phone_number = %s AND created_at > NOW() - INTERVAL '30 days'
+            GROUP BY day ORDER BY day DESC
+        ''', (phone_number,))
+        outbound_by_day = [
+            {"date": str(r[0]), "count": r[1], "types": r[2]}
+            for r in c.fetchall()
+        ]
+
         return {
             "config": {
                 "tier": premium_status,
@@ -3894,6 +3930,8 @@ async def cs_get_customer_nudges(phone_number: str, admin: str = Depends(verify_
             },
             "daily_counts": daily_counts,
             "recent": recent,
+            "outbound_by_type": outbound_by_type,
+            "outbound_by_day": outbound_by_day,
         }
     except HTTPException:
         raise
@@ -9134,6 +9172,30 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
                           }}).join('')
                         : '<tr><td colspan="4" style="color:#95a5a6; text-align:center; padding:20px;">No nudges sent yet</td></tr>';
 
+                    const outboundByType = data.outbound_by_type || [];
+                    const outboundByDay = data.outbound_by_day || [];
+
+                    const outboundTypeRows = outboundByType.length > 0
+                        ? outboundByType.map(t => `
+                            <tr>
+                                <td><span style="background:#ecf0f1; padding: 2px 8px; border-radius: 10px; font-size: 0.85em;">${{t.type}}</span></td>
+                                <td><strong>${{t.total}}</strong></td>
+                                <td>${{t.distinct_days}}</td>
+                                <td style="font-size:0.85em;">${{t.last_sent ? new Date(t.last_sent).toLocaleString() : '—'}}</td>
+                            </tr>
+                        `).join('')
+                        : '<tr><td colspan="4" style="color:#95a5a6; text-align:center; padding:15px;">No outbound messages in last 30 days</td></tr>';
+
+                    const outboundDayRows = outboundByDay.length > 0
+                        ? outboundByDay.slice(0, 30).map(d => `
+                            <div style="display: flex; align-items: center; gap: 10px; padding: 4px 0; font-size: 0.85em; border-bottom: 1px solid #f4f4f4;">
+                                <span style="color: #7f8c8d; min-width: 90px;">${{d.date}}</span>
+                                <span style="background: ${{d.count > 1 ? '#e67e22' : '#3498db'}}; color: white; padding: 2px 10px; border-radius: 10px; min-width: 30px; text-align: center;">${{d.count}}</span>
+                                <span style="color: #2c3e50; font-size: 0.85em;">${{d.types}}</span>
+                            </div>
+                        `).join('')
+                        : '<div style="color: #95a5a6;">No outbound messages in last 30 days</div>';
+
                     tabDiv.innerHTML = `
                         <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px;">
                             <div style="background: #f8f9fa; padding: 15px; border-radius: 4px;">
@@ -9145,11 +9207,11 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
                                     <div><strong>Nudge time:</strong> ${{cfg.smart_nudge_time || '—'}} (${{cfg.timezone || '—'}})</div>
                                     <div><strong>Daily summary:</strong> ${{cfg.daily_summary_enabled ? 'ON' : 'OFF'}}</div>
                                     <div><strong>Opted out:</strong> ${{cfg.opted_out ? 'YES' : 'no'}}</div>
-                                    <div style="margin-top: 8px; padding-top: 8px; border-top: 1px solid #ddd;"><strong>Expected cadence:</strong> ${{cfg.expected_cadence}}</div>
+                                    <div style="margin-top: 8px; padding-top: 8px; border-top: 1px solid #ddd;"><strong>Expected cadence (smart_nudge):</strong> ${{cfg.expected_cadence}}</div>
                                 </div>
                             </div>
                             <div style="background: #f8f9fa; padding: 15px; border-radius: 4px;">
-                                <h4 style="margin: 0 0 10px; color: #2c3e50;">Last 30 days</h4>
+                                <h4 style="margin: 0 0 10px; color: #2c3e50;">Smart nudges, last 30 days</h4>
                                 <div style="line-height: 1.7; font-size: 0.9em;">
                                     <div><strong>Total sent:</strong> ${{stats.total || 0}}</div>
                                     <div><strong>Distinct days:</strong> ${{stats.distinct_days || 0}}</div>
@@ -9161,12 +9223,28 @@ async def admin_dashboard(admin: str = Depends(verify_admin)):
                             </div>
                         </div>
 
-                        <h4 style="margin: 20px 0 10px; color: #2c3e50;">Daily send counts</h4>
+                        <h4 style="margin: 20px 0 10px; color: #2c3e50;">All outbound messages by type (last 30d)</h4>
+                        <div style="background: #fff8e1; border-left: 3px solid #f39c12; padding: 8px 12px; margin-bottom: 10px; font-size: 0.85em; color: #555;">
+                            Includes lifecycle, broadcast, billing, replies, etc. — not just smart nudges. Use this to find which message type is firing.
+                        </div>
+                        <div style="overflow-x: auto; margin-bottom: 20px;">
+                            <table class="history-table">
+                                <thead><tr><th>Message type</th><th>Total sends</th><th>Distinct days</th><th>Last sent</th></tr></thead>
+                                <tbody>${{outboundTypeRows}}</tbody>
+                            </table>
+                        </div>
+
+                        <h4 style="margin: 20px 0 10px; color: #2c3e50;">All outbound messages by day (last 30d)</h4>
+                        <div style="background: white; padding: 10px 15px; border-radius: 4px; max-height: 280px; overflow-y: auto; border: 1px solid #ecf0f1; margin-bottom: 20px;">
+                            ${{outboundDayRows}}
+                        </div>
+
+                        <h4 style="margin: 20px 0 10px; color: #2c3e50;">Smart nudge daily counts</h4>
                         <div style="background: white; padding: 10px 15px; border-radius: 4px; max-height: 240px; overflow-y: auto; border: 1px solid #ecf0f1; margin-bottom: 20px;">
                             ${{dailyBars}}
                         </div>
 
-                        <h4 style="margin: 20px 0 10px; color: #2c3e50;">Recent nudges</h4>
+                        <h4 style="margin: 20px 0 10px; color: #2c3e50;">Recent smart nudges</h4>
                         <div style="overflow-x: auto;">
                             <table class="history-table">
                                 <thead><tr><th>Sent</th><th>Type</th><th>Text</th><th>User response</th></tr></thead>

--- a/services/sms_service.py
+++ b/services/sms_service.py
@@ -46,6 +46,56 @@ def _log_outbound(phone_number, message_type):
         logger.warning(f"Failed to log outbound SMS: {e}")
 
 
+# System-pushed message types — included in the "recently messaged?" check
+# so two different lifecycle systems don't fire back-to-back. User-pulled
+# replies (reminder, reply, billing, support, signup, alert) are excluded.
+PUSHED_MESSAGE_TYPES = (
+    'trial_lifecycle',
+    'smart_nudge',
+    'engagement_nudge',
+    'daily_summary',
+    'onboarding_followup',
+    'broadcast',
+)
+
+
+def recently_pushed_message(phone_number, hours=48, types=PUSHED_MESSAGE_TYPES):
+    """Anti-bunching guard: True if the user received any system-pushed
+    lifecycle/nudge/broadcast message within the last `hours`.
+
+    Used by the post-trial/inactivity tasks before sending so two different
+    systems (e.g. weekly inactivity nudge + one-shot 30-day winback) don't
+    land 24h apart and feel like spam.
+
+    Fails open — if the DB check itself errors, returns False so we don't
+    silently block all lifecycle messages on infra issues.
+    """
+    from datetime import datetime, timedelta
+    from database import get_db_connection, return_db_connection
+    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT 1 FROM sms_outbound_log
+            WHERE phone_number = %s
+              AND message_type = ANY(%s)
+              AND created_at > %s
+            LIMIT 1
+            """,
+            (phone_number, list(types), cutoff),
+        )
+        return c.fetchone() is not None
+    except Exception as e:
+        logger.warning(f"recently_pushed_message check failed for {phone_number[-4:]}: {e}")
+        return False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
 def send_sms(to_number, message, media_url=None, message_type="other"):
     """Send an SMS/MMS message via Twilio
 

--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -21,7 +21,7 @@ from models.reminder import (
     check_reminder_exists_for_recurring,
     update_recurring_reminder_generated,
 )
-from services.sms_service import send_sms, UserOptedOutError
+from services.sms_service import send_sms, UserOptedOutError, recently_pushed_message
 from services.metrics_service import track_reminder_delivery
 
 logger = get_task_logger(__name__)
@@ -1816,6 +1816,11 @@ def send_post_trial_reengagement(self):
             if not (2 <= days_since_expiry <= 3):
                 continue
 
+            # Anti-bunching: skip if any other lifecycle/nudge fired in last 48h
+            if recently_pushed_message(phone_number):
+                logger.info(f"Skipping post-trial re-engagement for ...{phone_number[-4:]} — another lifecycle message sent in last 48h")
+                continue
+
             try:
                 greeting = f"Hi {first_name}!" if first_name else "Hi there!"
 
@@ -1923,6 +1928,11 @@ def send_14d_post_trial_touchpoint(self):
 
             # Range check to handle signup time-of-day
             if not (13 <= days_since_expiry <= 14):
+                continue
+
+            # Anti-bunching: skip if any other lifecycle/nudge fired in last 48h
+            if recently_pushed_message(phone_number):
+                logger.info(f"Skipping 14-day touchpoint for ...{phone_number[-4:]} — another lifecycle message sent in last 48h")
                 continue
 
             try:
@@ -2047,6 +2057,11 @@ def send_30d_winback(self):
             if not (9 <= user_local_hour < 10):
                 continue
 
+            # Anti-bunching: skip if any other lifecycle/nudge fired in last 48h
+            if recently_pushed_message(phone_number):
+                logger.info(f"Skipping 30-day winback for ...{phone_number[-4:]} — another lifecycle message sent in last 48h")
+                continue
+
             try:
                 greeting = f"Hi {first_name}!" if first_name else "Hi there!"
 
@@ -2150,6 +2165,11 @@ def send_inactivity_nudge(self):
                 user_tz = pytz.timezone('America/New_York')
             user_local_hour = datetime.now(pytz.utc).astimezone(user_tz).hour
             if not (9 <= user_local_hour < 10):
+                continue
+
+            # Anti-bunching: skip if any other lifecycle/nudge fired in last 48h
+            if recently_pushed_message(phone_number):
+                logger.info(f"Skipping inactivity nudge for ...{phone_number[-4:]} — another lifecycle message sent in last 48h")
                 continue
 
             try:

--- a/tests/test_messaging_guards.py
+++ b/tests/test_messaging_guards.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for the anti-bunching guard in services/sms_service.py.
+
+The guard prevents two different lifecycle/nudge systems from firing
+back-to-back (the issue we hit when a user got an inactivity nudge on
+Friday and a 30-day winback on Saturday).
+"""
+
+from unittest.mock import patch, MagicMock
+
+from services.sms_service import recently_pushed_message, PUSHED_MESSAGE_TYPES
+
+
+def _mock_db(returns_row: bool):
+    """Build a fake DB connection whose fetchone() returns a row or None."""
+    cur = MagicMock()
+    cur.fetchone.return_value = (1,) if returns_row else None
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+def test_returns_true_when_recent_pushed_message_exists():
+    conn, cur = _mock_db(returns_row=True)
+    with patch('database.get_db_connection', return_value=conn), \
+         patch('database.return_db_connection') as ret:
+        assert recently_pushed_message('+15551234567') is True
+        ret.assert_called_once_with(conn)
+        # Confirm we queried with the expected types and a 48h cutoff
+        args, _ = cur.execute.call_args
+        sql, params = args
+        assert 'sms_outbound_log' in sql
+        assert list(PUSHED_MESSAGE_TYPES) == params[1]
+
+
+def test_returns_false_when_no_recent_pushed_message():
+    conn, _ = _mock_db(returns_row=False)
+    with patch('database.get_db_connection', return_value=conn), \
+         patch('database.return_db_connection'):
+        assert recently_pushed_message('+15551234567') is False
+
+
+def test_fails_open_on_db_error():
+    """If the guard query itself errors, do not silently block lifecycle
+    sends — log and return False so the caller proceeds."""
+    with patch('database.get_db_connection', side_effect=RuntimeError('db down')):
+        assert recently_pushed_message('+15551234567') is False
+
+
+def test_custom_window_and_types_pass_through():
+    conn, cur = _mock_db(returns_row=False)
+    with patch('database.get_db_connection', return_value=conn), \
+         patch('database.return_db_connection'):
+        recently_pushed_message('+15551234567', hours=24, types=('broadcast',))
+        args, _ = cur.execute.call_args
+        _, params = args
+        assert params[1] == ['broadcast']
+
+
+def test_pushed_types_excludes_user_initiated_replies():
+    """Replies, reminders, billing, support — these are user-pulled, not
+    system-pushed. They should not count toward the bunching guard."""
+    user_initiated = {'reply', 'reminder', 'billing', 'support', 'signup', 'alert', 'onboarding'}
+    assert user_initiated.isdisjoint(PUSHED_MESSAGE_TYPES)


### PR DESCRIPTION
## Summary
- Discovered while investigating Codie (#4201): inactivity nudge fired Friday 4/24 9:30 AM and 30-day winback fired Saturday 4/25 9:25 AM. Each system was correct in isolation; the bunching is what felt like spam
- New \`recently_pushed_message()\` helper queries \`sms_outbound_log\` for any system-pushed message in the last 48h. Applied as a skip-guard inside the 4 post-trial / inactivity tasks
- 5 unit tests covering the true/false branches, fail-open on DB error, custom window pass-through, and confirming user-pulled categories (reply/reminder/billing/support) are excluded from the bunching check
- Tracks well with existing PR #260 which surfaces \`sms_outbound_log\` on the Nudges tab so ops can see the guard's effect

## Test plan
- [x] \`python -m pytest tests/test_messaging_guards.py\` — 5/5 passing
- [ ] After deploy, confirm with a known cluster-prone user (e.g. someone hitting day 14 + just got a broadcast) that the second message is skipped and the log shows \"Skipping ... — another lifecycle message sent in last 48h\"

## Out of scope
- Active-trial lifecycle tasks (Day 1/2/3/4) aren't guarded — they fire on different days by design and don't bunch with each other
- Doesn't reschedule skipped messages — if a one-shot message is skipped due to bunching and the eligibility window passes, that send is permanently dropped (correct behavior: user already got something else recently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)