### PR TITLE
Add founder survey: ask active users what they use Remyndrs for

### DIFF
--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -903,6 +903,238 @@ def start_broadcast_checker():
 
 
 # =====================================================
+# FOUNDER SURVEY (one-off: ask active users what they use Remyndrs for)
+# =====================================================
+
+def _founder_survey_recipients(c):
+    """Active-in-last-14-days users, excluding opted-out and the founder's own
+    numbers. Returns list of dicts with decrypted name + already-surveyed flag."""
+    from config import FOUNDER_SURVEY_EXCLUDE_PHONES
+    c.execute('''
+        SELECT u.phone_number, u.first_name, u.last_active_at,
+               EXISTS(
+                   SELECT 1 FROM smart_nudges sn
+                   WHERE sn.phone_number = u.phone_number
+                     AND sn.nudge_type = 'founder_survey'
+               ) AS already_surveyed
+        FROM users u
+        WHERE u.onboarding_complete = TRUE
+          AND u.last_active_at >= NOW() - INTERVAL '14 days'
+          AND (u.opted_out = FALSE OR u.opted_out IS NULL)
+          AND u.phone_number <> ALL(%s)
+        ORDER BY u.last_active_at DESC
+    ''', (FOUNDER_SURVEY_EXCLUDE_PHONES,))
+    recipients = []
+    for phone, first_name, last_active, already in c.fetchall():
+        recipients.append({
+            "phone_full": phone,
+            "phone": mask_phone_number(phone),
+            "name": (safe_decrypt(first_name, "") if first_name else "") or None,
+            "last_active": last_active.strftime("%Y-%m-%d") if last_active else None,
+            "already_surveyed": bool(already),
+        })
+    return recipients
+
+
+@router.get("/admin/founder-survey/recipients-preview")
+async def founder_survey_preview(admin: str = Depends(verify_admin)):
+    """Preview who would receive the founder survey (no sends)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        recipients = _founder_survey_recipients(conn.cursor())
+        not_yet = [r for r in recipients if not r["already_surveyed"]]
+        return JSONResponse(content={
+            "recipients": recipients,
+            "summary": {
+                "total": len(recipients),
+                "not_yet_surveyed": len(not_yet),
+                "already_surveyed": len(recipients) - len(not_yet),
+            },
+        })
+    except Exception as e:
+        logger.error(f"Error previewing founder survey: {e}")
+        raise HTTPException(status_code=500, detail="Error previewing founder survey")
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def _send_founder_surveys(recipients: list):
+    """Background task: send the survey + arm capture for each recipient."""
+    import time
+    from services.nudge_service import send_founder_survey
+    sent = 0
+    for r in recipients:
+        try:
+            if send_founder_survey(r["phone_full"], r.get("name")):
+                sent += 1
+        except Exception as e:
+            logger.error(f"Founder survey send failed for {r['phone_full'][-4:]}: {e}")
+        time.sleep(0.1)  # gentle pacing for Twilio
+    logger.info(f"Founder survey batch complete: {sent}/{len(recipients)} sent")
+
+
+@router.post("/admin/founder-survey/send")
+async def founder_survey_send(
+    background_tasks: BackgroundTasks,
+    skip_surveyed: bool = True,
+    admin: str = Depends(verify_admin),
+):
+    """Send the founder survey to active users (skips already-surveyed by default)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        recipients = _founder_survey_recipients(conn.cursor())
+        if skip_surveyed:
+            recipients = [r for r in recipients if not r["already_surveyed"]]
+        if not recipients:
+            return JSONResponse(content={"queued": 0, "message": "No eligible recipients."})
+        background_tasks.add_task(_send_founder_surveys, recipients)
+        logger.info(f"Founder survey queued by {admin}: {len(recipients)} recipients")
+        return JSONResponse(content={
+            "queued": len(recipients),
+            "message": f"Sending the survey to {len(recipients)} user(s)...",
+        })
+    except Exception as e:
+        logger.error(f"Error sending founder survey: {e}")
+        raise HTTPException(status_code=500, detail="Error sending founder survey")
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+@router.get("/admin/founder-survey/responses")
+async def founder_survey_responses(admin: str = Depends(verify_admin)):
+    """List every founder-survey send and its response (if any)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute('''
+            SELECT sn.phone_number, u.first_name, sn.sent_at,
+                   sn.user_response, sn.user_responded_at
+            FROM smart_nudges sn
+            LEFT JOIN users u ON u.phone_number = sn.phone_number
+            WHERE sn.nudge_type = 'founder_survey'
+            ORDER BY (sn.user_response IS NOT NULL) DESC, sn.sent_at DESC
+        ''')
+        rows = []
+        responded = 0
+        for phone, first_name, sent_at, response, responded_at in c.fetchall():
+            if response:
+                responded += 1
+            rows.append({
+                "phone": mask_phone_number(phone),
+                "name": (safe_decrypt(first_name, "") if first_name else "") or None,
+                "sent_at": sent_at.strftime("%Y-%m-%d %H:%M") if sent_at else None,
+                "response": response,
+                "responded_at": responded_at.strftime("%Y-%m-%d %H:%M") if responded_at else None,
+            })
+        return JSONResponse(content={
+            "responses": rows,
+            "summary": {"sent": len(rows), "responded": responded},
+        })
+    except Exception as e:
+        logger.error(f"Error loading founder survey responses: {e}")
+        raise HTTPException(status_code=500, detail="Error loading founder survey responses")
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+@router.get("/admin/founder-survey", response_class=HTMLResponse)
+async def founder_survey_page(admin: str = Depends(verify_admin)):
+    """Self-contained admin page to preview, send, and read founder survey answers."""
+    return HTMLResponse(content=FOUNDER_SURVEY_HTML)
+
+
+FOUNDER_SURVEY_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Founder Survey · Remyndrs Admin</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, sans-serif; max-width: 880px; margin: 24px auto; padding: 0 16px; color: #1a1a1a; }
+  h1 { font-size: 22px; } h2 { font-size: 16px; margin-top: 28px; }
+  p.sub { color: #666; font-size: 14px; }
+  button { background: #2563eb; color: #fff; border: 0; padding: 9px 14px; border-radius: 6px; font-size: 14px; cursor: pointer; }
+  button.secondary { background: #e5e7eb; color: #111; }
+  button:disabled { opacity: .5; cursor: default; }
+  table { border-collapse: collapse; width: 100%; margin-top: 10px; font-size: 14px; }
+  th, td { text-align: left; padding: 7px 9px; border-bottom: 1px solid #eee; vertical-align: top; }
+  th { color: #555; font-weight: 600; }
+  .pill { font-size: 12px; padding: 2px 8px; border-radius: 999px; }
+  .pending { background: #fef3c7; color: #92400e; } .done { background: #dcfce7; color: #166534; }
+  .muted { color: #999; } .answer { white-space: pre-wrap; }
+  #status { margin-left: 10px; font-size: 14px; color: #166534; }
+</style>
+</head>
+<body>
+  <h1>Founder Survey</h1>
+  <p class="sub">Asks active users what they use Remyndrs for. Each reply is captured verbatim (not processed as a reminder/memory) and shown below. Your own numbers are excluded automatically.</p>
+
+  <h2>1 · Recipients</h2>
+  <button class="secondary" onclick="loadPreview()">Preview recipients</button>
+  <button id="sendBtn" onclick="sendSurvey()" style="display:none">Send survey</button>
+  <span id="status"></span>
+  <div id="preview"></div>
+
+  <h2>2 · Responses</h2>
+  <button class="secondary" onclick="loadResponses()">Refresh responses</button>
+  <div id="responses"></div>
+
+<script>
+async function loadPreview() {
+  const el = document.getElementById('preview');
+  el.innerHTML = 'Loading...';
+  const r = await fetch('/admin/founder-survey/recipients-preview');
+  const d = await r.json();
+  const s = d.summary;
+  let html = `<p class="sub">${s.total} active recipient(s) · ${s.not_yet_surveyed} not yet surveyed · ${s.already_surveyed} already surveyed</p>`;
+  html += '<table><tr><th>Name</th><th>Phone</th><th>Last active</th><th>Status</th></tr>';
+  for (const u of d.recipients) {
+    html += `<tr><td>${u.name || '<span class=muted>(no name)</span>'}</td><td>${u.phone}</td><td>${u.last_active || ''}</td>`
+         + `<td>${u.already_surveyed ? '<span class="pill done">surveyed</span>' : '<span class="pill pending">new</span>'}</td></tr>`;
+  }
+  html += '</table>';
+  el.innerHTML = html;
+  const btn = document.getElementById('sendBtn');
+  btn.style.display = s.not_yet_surveyed > 0 ? 'inline-block' : 'none';
+  btn.textContent = `Send survey to ${s.not_yet_surveyed} new user(s)`;
+}
+async function sendSurvey() {
+  if (!confirm('Send the founder survey now? This texts real users.')) return;
+  const btn = document.getElementById('sendBtn'); btn.disabled = true;
+  const r = await fetch('/admin/founder-survey/send?skip_surveyed=true', { method: 'POST' });
+  const d = await r.json();
+  document.getElementById('status').textContent = d.message || 'Done.';
+  btn.disabled = false;
+  setTimeout(loadResponses, 1500);
+}
+async function loadResponses() {
+  const el = document.getElementById('responses');
+  el.innerHTML = 'Loading...';
+  const r = await fetch('/admin/founder-survey/responses');
+  const d = await r.json();
+  let html = `<p class="sub">${d.summary.responded} of ${d.summary.sent} sent have replied</p>`;
+  html += '<table><tr><th>Name</th><th>Phone</th><th>Sent</th><th>Answer</th></tr>';
+  for (const x of d.responses) {
+    const ans = x.response
+      ? `<span class="answer">${(x.response||'').replace(/</g,'&lt;')}</span><br><span class="muted">${x.responded_at||''}</span>`
+      : '<span class="pill pending">waiting</span>';
+    html += `<tr><td>${x.name || '<span class=muted>(no name)</span>'}</td><td>${x.phone}</td><td class="muted">${x.sent_at||''}</td><td>${ans}</td></tr>`;
+  }
+  html += '</table>';
+  el.innerHTML = d.responses.length ? html : '<p class="sub">No surveys sent yet.</p>';
+}
+loadResponses();
+</script>
+</body>
+</html>"""
+
+
+# =====================================================
 # FEEDBACK API ENDPOINTS
 # =====================================================
 

