### PR TITLE
Add soft opt-out flag for lifecycle messages

### DIFF
--- a/database.py
+++ b/database.py
@@ -704,6 +704,11 @@ def init_db():
             # Shared lists beta: user-initiated opt-in (Premium-only feature, but any user can opt in)
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS shared_lists_beta_opt_in BOOLEAN DEFAULT FALSE",
             "UPDATE users SET shared_lists_beta_opt_in = FALSE WHERE shared_lists_beta_opt_in IS NULL",
+            # Soft opt-out: silence proactive lifecycle/marketing messages while still
+            # allowing user-requested reminders. Hard STOP still uses opted_out.
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS lifecycle_messages_opted_out BOOLEAN DEFAULT FALSE",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS lifecycle_messages_opted_out_at TIMESTAMP",
+            "UPDATE users SET lifecycle_messages_opted_out = FALSE WHERE lifecycle_messages_opted_out IS NULL",
         ]
 
         # Create indexes on phone_hash columns for efficient lookups

--- a/main.py
+++ b/main.py
@@ -3476,6 +3476,41 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             return Response(content=str(resp), media_type="application/xml")
 
         # ==========================================
+        # SOFT OPT-OUT: PAUSE / RESUME LIFECYCLE MESSAGES
+        # ==========================================
+        # Silences proactive lifecycle/marketing messages (trial warnings, day-N
+        # nudges, winbacks, inactivity nudges) without disabling user-requested
+        # reminders. STOP remains the hard opt-out for everything.
+        if msg_upper in [
+            "PAUSE", "PAUSE MESSAGES", "PAUSE NOTIFICATIONS",
+            "QUIET", "QUIET MODE",
+            "MUTE", "MUTE MESSAGES", "MUTE NOTIFICATIONS",
+        ]:
+            from models.user import pause_lifecycle_messages
+            pause_lifecycle_messages(phone_number)
+            resp = MessagingResponse()
+            resp.message(staging_prefix(
+                "Got it — I'll only text you about reminders you've asked for. "
+                "No more check-ins or trial messages.\n\n"
+                "Text RESUME anytime to turn them back on, or STOP to opt out of everything."
+            ))
+            log_interaction(phone_number, incoming_msg, "Lifecycle messages paused", "lifecycle_pause", True)
+            return Response(content=str(resp), media_type="application/xml")
+
+        if msg_upper in [
+            "RESUME", "RESUME MESSAGES", "RESUME NOTIFICATIONS",
+            "UNPAUSE", "UNMUTE", "UNMUTE MESSAGES",
+        ]:
+            from models.user import resume_lifecycle_messages
+            resume_lifecycle_messages(phone_number)
+            resp = MessagingResponse()
+            resp.message(staging_prefix(
+                "Welcome back! You'll start receiving check-ins and lifecycle messages again."
+            ))
+            log_interaction(phone_number, incoming_msg, "Lifecycle messages resumed", "lifecycle_resume", True)
+            return Response(content=str(resp), media_type="application/xml")
+
+        # ==========================================
         # SHARED LISTS BETA OPT-IN
         # ==========================================
 
@@ -6110,6 +6145,22 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                     reply_text = staging_prefix(f"Daily summary enabled! You'll receive a summary of your day's reminders at {dh}:{m:02d} {ap}.\n\nTo change the time, text: SUMMARY TIME 7AM")
                 else:
                     reply_text = staging_prefix("Daily summary disabled. You'll no longer receive daily reminder summaries.")
+
+            elif setting == "lifecycle_messages":
+                from models.user import pause_lifecycle_messages, resume_lifecycle_messages
+                pause = value.lower() in ['paused', 'pause', 'off', 'false', 'disable', 'disabled', 'stop', 'mute']
+                if pause:
+                    pause_lifecycle_messages(phone_number)
+                    reply_text = staging_prefix(
+                        "Got it — I'll only text you about reminders you've asked for. "
+                        "No more check-ins or trial messages.\n\n"
+                        "Text RESUME anytime to turn them back on, or STOP to opt out of everything."
+                    )
+                else:
+                    resume_lifecycle_messages(phone_number)
+                    reply_text = staging_prefix(
+                        "Welcome back! You'll start receiving check-ins and lifecycle messages again."
+                    )
             else:
                 reply_text = "I'm not sure which setting you'd like to change. You can change your daily summary time by texting something like 'change my summary time to 8am'."
 

