### PR TITLE
Reduce lifecycle over-messaging: disable trial warnings, cap inactivity nudge

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -68,13 +68,17 @@ beat_schedule = {
         "schedule": timedelta(hours=1),
     },
     # Check trial expirations hourly — sends when user's local time is 9-10 AM
-    "check-trial-expirations": {
-        "task": "tasks.reminder_tasks.check_trial_expirations",
-        "schedule": crontab(minute=0),  # Every hour, on the hour
-        "options": {
-            "expires": 3500,  # Just under 1 hour
-        },
-    },
+    # DISABLED 2026-05-30: there is no real trial->paywall in production, so these
+    # "your trial is expiring" warnings were crying wolf to ~46 users (a top STOP
+    # driver). The task function is kept intact; re-add this schedule entry only
+    # once a genuine trial/paywall exists. See docs/changelog.md.
+    # "check-trial-expirations": {
+    #     "task": "tasks.reminder_tasks.check_trial_expirations",
+    #     "schedule": crontab(minute=0),  # Every hour, on the hour
+    #     "options": {
+    #         "expires": 3500,  # Just under 1 hour
+    #     },
+    # },
     # Send mid-trial value reminders hourly — timezone-aware (9-10 AM local)
     "send-mid-trial-value-reminders": {
         "task": "tasks.reminder_tasks.send_mid_trial_value_reminders",

--- a/config.py
+++ b/config.py
@@ -262,6 +262,10 @@ NUDGE_CONFIDENCE_THRESHOLD = 50    # Minimum confidence to send a nudge (0-100)
 NUDGE_MAX_CHARS = 280              # Max characters per nudge (2 SMS segments)
 COMBINED_NUDGE_MAX_CHARS = 1500    # Max total length for combined summary + nudge message
 
+# Re-engagement: stop nudging a chronically inactive user after this many
+# attempts (was previously weekly-forever, a top STOP driver). 0 = unlimited.
+INACTIVITY_NUDGE_MAX_ATTEMPTS = 2
+
 # Anthropic API Key (for future Agent 4 AI file identification)
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 

--- a/database.py
+++ b/database.py
@@ -588,6 +588,9 @@ def init_db():
             # Inactivity re-engagement nudge
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS inactivity_nudge_sent_at TIMESTAMP",
             "UPDATE users SET inactivity_nudge_sent_at = NULL WHERE inactivity_nudge_sent_at IS NULL",
+            # Cap how many inactivity nudges a single user receives (was weekly-forever)
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS inactivity_nudge_count INTEGER DEFAULT 0",
+            "UPDATE users SET inactivity_nudge_count = 0 WHERE inactivity_nudge_count IS NULL",
             # Smart Nudges: proactive AI intelligence layer
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS smart_nudges_enabled BOOLEAN DEFAULT FALSE",
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS smart_nudge_time TIME DEFAULT '09:00'",

--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -2118,13 +2118,16 @@ def send_inactivity_nudge(self):
 
     Runs hourly via Celery Beat. Timezone-aware: only sends at 9-10 AM local.
     Uses inactivity_nudge_sent_at timestamp with 7-day cooldown for repeat nudging.
-    First nudge: after 7 days inactive. Repeats weekly while user remains inactive.
+    First nudge: after 7 days inactive. Repeats weekly while user remains inactive,
+    up to INACTIVITY_NUDGE_MAX_ATTEMPTS total (0 = unlimited) so chronically dormant
+    users aren't nudged forever.
     """
     import pytz
     from datetime import datetime, timedelta
     from database import get_db_connection, return_db_connection
     from models.list_model import get_list_count
     from services.tier_service import get_memory_count, get_recurring_reminder_count
+    from config import INACTIVITY_NUDGE_MAX_ATTEMPTS
 
     logger.info("Starting inactivity re-engagement nudge check")
 
@@ -2144,8 +2147,10 @@ def send_inactivity_nudge(self):
               AND last_active_at < %s
               AND onboarding_complete = TRUE
               AND (inactivity_nudge_sent_at IS NULL OR inactivity_nudge_sent_at < %s)
+              AND (%s <= 0 OR COALESCE(inactivity_nudge_count, 0) < %s)
               AND (opted_out IS NULL OR opted_out = FALSE)
-        """, (inactive_threshold, cooldown_threshold))
+        """, (inactive_threshold, cooldown_threshold,
+              INACTIVITY_NUDGE_MAX_ATTEMPTS, INACTIVITY_NUDGE_MAX_ATTEMPTS))
 
         users = c.fetchall()
 
@@ -2222,7 +2227,9 @@ Reply STOP to opt out."""
 
                 send_sms(phone_number, message, message_type="trial_lifecycle")
                 c.execute(
-                    "UPDATE users SET inactivity_nudge_sent_at = %s WHERE phone_number = %s",
+                    "UPDATE users SET inactivity_nudge_sent_at = %s, "
+                    "inactivity_nudge_count = COALESCE(inactivity_nudge_count, 0) + 1 "
+                    "WHERE phone_number = %s",
                     (now_utc, phone_number)
                 )
                 conn.commit()


### PR DESCRIPTION
## Why
Diagnosis of production data (2026-05-30) found ~22% of users (12 of 55) had texted STOP, driven by over-aggressive proactive SMS. Two of the worst offenders:

1. **Trial-expiration warnings** were sent to ~46 users, but there is no real trial→paywall in production — pure wolf-crying.
2. **Inactivity nudges** re-fired weekly *forever* to every cold user.

## Changes
- **Unschedule `check_trial_expirations`** in Celery Beat (function kept intact; re-enable when a real trial/paywall exists).
- **Cap the inactivity nudge** at `INACTIVITY_NUDGE_MAX_ATTEMPTS` (2) instead of weekly-forever. Adds `users.inactivity_nudge_count` (auto-migrated by `init_db`).

## Notes
- `send_mid_trial_value_reminders` left scheduled (it's a value message, not a wolf-cry) — slated for the next consolidation pass.
- Already-cold users reset to count 0, so a long-dormant user could get up to 2 more nudges before the cap bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)