--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -911,7 +911,7 @@ def _founder_survey_recipients(c):
     numbers. Returns list of dicts with decrypted name + already-surveyed flag."""
     from config import FOUNDER_SURVEY_EXCLUDE_PHONES
     c.execute('''
-        SELECT u.phone_number, u.first_name, u.last_active_at,
+        SELECT u.phone_number, u.first_name, u.last_active_at, u.timezone,
                EXISTS(
                    SELECT 1 FROM smart_nudges sn
                    WHERE sn.phone_number = u.phone_number
@@ -925,12 +925,21 @@ def _founder_survey_recipients(c):
         ORDER BY u.last_active_at DESC
     ''', (FOUNDER_SURVEY_EXCLUDE_PHONES,))
     recipients = []
-    for phone, first_name, last_active, already in c.fetchall():
+    for phone, first_name, last_active, timezone_str, already in c.fetchall():
+        try:
+            tz = pytz.timezone(timezone_str or DEFAULT_TIMEZONE)
+        except pytz.UnknownTimezoneError:
+            tz = pytz.timezone(DEFAULT_TIMEZONE)
+        local_time = datetime.now(tz).strftime("%I:%M %p").lstrip("0")
         recipients.append({
             "phone_full": phone,
             "phone": mask_phone_number(phone),
             "name": (safe_decrypt(first_name, "") if first_name else "") or None,
             "last_active": last_active.strftime("%Y-%m-%d") if last_active else None,
+            "timezone": timezone_str or DEFAULT_TIMEZONE,
+            "local_time": local_time,
+            # Only send during daytime (8am-8pm local), matching broadcast policy
+            "in_window": is_within_broadcast_window(timezone_str),
             "already_surveyed": bool(already),
         })
     return recipients
@@ -944,12 +953,15 @@ async def founder_survey_preview(admin: str = Depends(verify_admin)):
         conn = get_db_connection()
         recipients = _founder_survey_recipients(conn.cursor())
         not_yet = [r for r in recipients if not r["already_surveyed"]]
+        sendable_now = [r for r in not_yet if r["in_window"]]
         return JSONResponse(content={
             "recipients": recipients,
             "summary": {
                 "total": len(recipients),
                 "not_yet_surveyed": len(not_yet),
                 "already_surveyed": len(recipients) - len(not_yet),
+                "sendable_now": len(sendable_now),
+                "waiting_for_window": len(not_yet) - len(sendable_now),
             },
         })
     except Exception as e:
@@ -988,13 +1000,24 @@ async def founder_survey_send(
         recipients = _founder_survey_recipients(conn.cursor())
         if skip_surveyed:
             recipients = [r for r in recipients if not r["already_surveyed"]]
+        # Only text users currently in their 8am-8pm local window; the rest can
+        # be reached by sending again later (skip_surveyed avoids double-texts).
+        held = [r for r in recipients if not r["in_window"]]
+        recipients = [r for r in recipients if r["in_window"]]
         if not recipients:
-            return JSONResponse(content={"queued": 0, "message": "No eligible recipients."})
+            msg = "No recipients are within their 8am-8pm local window right now."
+            if held:
+                msg += f" {len(held)} waiting for daytime — try again later."
+            return JSONResponse(content={"queued": 0, "held_out_of_window": len(held), "message": msg})
         background_tasks.add_task(_send_founder_surveys, recipients)
-        logger.info(f"Founder survey queued by {admin}: {len(recipients)} recipients")
+        logger.info(f"Founder survey queued by {admin}: {len(recipients)} recipients ({len(held)} held - outside window)")
+        message = f"Sending the survey to {len(recipients)} user(s)..."
+        if held:
+            message += f" ({len(held)} held until daytime — re-send later to reach them.)"
         return JSONResponse(content={
             "queued": len(recipients),
-            "message": f"Sending the survey to {len(recipients)} user(s)...",
+            "held_out_of_window": len(held),
+            "message": message,
         })
     except Exception as e:
         logger.error(f"Error sending founder survey: {e}")
@@ -1091,17 +1114,22 @@ async function loadPreview() {
   const r = await fetch('/admin/founder-survey/recipients-preview');
   const d = await r.json();
   const s = d.summary;
-  let html = `<p class="sub">${s.total} active recipient(s) · ${s.not_yet_surveyed} not yet surveyed · ${s.already_surveyed} already surveyed</p>`;
-  html += '<table><tr><th>Name</th><th>Phone</th><th>Last active</th><th>Status</th></tr>';
+  let html = `<p class="sub">${s.total} active recipient(s) · ${s.not_yet_surveyed} not yet surveyed · ${s.already_surveyed} already surveyed`
+           + ` · <strong>${s.sendable_now} sendable now</strong> (8am-8pm local), ${s.waiting_for_window} waiting for daytime</p>`;
+  html += '<table><tr><th>Name</th><th>Phone</th><th>Last active</th><th>Local time</th><th>Status</th></tr>';
   for (const u of d.recipients) {
+    let status;
+    if (u.already_surveyed) status = '<span class="pill done">surveyed</span>';
+    else if (u.in_window) status = '<span class="pill pending">new</span>';
+    else status = '<span class="pill" style="background:#e5e7eb;color:#555">waiting for daytime</span>';
     html += `<tr><td>${u.name || '<span class=muted>(no name)</span>'}</td><td>${u.phone}</td><td>${u.last_active || ''}</td>`
-         + `<td>${u.already_surveyed ? '<span class="pill done">surveyed</span>' : '<span class="pill pending">new</span>'}</td></tr>`;
+         + `<td class="muted">${u.local_time || ''}</td><td>${status}</td></tr>`;
   }
   html += '</table>';
   el.innerHTML = html;
   const btn = document.getElementById('sendBtn');
-  btn.style.display = s.not_yet_surveyed > 0 ? 'inline-block' : 'none';
-  btn.textContent = `Send survey to ${s.not_yet_surveyed} new user(s)`;
+  btn.style.display = s.sendable_now > 0 ? 'inline-block' : 'none';
+  btn.textContent = `Send survey to ${s.sendable_now} user(s) in daytime now`;
 }
 async function sendSurvey() {
   if (!confirm('Send the founder survey now? This texts real users.')) return;

--- a/config.py
+++ b/config.py
@@ -85,6 +85,14 @@ ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD")
 # (e.g. UPGRADE keyword, shared-list mentions). Empty = notifications disabled.
 ADMIN_NOTIFICATION_PHONE = os.environ.get("ADMIN_NOTIFICATION_PHONE", "+18593935374")
 
+# Founder survey: phone numbers to always exclude from the survey (founder's
+# own / household test lines). Comma-separated E.164; env-overridable.
+FOUNDER_SURVEY_EXCLUDE_PHONES = [
+    p.strip() for p in os.environ.get(
+        "FOUNDER_SURVEY_EXCLUDE_PHONES", "+18593935374,+18593935373"
+    ).split(",") if p.strip()
+]
+
 # Customer Service Portal Authentication
 # Falls back to admin credentials if not set
 CS_USERNAME = os.environ.get("CS_USERNAME", ADMIN_USERNAME)

--- a/main.py
+++ b/main.py
@@ -1082,7 +1082,10 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
         # ==========================================
         # Check if user is responding to a smart nudge
         pending_nudge = get_pending_nudge_response(phone_number)
-        if pending_nudge and not is_undo_command and not is_new_reminder_request:
+        # A founder-survey reply is open-ended free text and must be captured
+        # verbatim even if it looks like a reminder request ("remind me about X").
+        is_survey_response = bool(pending_nudge and pending_nudge.get('nudge_type') == 'founder_survey')
+        if pending_nudge and (is_survey_response or (not is_undo_command and not is_new_reminder_request)):
             from services.nudge_service import handle_nudge_response
             nudge_reply = handle_nudge_response(phone_number, incoming_msg, pending_nudge)
             if nudge_reply:

--- a/services/nudge_service.py
+++ b/services/nudge_service.py
@@ -377,6 +377,41 @@ def send_nudge_to_user(phone_number: str, nudge_data: dict[str, Any]) -> bool:
         return False
 
 
+FOUNDER_SURVEY_QUESTION = (
+    "Hi {name}! Quick favor from the Remyndrs team: what's the one thing you "
+    "use Remyndrs for most, and what would make it a must-have for you? "
+    "Your reply comes straight to us. Thanks so much!"
+)
+
+
+def send_founder_survey(phone_number: str, first_name: str = None) -> Optional[int]:
+    """Send the one-off founder survey question and arm free-text capture.
+
+    Stores a smart_nudges row (nudge_type='founder_survey') and sets the pending
+    nudge response so the user's NEXT reply is captured verbatim by
+    handle_nudge_response (rather than being processed as a memory/reminder).
+
+    Returns the nudge id, or None on failure.
+    """
+    from services.sms_service import send_sms
+
+    greeting_name = (first_name or "").strip() or "there"
+    message = FOUNDER_SURVEY_QUESTION.format(name=greeting_name)
+
+    nudge_data = {'nudge_type': 'founder_survey', 'nudge_text': message}
+    try:
+        nudge_id = save_nudge(phone_number, nudge_data)
+        if not nudge_id:
+            return None
+        send_sms(phone_number, message, message_type="smart_nudge")
+        set_pending_nudge_response(phone_number, nudge_id, nudge_data)
+        logger.info(f"Sent founder survey to {phone_number[-4:]} (nudge {nudge_id})")
+        return nudge_id
+    except Exception as e:
+        logger.error(f"Error sending founder survey to {phone_number[-4:]}: {e}")
+        return None
+
+
 def is_nudge_eligible(premium_status: str, current_day: str) -> bool:
     """Check if user is eligible for a nudge based on tier.
 