--- a/models/user.py
+++ b/models/user.py
@@ -50,6 +50,8 @@ ALLOWED_USER_FIELDS = {
     # Shared lists
     'pending_share_name',
     'shared_lists_beta_opt_in',
+    # Soft opt-out for proactive lifecycle messages
+    'lifecycle_messages_opted_out', 'lifecycle_messages_opted_out_at',
 }
 
 
@@ -497,6 +499,84 @@ def is_user_opted_out(phone_number: str) -> bool:
             return_db_connection(conn)
 
 
+def is_lifecycle_paused(phone_number: str) -> bool:
+    """Check if a user has soft-opted-out of proactive lifecycle messages.
+
+    Distinct from `is_user_opted_out`: a paused user still receives the
+    reminders they explicitly scheduled, just not trial/winback/inactivity sends.
+    """
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        if ENCRYPTION_ENABLED:
+            from utils.encryption import hash_phone
+            phone_hash = hash_phone(phone_number)
+            c.execute('SELECT lifecycle_messages_opted_out FROM users WHERE phone_hash = %s', (phone_hash,))
+            result = c.fetchone()
+            if not result:
+                c.execute('SELECT lifecycle_messages_opted_out FROM users WHERE phone_number = %s', (phone_number,))
+                result = c.fetchone()
+        else:
+            c.execute('SELECT lifecycle_messages_opted_out FROM users WHERE phone_number = %s', (phone_number,))
+            result = c.fetchone()
+
+        return bool(result and result[0])
+    except Exception as e:
+        logger.error(f"Error checking lifecycle pause status: {e}")
+        return False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def pause_lifecycle_messages(phone_number: str) -> bool:
+    """Soft-opt-out: silence proactive lifecycle messages."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            'UPDATE users SET lifecycle_messages_opted_out = TRUE, '
+            'lifecycle_messages_opted_out_at = CURRENT_TIMESTAMP '
+            'WHERE phone_number = %s',
+            (phone_number,)
+        )
+        conn.commit()
+        logger.info(f"Lifecycle messages paused: ...{phone_number[-4:]}")
+        return True
+    except Exception as e:
+        logger.error(f"Error pausing lifecycle messages: {e}")
+        return False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def resume_lifecycle_messages(phone_number: str) -> bool:
+    """Reverse a soft opt-out."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            'UPDATE users SET lifecycle_messages_opted_out = FALSE, '
+            'lifecycle_messages_opted_out_at = NULL '
+            'WHERE phone_number = %s',
+            (phone_number,)
+        )
+        conn.commit()
+        logger.info(f"Lifecycle messages resumed: ...{phone_number[-4:]}")
+        return True
+    except Exception as e:
+        logger.error(f"Error resuming lifecycle messages: {e}")
+        return False
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
 def get_daily_summary_settings(phone_number: str) -> Optional[dict[str, Any]]:
     """Get user's daily summary settings.
 
@@ -842,7 +922,8 @@ def get_user_nudge_status(phone_number: str) -> dict:
 
         query = '''
             SELECT five_minute_nudge_scheduled_at, five_minute_nudge_sent,
-                   post_onboarding_interactions, opted_out
+                   post_onboarding_interactions, opted_out,
+                   COALESCE(lifecycle_messages_opted_out, FALSE)
             FROM users WHERE {phone_condition}
         '''
 
@@ -863,12 +944,15 @@ def get_user_nudge_status(phone_number: str) -> dict:
                 'scheduled_at': result[0],
                 'sent': result[1] or False,
                 'interactions': result[2] or 0,
-                'opted_out': result[3] or False
+                'opted_out': result[3] or False,
+                'lifecycle_paused': result[4] or False,
             }
-        return {'scheduled_at': None, 'sent': False, 'interactions': 0, 'opted_out': False}
+        return {'scheduled_at': None, 'sent': False, 'interactions': 0,
+                'opted_out': False, 'lifecycle_paused': False}
     except Exception as e:
         logger.error(f"Error getting nudge status: {e}")
-        return {'scheduled_at': None, 'sent': False, 'interactions': 0, 'opted_out': False}
+        return {'scheduled_at': None, 'sent': False, 'interactions': 0,
+                'opted_out': False, 'lifecycle_paused': False}
     finally:
         if conn:
             return_db_connection(conn)

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -344,11 +344,11 @@ WHEN TO USE update_reminder:
 IMPORTANT: Use update_reminder when user wants to CHANGE/MODIFY/RESCHEDULE/MOVE an existing reminder to a new time. Do NOT delete the reminder.
 IMPORTANT: Do NOT use update_reminder for changing the daily summary time or other settings. Use update_settings instead.
 
-For UPDATING SETTINGS/PREFERENCES (daily summary time, enable/disable summary):
+For UPDATING SETTINGS/PREFERENCES (daily summary time, enable/disable summary, pause/resume lifecycle messages):
 {{
     "action": "update_settings",
-    "setting": "daily_summary_time" | "daily_summary_enabled",
-    "value": "the new value (e.g., '8:00 AM' for time, 'true'/'false' for enabled)",
+    "setting": "daily_summary_time" | "daily_summary_enabled" | "lifecycle_messages",
+    "value": "the new value (e.g., '8:00 AM' for time, 'true'/'false' for enabled, 'paused'/'resumed' for lifecycle_messages)",
     "confirmation": "Updated your daily summary time to [time]"
 }}
 WHEN TO USE update_settings:
@@ -358,7 +358,14 @@ WHEN TO USE update_settings:
 - "turn off my daily summary" → setting: "daily_summary_enabled", value: "false"
 - "turn on my daily summary" → setting: "daily_summary_enabled", value: "true"
 - "I want my summary at 9am" → setting: "daily_summary_time", value: "9:00 AM"
+- "don't text me unless it's about a reminder I asked for" → setting: "lifecycle_messages", value: "paused"
+- "stop sending me check-ins" → setting: "lifecycle_messages", value: "paused"
+- "only text me about my reminders" → setting: "lifecycle_messages", value: "paused"
+- "I don't want any marketing texts" → setting: "lifecycle_messages", value: "paused"
+- "you can text me again" → setting: "lifecycle_messages", value: "resumed"
+- "resume normal messages" → setting: "lifecycle_messages", value: "resumed"
 IMPORTANT: "daily summary" refers to the daily summary SETTING, NOT a reminder. Any request to change/update/modify the daily summary time or enable/disable it should use update_settings, NOT update_reminder or delete_reminder.
+IMPORTANT: "lifecycle_messages" controls proactive check-ins/trial nudges/marketing only — it does NOT silence reminders the user has asked for. Use it when the user expresses they don't want unsolicited texts but still want their reminders.
 
 For DELETING/FORGETTING A MEMORY:
 {{

--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -783,6 +783,12 @@ def send_engagement_nudge(self, phone_number: str):
             create_or_update_user(phone_number, five_minute_nudge_sent=True)
             return {"status": "skipped", "reason": "opted_out"}
 
+        # Check: User has soft-paused lifecycle messages
+        if status.get('lifecycle_paused'):
+            logger.info(f"User ...{phone_number[-4:]} paused lifecycle messages, skipping engagement nudge")
+            create_or_update_user(phone_number, five_minute_nudge_sent=True)
+            return {"status": "skipped", "reason": "lifecycle_paused"}
+
         # Check: User has sent 2+ messages since onboarding
         if status['interactions'] >= 2:
             logger.info(f"User ...{phone_number[-4:]} has {status['interactions']} interactions, "
@@ -876,6 +882,7 @@ def check_trial_expirations(self):
               AND trial_end_date > %s - INTERVAL '8 days'
               AND onboarding_complete = TRUE
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
               AND (stripe_subscription_id IS NULL OR subscription_status != 'active')
         """, (now_utc,))
 
@@ -1073,6 +1080,7 @@ def send_mid_trial_value_reminders(self):
               AND (mid_trial_reminder_sent IS NULL OR mid_trial_reminder_sent = FALSE)
               AND (trial_warning_7d_sent IS NULL OR trial_warning_7d_sent = FALSE)
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
         """, (now_utc, now_utc))
 
         users = c.fetchall()
@@ -1333,6 +1341,7 @@ def send_day_1_morning_nudge(self):
               AND onboarding_complete = TRUE
               AND (day_1_nudge_sent IS NULL OR day_1_nudge_sent = FALSE)
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
         """, (now_utc,))
 
         users = c.fetchall()
@@ -1441,6 +1450,7 @@ def send_day_2_feature_prompt(self):
               AND onboarding_complete = TRUE
               AND (day_2_nudge_sent IS NULL OR day_2_nudge_sent = FALSE)
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
         """, (now_utc,))
 
         users = c.fetchall()
@@ -1562,6 +1572,7 @@ def send_day_3_engagement_nudges(self):
               AND onboarding_complete = TRUE
               AND (day_3_nudge_sent IS NULL OR day_3_nudge_sent = FALSE)
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
         """, (now_utc,))
 
         users = c.fetchall()
@@ -1673,6 +1684,7 @@ def send_day_4_email_collection(self):
               AND onboarding_complete = TRUE
               AND (day_4_email_sent IS NULL OR day_4_email_sent = FALSE)
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
               AND (email IS NULL OR email = '')
         """, (now_utc,))
 
@@ -1786,6 +1798,7 @@ def send_post_trial_reengagement(self):
               AND premium_status = 'free'
               AND (post_trial_reengagement_sent IS NULL OR post_trial_reengagement_sent = FALSE)
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
               AND (stripe_subscription_id IS NULL OR subscription_status != 'active')
         """, (now_utc,))
 