@@ -427,6 +462,14 @@ def handle_nudge_response(phone_number: str, message: str, pending_nudge: dict[s
     nudge_type = pending_nudge.get('nudge_type')
     suggested_reminder = pending_nudge.get('suggested_reminder_text')
     related_reminder_id = pending_nudge.get('related_reminder_id')
+
+    # Founder survey: capture the entire free-text reply verbatim. This is an
+    # open-ended question, not a YES/NO keyword flow, so it must run before any
+    # keyword handling below.
+    if nudge_type == 'founder_survey':
+        create_or_update_user(phone_number, pending_nudge_response=None)
+        record_nudge_response(phone_number, nudge_id, message.strip(), 'survey_response')
+        return "Thank you — this genuinely helps us make Remyndrs better for you!"
 
     msg = message.strip().upper()
 


### PR DESCRIPTION
## Why
We have early product-market fit with a small power-user segment but need to learn *why* they stay and whether they'd pay. This adds a tool to ask them directly and collect answers in one place.

## What
- **`send_founder_survey()`** reuses the `smart_nudges` table (`nudge_type='founder_survey'`) and arms `pending_nudge_response` so the user's next reply is captured **verbatim** (not parsed as a reminder/memory).
- **Capture** wired through `handle_nudge_response` + the SMS webhook, bypassing the reminder-intent guard so answers like "remind me about X" aren't lost.
- **Admin page at `/admin/founder-survey`**: preview recipients (active last 14d, founder's own numbers excluded via `FOUNDER_SURVEY_EXCLUDE_PHONES`), send, and read answers as they arrive.
- **Timezone-aware**: only sends to users within their 8am-8pm local window (matches broadcast policy); the rest are held for a later re-send.

## Notes
- No DB migration — reuses `smart_nudges`.
- Sends run in prod only (needs Twilio creds); cannot send from local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)