@@ -1901,6 +1914,7 @@ def send_14d_post_trial_touchpoint(self):
               AND premium_status = 'free'
               AND (post_trial_14d_sent IS NULL OR post_trial_14d_sent = FALSE)
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
               AND (stripe_subscription_id IS NULL OR subscription_status != 'active')
         """, (now_utc,))
 
@@ -2034,6 +2048,7 @@ def send_30d_winback(self):
               AND premium_status = 'free'
               AND (winback_30d_sent IS NULL OR winback_30d_sent = FALSE)
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
               AND (stripe_subscription_id IS NULL OR subscription_status != 'active')
         """, (window_start, target_date))
 
@@ -2145,6 +2160,7 @@ def send_inactivity_nudge(self):
               AND onboarding_complete = TRUE
               AND (inactivity_nudge_sent_at IS NULL OR inactivity_nudge_sent_at < %s)
               AND (opted_out IS NULL OR opted_out = FALSE)
+              AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)
         """, (inactive_threshold, cooldown_threshold))
 
         users = c.fetchall()

--- a/tests/test_lifecycle_pause.py
+++ b/tests/test_lifecycle_pause.py
@@ -1,0 +1,204 @@
+"""
+Tests for the lifecycle-message soft opt-out.
+
+Distinct from the hard STOP opt-out: a paused user still gets the reminders
+they explicitly scheduled, but proactive trial/winback/inactivity sends are
+silenced. The flag is `users.lifecycle_messages_opted_out`.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# =====================================================
+# HELPER FUNCTION TESTS (mocked DB)
+# =====================================================
+
+def _conn_with_fetchone(returns):
+    cur = MagicMock()
+    cur.fetchone.return_value = returns
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestLifecyclePauseHelpers:
+    def test_pause_lifecycle_messages_sets_flag_and_timestamp(self):
+        from models import user as user_model
+        conn, cur = _conn_with_fetchone(None)
+        with patch.object(user_model, 'get_db_connection', return_value=conn), \
+             patch.object(user_model, 'return_db_connection'):
+            assert user_model.pause_lifecycle_messages('+15551234567') is True
+            sql = cur.execute.call_args[0][0]
+            assert 'lifecycle_messages_opted_out = TRUE' in sql
+            assert 'lifecycle_messages_opted_out_at = CURRENT_TIMESTAMP' in sql
+
+    def test_resume_lifecycle_messages_clears_flag(self):
+        from models import user as user_model
+        conn, cur = _conn_with_fetchone(None)
+        with patch.object(user_model, 'get_db_connection', return_value=conn), \
+             patch.object(user_model, 'return_db_connection'):
+            assert user_model.resume_lifecycle_messages('+15551234567') is True
+            sql = cur.execute.call_args[0][0]
+            assert 'lifecycle_messages_opted_out = FALSE' in sql
+            assert 'lifecycle_messages_opted_out_at = NULL' in sql
+
+    def test_is_lifecycle_paused_true_when_flag_set(self):
+        from models import user as user_model
+        conn, _ = _conn_with_fetchone((True,))
+        with patch.object(user_model, 'get_db_connection', return_value=conn), \
+             patch.object(user_model, 'return_db_connection'), \
+             patch.object(user_model, 'ENCRYPTION_ENABLED', False):
+            assert user_model.is_lifecycle_paused('+15551234567') is True
+
+    def test_is_lifecycle_paused_false_when_flag_unset(self):
+        from models import user as user_model
+        conn, _ = _conn_with_fetchone((False,))
+        with patch.object(user_model, 'get_db_connection', return_value=conn), \
+             patch.object(user_model, 'return_db_connection'), \
+             patch.object(user_model, 'ENCRYPTION_ENABLED', False):
+            assert user_model.is_lifecycle_paused('+15551234567') is False
+
+    def test_is_lifecycle_paused_false_for_unknown_user(self):
+        from models import user as user_model
+        conn, _ = _conn_with_fetchone(None)
+        with patch.object(user_model, 'get_db_connection', return_value=conn), \
+             patch.object(user_model, 'return_db_connection'), \
+             patch.object(user_model, 'ENCRYPTION_ENABLED', False):
+            assert user_model.is_lifecycle_paused('+15551234567') is False
+
+
+# =====================================================
+# LIFECYCLE QUERY GATING — make sure each scheduled task
+# query has a clause excluding paused users.
+# =====================================================
+
+class TestLifecycleQueriesAreGated:
+    """Every lifecycle query must filter out lifecycle_messages_opted_out users.
+    This guards against forgetting to add the gate when new lifecycle tasks
+    land in tasks/reminder_tasks.py.
+    """
+
+    def test_every_opted_out_clause_has_lifecycle_clause(self):
+        with open('tasks/reminder_tasks.py', 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        opted_out_count = content.count('AND (opted_out IS NULL OR opted_out = FALSE)')
+        lifecycle_count = content.count(
+            'AND (lifecycle_messages_opted_out IS NULL OR lifecycle_messages_opted_out = FALSE)'
+        )
+        # Every opt-out gate should be paired with a lifecycle gate.
+        assert opted_out_count > 0, "Expected at least one opted_out clause"
+        assert lifecycle_count == opted_out_count, (
+            f"Found {opted_out_count} `opted_out` clauses but only "
+            f"{lifecycle_count} `lifecycle_messages_opted_out` clauses — "
+            "every lifecycle query must be gated on both."
+        )
+
+
+# =====================================================
+# KEYWORD HANDLER TESTS (via ConversationSimulator)
+# =====================================================
+
+class TestPauseKeywordHandlers:
+    @pytest.mark.asyncio
+    async def test_pause_keyword_pauses_lifecycle(
+        self, simulator, sms_capture, ai_mock, onboarded_user
+    ):
+        phone = onboarded_user['phone']
+        result = await simulator.send_message(phone, "PAUSE")
+        assert 'reminders you' in result['output'].lower() \
+            or 'check-in' in result['output'].lower()
+
+        from models.user import is_lifecycle_paused
+        assert is_lifecycle_paused(phone) is True
+
+    @pytest.mark.asyncio
+    async def test_quiet_keyword_pauses_lifecycle(
+        self, simulator, sms_capture, ai_mock, onboarded_user
+    ):
+        phone = onboarded_user['phone']
+        await simulator.send_message(phone, "QUIET")
+
+        from models.user import is_lifecycle_paused
+        assert is_lifecycle_paused(phone) is True
+
+    @pytest.mark.asyncio
+    async def test_mute_keyword_pauses_lifecycle(
+        self, simulator, sms_capture, ai_mock, onboarded_user
+    ):
+        phone = onboarded_user['phone']
+        await simulator.send_message(phone, "MUTE")
+
+        from models.user import is_lifecycle_paused
+        assert is_lifecycle_paused(phone) is True
+
+    @pytest.mark.asyncio
+    async def test_resume_keyword_unpauses_lifecycle(
+        self, simulator, sms_capture, ai_mock, onboarded_user
+    ):
+        phone = onboarded_user['phone']
+        await simulator.send_message(phone, "PAUSE")
+        result = await simulator.send_message(phone, "RESUME")
+        assert 'welcome back' in result['output'].lower() \
+            or 'lifecycle' in result['output'].lower()
+
+        from models.user import is_lifecycle_paused
+        assert is_lifecycle_paused(phone) is False
+
+    @pytest.mark.asyncio
+    async def test_pause_does_not_set_hard_opt_out(
+        self, simulator, sms_capture, ai_mock, onboarded_user
+    ):
+        """Soft pause must not flip the carrier-level opted_out flag — that's
+        what STOP is for, and the user explicitly wants their reminders."""
+        phone = onboarded_user['phone']
+        await simulator.send_message(phone, "PAUSE")
+
+        from models.user import is_user_opted_out, is_lifecycle_paused
+        assert is_lifecycle_paused(phone) is True
+        assert is_user_opted_out(phone) is False
+
+
+# =====================================================
+# AI NATURAL-LANGUAGE PATH (via update_settings action)
+# =====================================================
+
+class TestLifecycleViaAI:
+    @pytest.mark.asyncio
+    async def test_natural_language_pause_sets_flag(
+        self, simulator, sms_capture, ai_mock, onboarded_user
+    ):
+        phone = onboarded_user['phone']
+        msg = "Don't text me unless it's about a reminder I asked about"
+        ai_mock.set_response(msg, {
+            'action': 'update_settings',
+            'setting': 'lifecycle_messages',
+            'value': 'paused',
+            'confirmation': "Pausing lifecycle messages",
+        })
+        await simulator.send_message(phone, msg)
+
+        from models.user import is_lifecycle_paused
+        assert is_lifecycle_paused(phone) is True
+
+    @pytest.mark.asyncio
+    async def test_natural_language_resume_clears_flag(
+        self, simulator, sms_capture, ai_mock, onboarded_user
+    ):
+        phone = onboarded_user['phone']
+        from models.user import pause_lifecycle_messages
+        pause_lifecycle_messages(phone)
+
+        msg = "you can text me again"
+        ai_mock.set_response(msg, {
+            'action': 'update_settings',
+            'setting': 'lifecycle_messages',
+            'value': 'resumed',
+            'confirmation': "Resuming lifecycle messages",
+        })
+        await simulator.send_message(phone, msg)
+
+        from models.user import is_lifecycle_paused
+        assert is_lifecycle_paused(phone) is False


### PR DESCRIPTION
## Summary
- New `users.lifecycle_messages_opted_out` flag silences trial/winback/inactivity/email-collection sends without affecting user-scheduled reminders. STOP remains the hard opt-out.
- Triggered via keyword (`PAUSE`/`QUIET`/`MUTE`, inverse `RESUME`/`UNPAUSE`/`UNMUTE`) **or** natural language routed through `update_settings` (e.g. *"don't text me unless it's about a reminder I asked for"*).
- All 10 lifecycle queries in `tasks/reminder_tasks.py` and the runtime `send_engagement_nudge` check now exclude paused users.
- Includes a guard test that fails if a future lifecycle query is added without the gate, so this can't silently rot.

## Why
A user texted "Don't text me unless it's about a reminder I asked about" and the AI replied "I understand!" — but no flag was set, so they'd still receive every Day 3/4/7/14/30/44 lifecycle message until they texted STOP. STOP is too blunt (kills reminders too). This adds the missing middle ground.

## Test plan
- [x] `python -m pytest tests/test_lifecycle_pause.py` — 13/13 passing (helpers, keyword handlers, AI path, guard test)
- [x] `python run_tests.py --quick` — no new failures (two unrelated pre-existing failures in `test_context_switching.py`)
- [ ] Smoke-test in staging: pause via PAUSE keyword, verify a scheduled reminder still fires, verify lifecycle queries skip the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)