### PR TITLE
Add analytics/ ops scripts

### DIFF
--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,0 +1,40 @@
+# Analytics & ops scripts
+
+One-off, **read-only by default** scripts for diagnosing the product and doing
+occasional data ops. They connect directly to Postgres — they do not import the
+app. Run them from the repo root with the venv active.
+
+## Connection / safety
+
+Set these in `.env` (gitignored):
+
+- `ANALYTICS_DATABASE_URL` — the DB to read. Use a read-only credential if you
+  have one; either way the read scripts open a **read-only session** as a guard.
+  Falls back to `DATABASE_URL` if unset.
+- `WRITE_DATABASE_URL` — only needed by `extend_beta_grants.py --apply`. The
+  Render "External Database URL" is read-write and works here. Falls back to
+  `DATABASE_URL`.
+
+The External Database URL from Render is read-write; the read scripts stay safe
+by forcing a read-only session on top of it, not by relying on the credential.
+
+## Scripts
+
+| Script | What it does | Writes? |
+|--------|--------------|---------|
+| `diagnose.py` | Funnel / retention / activation / delivery / intent diagnosis (9 sections). | No |
+| `funnel_probe.py` | Just the conversion-funnel stage counts (mirrors `/admin/funnel`). | No |
+| `check_grants.py` | Beta premium grant lengths + expiry timing. | No |
+| `extend_beta_grants.py` | Extends time-boxed beta comp grants so they don't expire. **Dry-run unless `--apply`.** | Only with `--apply` |
+
+```bash
+python analytics/diagnose.py
+python analytics/funnel_probe.py
+python analytics/check_grants.py
+python analytics/extend_beta_grants.py            # preview (no writes)
+python analytics/extend_beta_grants.py --apply    # extend (needs WRITE_DATABASE_URL)
+python analytics/extend_beta_grants.py --days 60  # override extension length
+```
+
+Note: phone numbers are stored plaintext in prod; names/emails may be encrypted.
+The read scripts auto-detect encryption and join on `phone_hash` when needed.

--- a/analytics/check_grants.py
+++ b/analytics/check_grants.py
@@ -1,0 +1,54 @@
+"""Read-only check: how long were beta premium grants, and when do they expire?"""
+import os
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+url = os.environ.get("ANALYTICS_DATABASE_URL") or os.environ.get("DATABASE_URL")
+c = psycopg2.connect(url)
+c.set_session(readonly=True, autocommit=True)
+cur = c.cursor()
+
+
+def show(label, sql):
+    cur.execute(sql)
+    print(label)
+    for r in cur.fetchall():
+        print("   ", r)
+    print()
+
+
+show("Granted length distribution (trial_end - premium_since, in days):", """
+  SELECT (trial_end_date::date - premium_since::date) AS days_granted, COUNT(*)
+  FROM users
+  WHERE premium_status='premium' AND premium_since IS NOT NULL AND trial_end_date IS NOT NULL
+  GROUP BY 1 ORDER BY 1
+""")
+
+show("Per-user grant detail (premium_since, trial_end, days):", """
+  SELECT premium_since::date, trial_end_date::date,
+         (trial_end_date::date - premium_since::date) AS days
+  FROM users
+  WHERE premium_status='premium' AND premium_since IS NOT NULL AND trial_end_date IS NOT NULL
+  ORDER BY trial_end_date
+""")
+
+show("Expiry timing vs today (2026-05-30):", """
+  SELECT
+    COUNT(*) FILTER (WHERE trial_end_date < NOW())                                            AS already_expired,
+    COUNT(*) FILTER (WHERE trial_end_date >= NOW() AND trial_end_date < NOW() + INTERVAL '14 days')   AS next_14d,
+    COUNT(*) FILTER (WHERE trial_end_date >= NOW() + INTERVAL '14 days' AND trial_end_date < NOW() + INTERVAL '30 days') AS d15_30,
+    COUNT(*) FILTER (WHERE trial_end_date >= NOW() + INTERVAL '30 days')                       AS later
+  FROM users WHERE premium_status='premium' AND trial_end_date IS NOT NULL
+""")
+
+show("Premium comps with NO trial_end_date:", """
+  SELECT COUNT(*) FROM users WHERE premium_status='premium' AND trial_end_date IS NULL
+""")
+
+show("subscription_status of premium comps:", """
+  SELECT COALESCE(subscription_status,'(null)'), COUNT(*)
+  FROM users WHERE premium_status='premium' GROUP BY 1
+""")
+
+c.close()

--- a/analytics/diagnose.py
+++ b/analytics/diagnose.py
@@ -1,0 +1,281 @@
+"""
+Read-only product diagnosis script.
+
+Connects to a PostgreSQL database in READ ONLY mode and prints a funnel /
+retention / activation report. It NEVER writes. Point it at a read-only
+credential via ANALYTICS_DATABASE_URL (falls back to DATABASE_URL).
+
+Usage:
+    python analytics/diagnose.py
+
+Auto-detects PII encryption: when users.phone_hash is populated, child tables
+are joined on phone_hash (a deterministic HMAC); otherwise on phone_number.
+"""
+
+import os
+import sys
+from contextlib import contextmanager
+
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_URL = os.environ.get("ANALYTICS_DATABASE_URL") or os.environ.get("DATABASE_URL")
+
+
+@contextmanager
+def ro_cursor():
+    """Read-only cursor. Forces the whole session to reject writes."""
+    if not DB_URL:
+        sys.exit("No ANALYTICS_DATABASE_URL or DATABASE_URL set in environment.")
+    conn = psycopg2.connect(DB_URL)
+    try:
+        conn.set_session(readonly=True, autocommit=True)
+        cur = conn.cursor()
+        cur.execute("SET default_transaction_read_only = on")
+        yield cur
+    finally:
+        conn.close()
+
+
+def q(cur, sql, params=None):
+    cur.execute(sql, params or ())
+    return cur.fetchall()
+
+
+def header(title):
+    print("\n" + "=" * 64)
+    print(title)
+    print("=" * 64)
+
+
+def detect_key(cur):
+    """Return the column to group/join users on (phone_hash if encrypted)."""
+    rows = q(cur, "SELECT COUNT(*) FROM users WHERE phone_hash IS NOT NULL")
+    if rows and rows[0][0] and rows[0][0] > 0:
+        return "phone_hash"
+    return "phone_number"
+
+
+def has_column(cur, table, col):
+    rows = q(
+        cur,
+        "SELECT 1 FROM information_schema.columns "
+        "WHERE table_name = %s AND column_name = %s",
+        (table, col),
+    )
+    return bool(rows)
+
+
+def join_key(cur, table, preferred):
+    """Use the preferred key only if this table actually has that column."""
+    if preferred == "phone_hash" and not has_column(cur, table, "phone_hash"):
+        return "phone_number"
+    return preferred
+
+
+def section(title, fn):
+    """Run a report section; isolate failures so one bad query won't abort."""
+    header(title)
+    try:
+        fn()
+    except Exception as e:  # noqa: BLE001 - diagnostic tool, keep going
+        print(f"  [skipped: {e}]")
+
+
+def main():
+    with ro_cursor() as cur:
+        key = detect_key(cur)
+        print(f"DB connected (read-only). User join key: {key}")
+
+        # ---- 1. OVERVIEW -------------------------------------------------
+        def overview():
+            (total,) = q(cur, "SELECT COUNT(*) FROM users")[0]
+            (onboarded,) = q(
+                cur, "SELECT COUNT(*) FROM users WHERE onboarding_complete"
+            )[0]
+            (premium,) = q(
+                cur,
+                "SELECT COUNT(*) FROM users WHERE premium_status NOT IN ('free','') "
+                "AND premium_status IS NOT NULL",
+            )[0]
+            print(f"  Total users:          {total}")
+            print(f"  Onboarding complete:  {onboarded}")
+            print(f"  Premium / paid:       {premium}")
+            if has_column(cur, "users", "lifecycle_messages_opted_out"):
+                (optout,) = q(
+                    cur,
+                    "SELECT COUNT(*) FROM users WHERE lifecycle_messages_opted_out",
+                )[0]
+                print(f"  Lifecycle opted-out:  {optout}")
+            else:
+                print("  Lifecycle opted-out:  (column not deployed to prod yet)")
+
+        section("1. OVERVIEW", overview)
+
+        # ---- 2. ACTIVITY RECENCY ----------------------------------------
+        def recency():
+            sql = """
+                SELECT
+                  COUNT(*) FILTER (WHERE last_active_at >= NOW() - INTERVAL '1 day')  AS d1,
+                  COUNT(*) FILTER (WHERE last_active_at >= NOW() - INTERVAL '7 days')  AS d7,
+                  COUNT(*) FILTER (WHERE last_active_at >= NOW() - INTERVAL '14 days') AS d14,
+                  COUNT(*) FILTER (WHERE last_active_at >= NOW() - INTERVAL '30 days') AS d30,
+                  COUNT(*) FILTER (WHERE last_active_at <  NOW() - INTERVAL '30 days'
+                                      OR last_active_at IS NULL)                       AS cold
+                FROM users
+            """
+            d1, d7, d14, d30, cold = q(cur, sql)[0]
+            print(f"  Active last 24h:   {d1}")
+            print(f"  Active last 7d:    {d7}")
+            print(f"  Active last 14d:   {d14}")
+            print(f"  Active last 30d:   {d30}")
+            print(f"  Cold (>30d/never): {cold}")
+
+        section("2. ACTIVITY RECENCY (by last_active_at)", recency)
+
+        # ---- 3. SIGNUP COHORTS BY WEEK ----------------------------------
+        def cohorts():
+            sql = """
+                SELECT
+                  date_trunc('week', created_at)::date AS wk,
+                  COUNT(*)                                              AS signups,
+                  COUNT(*) FILTER (WHERE onboarding_complete)           AS onboarded,
+                  COUNT(*) FILTER (WHERE last_active_at >= created_at + INTERVAL '7 days')  AS retained_7d,
+                  COUNT(*) FILTER (WHERE last_active_at >= NOW() - INTERVAL '30 days')      AS still_active,
+                  COUNT(*) FILTER (WHERE premium_status NOT IN ('free','')
+                                     AND premium_status IS NOT NULL)    AS paid
+                FROM users
+                GROUP BY 1 ORDER BY 1 DESC
+                LIMIT 20
+            """
+            print(f"  {'week':<12}{'signup':>7}{'onbd':>6}{'ret7d':>7}{'active':>8}{'paid':>6}")
+            for wk, s, o, r7, act, paid in q(cur, sql):
+                print(f"  {str(wk):<12}{s:>7}{o:>6}{r7:>7}{act:>8}{paid:>6}")
+
+        section("3. SIGNUP COHORTS BY WEEK (most recent first)", cohorts)
+
+        # ---- 4. ACTIVATION: time to first reminder ----------------------
+        def activation():
+            sql = f"""
+                WITH firsts AS (
+                    SELECT u.{key} AS k, u.created_at AS signup,
+                           MIN(r.created_at) AS first_reminder
+                    FROM users u
+                    LEFT JOIN reminders r ON r.{key} = u.{key}
+                    GROUP BY u.{key}, u.created_at
+                )
+                SELECT
+                  COUNT(*)                                              AS users,
+                  COUNT(first_reminder)                                 AS ever_made_reminder,
+                  ROUND(AVG(EXTRACT(EPOCH FROM (first_reminder - signup))/3600)::numeric, 1) AS avg_hrs,
+                  ROUND((PERCENTILE_CONT(0.5) WITHIN GROUP (
+                      ORDER BY EXTRACT(EPOCH FROM (first_reminder - signup))/3600))::numeric, 1) AS median_hrs
+                FROM firsts
+            """
+            users, made, avg_h, med_h = q(cur, sql)[0]
+            pct = (made / users * 100) if users else 0
+            print(f"  Users:                         {users}")
+            print(f"  Ever created a reminder:       {made} ({pct:.0f}%)")
+            print(f"  Avg time signup->1st reminder: {avg_h} hrs")
+            print(f"  Median time:                   {med_h} hrs")
+
+        section("4. ACTIVATION (signup -> first reminder)", activation)
+
+        # ---- 5. CHURN LIFESPAN ------------------------------------------
+        def churn():
+            sql = """
+                SELECT
+                  ROUND(AVG(EXTRACT(EPOCH FROM (last_active_at - created_at))/86400)::numeric, 1) AS avg_days,
+                  ROUND((PERCENTILE_CONT(0.5) WITHIN GROUP (
+                      ORDER BY EXTRACT(EPOCH FROM (last_active_at - created_at))/86400))::numeric, 1) AS median_days,
+                  COUNT(*) FILTER (WHERE last_active_at < created_at + INTERVAL '1 day') AS one_and_done
+                FROM users
+                WHERE last_active_at IS NOT NULL
+                  AND last_active_at < NOW() - INTERVAL '30 days'
+            """
+            avg_d, med_d, oad = q(cur, sql)[0]
+            print("  (churned = no activity in 30d)")
+            print(f"  Avg lifespan (signup->last active):    {avg_d} days")
+            print(f"  Median lifespan:                       {med_d} days")
+            print(f"  'One and done' (gone within 24h):      {oad}")
+
+        section("5. CHURN LIFESPAN", churn)
+
+        # ---- 6. THE SURVIVORS: active users deep-dive -------------------
+        def survivors():
+            # recurring_reminders has no phone_hash column; join it on phone_number.
+            rk = join_key(cur, "recurring_reminders", key)
+            sql = f"""
+                SELECT
+                  u.created_at::date                                   AS joined,
+                  u.last_active_at::date                               AS last_seen,
+                  u.premium_status,
+                  COALESCE(u.total_messages, 0)                        AS msgs,
+                  (SELECT COUNT(*) FROM reminders r       WHERE r.{key}=u.{key}) AS reminders,
+                  (SELECT COUNT(*) FROM recurring_reminders rr WHERE rr.{rk}=u.{rk}) AS recurring,
+                  (SELECT COUNT(*) FROM memories m        WHERE m.{key}=u.{key}) AS memories,
+                  (SELECT COUNT(*) FROM lists l           WHERE l.{key}=u.{key}) AS lists,
+                  (SELECT COUNT(*) FROM list_items li     WHERE li.{key}=u.{key}) AS items
+                FROM users u
+                WHERE u.last_active_at >= NOW() - INTERVAL '14 days'
+                ORDER BY u.last_active_at DESC
+            """
+            rows = q(cur, sql)
+            print(f"  {'joined':<12}{'lastseen':<12}{'tier':<9}{'msg':>5}{'rem':>5}{'rec':>5}{'mem':>5}{'lst':>5}{'itm':>5}")
+            for joined, last, tier, msgs, rem, rec, mem, lst, itm in rows:
+                print(f"  {str(joined):<12}{str(last):<12}{str(tier)[:8]:<9}{msgs:>5}{rem:>5}{rec:>5}{mem:>5}{lst:>5}{itm:>5}")
+            print(f"\n  ({len(rows)} users active in last 14 days)")
+
+        section("6. THE SURVIVORS (users active in last 14d)", survivors)
+
+        # ---- 7. REMINDER DELIVERY HEALTH --------------------------------
+        def delivery():
+            sql = """
+                SELECT COALESCE(delivery_status, 'null'), COUNT(*)
+                FROM reminders GROUP BY 1 ORDER BY 2 DESC
+            """
+            print("  delivery_status breakdown:")
+            for status, n in q(cur, sql):
+                print(f"    {status:<14}{n}")
+
+        section("7. REMINDER DELIVERY HEALTH", delivery)
+
+        # ---- 8. WHAT PEOPLE ACTUALLY DO (intents, last 90d) -------------
+        def intents():
+            sql = """
+                SELECT COALESCE(intent, 'unknown') AS intent, COUNT(*) AS n
+                FROM logs
+                WHERE created_at >= NOW() - INTERVAL '90 days'
+                GROUP BY 1 ORDER BY 2 DESC LIMIT 20
+            """
+            print("  Top intents (inbound messages, last 90d):")
+            for intent, n in q(cur, sql):
+                print(f"    {str(intent)[:30]:<32}{n}")
+
+        section("8. WHAT PEOPLE ACTUALLY DO (log intents)", intents)
+
+        # ---- 9. LIFECYCLE / NUDGE ENGAGEMENT ----------------------------
+        def nudges():
+            sql = """
+                SELECT
+                  COUNT(*)                              AS sent,
+                  COUNT(user_response)                  AS responded,
+                  COUNT(*) FILTER (WHERE action_taken IS NOT NULL
+                                     AND action_taken <> '') AS acted
+                FROM smart_nudges
+                WHERE sent_at >= NOW() - INTERVAL '90 days'
+            """
+            sent, resp, acted = q(cur, sql)[0]
+            print(f"  Nudges sent (90d):  {sent}")
+            print(f"  Responded:          {resp}")
+            print(f"  Drove an action:    {acted}")
+
+        section("9. SMART NUDGE ENGAGEMENT", nudges)
+
+        print("\nDone. (No data was modified.)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/analytics/extend_beta_grants.py
+++ b/analytics/extend_beta_grants.py
@@ -1,0 +1,94 @@
+"""
+One-off: extend the beta premium grants so they don't expire on 2026-06-01.
+
+The ~28-31 beta users were given 90-day comp premium that all lands on
+2026-06-01. We're pushing that out to buy time to build a real conversion
+offer (no proven Stripe pay path yet). Engaged users keep premium; nothing
+gets yanked on Monday.
+
+SAFE BY DEFAULT: running with no flags only PREVIEWS (read-only). Pass --apply
+to actually write. Writes require a read-write URL in WRITE_DATABASE_URL
+(falls back to DATABASE_URL); the preview uses ANALYTICS_DATABASE_URL.
+
+  python analytics/extend_beta_grants.py            # dry-run preview
+  python analytics/extend_beta_grants.py --apply    # actually extend (needs write URL)
+  python analytics/extend_beta_grants.py --days 60  # override extension length
+
+Targets: premium_status='premium' with a time-boxed trial_end_date that is
+expiring soon, and NOT a real payer or a permanent 'manual' comp. Idempotent:
+users already extended past the new date are skipped.
+"""
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--apply", action="store_true", help="actually write (default: dry-run)")
+parser.add_argument("--days", type=int, default=90, help="days from today to extend to (default 90)")
+parser.add_argument("--expiring-before", default="2026-07-01",
+                    help="only touch grants expiring before this date (default 2026-07-01)")
+args = parser.parse_args()
+
+new_end = (datetime.utcnow() + timedelta(days=args.days)).date()
+
+read_url = os.environ.get("ANALYTICS_DATABASE_URL") or os.environ.get("DATABASE_URL")
+write_url = os.environ.get("WRITE_DATABASE_URL") or os.environ.get("DATABASE_URL")
+url = write_url if args.apply else read_url
+if not url:
+    sys.exit("No database URL set (ANALYTICS_DATABASE_URL / WRITE_DATABASE_URL / DATABASE_URL).")
+
+# WHERE clause for the beta grants we want to extend
+WHERE = """
+    premium_status = 'premium'
+    AND trial_end_date IS NOT NULL
+    AND trial_end_date < %s
+    AND (subscription_status IS NULL OR subscription_status NOT IN ('active', 'manual'))
+    AND (stripe_subscription_id IS NULL OR stripe_subscription_id = '')
+    AND trial_end_date::date < %s
+"""
+params = (args.expiring_before, new_end)
+
+conn = psycopg2.connect(url)
+conn.set_session(readonly=not args.apply, autocommit=False)
+cur = conn.cursor()
+
+# Preview the affected rows
+cur.execute(f"""
+    SELECT RIGHT(phone_number, 4) AS last4, premium_since::date, trial_end_date::date
+    FROM users WHERE {WHERE}
+    ORDER BY trial_end_date
+""", params)
+rows = cur.fetchall()
+
+print(f"New expiry target: {new_end}  (today + {args.days} days)")
+print(f"Only touching grants expiring before: {args.expiring_before}")
+print(f"Matched {len(rows)} beta grant(s) to extend:\n")
+print(f"  {'phone':<8}{'granted':<13}{'current_expiry':<14}")
+for last4, since, end in rows:
+    print(f"  ...{last4:<5}{str(since):<13}{str(end):<14}")
+
+if not args.apply:
+    print("\nDRY RUN — nothing written. Re-run with --apply (and a write URL) to extend.")
+    conn.close()
+    sys.exit(0)
+
+# Apply
+cur.execute(f"""
+    UPDATE users
+    SET trial_end_date = %s,
+        trial_warning_7d_sent = FALSE,
+        trial_warning_1d_sent = FALSE,
+        trial_warning_0d_sent = FALSE
+    WHERE {WHERE}
+""", (new_end,) + params)
+updated = cur.rowcount
+conn.commit()
+print(f"\nAPPLIED: extended {updated} grant(s) to {new_end}. "
+      f"Trial-warning flags reset so a future warning can fire cleanly.")
+conn.close()

--- a/analytics/funnel_probe.py
+++ b/analytics/funnel_probe.py
@@ -1,0 +1,55 @@
+"""Read-only: compute the funnel stage counts to validate the SQL before
+wiring it into the admin endpoint."""
+import os
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+url = os.environ.get("ANALYTICS_DATABASE_URL") or os.environ.get("DATABASE_URL")
+c = psycopg2.connect(url)
+c.set_session(readonly=True, autocommit=True)
+cur = c.cursor()
+
+
+def scalar(sql):
+    cur.execute(sql)
+    return cur.fetchone()[0]
+
+
+# Top of funnel: distinct people who ever started (onboarding_progress) +
+# anyone who has a users row (some finishers may not be in onboarding_progress)
+try:
+    started = scalar("""
+        SELECT COUNT(*) FROM (
+            SELECT phone_number FROM onboarding_progress
+            UNION
+            SELECT phone_number FROM users
+        ) s
+    """)
+except Exception as e:
+    started = f"(onboarding_progress missing? {e})"
+
+total_users = scalar("SELECT COUNT(*) FROM users")
+onboarded = scalar("SELECT COUNT(*) FROM users WHERE onboarding_complete = TRUE")
+activated = scalar("""
+    SELECT COUNT(*) FROM users u
+    WHERE u.onboarding_complete = TRUE AND (
+        EXISTS(SELECT 1 FROM reminders r WHERE r.phone_number = u.phone_number) OR
+        EXISTS(SELECT 1 FROM memories m WHERE m.phone_number = u.phone_number) OR
+        EXISTS(SELECT 1 FROM lists l WHERE l.phone_number = u.phone_number)
+    )
+""")
+eng30 = scalar("SELECT COUNT(*) FROM users WHERE onboarding_complete AND last_active_at >= NOW() - INTERVAL '30 days'")
+hab7 = scalar("SELECT COUNT(*) FROM users WHERE onboarding_complete AND last_active_at >= NOW() - INTERVAL '7 days'")
+paying = scalar("SELECT COUNT(*) FROM users WHERE stripe_subscription_id IS NOT NULL AND stripe_subscription_id <> '' AND subscription_status = 'active'")
+comped = scalar("SELECT COUNT(*) FROM users WHERE premium_status = 'premium' AND (stripe_subscription_id IS NULL OR stripe_subscription_id = '')")
+
+print(f"Signed up (started):     {started}")
+print(f"  Total users rows:      {total_users}")
+print(f"Onboarded:               {onboarded}")
+print(f"Activated (any object):  {activated}")
+print(f"Engaged (30d):           {eng30}")
+print(f"Habit (7d):              {hab7}")
+print(f"Paying (real Stripe):    {paying}")
+print(f"Comped premium (annot):  {comped}")
+c.close()


### PR DESCRIPTION
Commits the read-only diagnostic + ops scripts built during the turnaround analysis as reusable tools, with a README covering the env vars and safety model.

- `diagnose.py` — funnel/retention/activation/delivery/intent diagnosis
- `funnel_probe.py` — conversion-funnel stage counts
- `check_grants.py` — beta grant lengths + expiry timing
- `extend_beta_grants.py` — extend beta comp grants (dry-run unless `--apply`)

Read-only by default (read scripts force a read-only DB session). No hardcoded secrets — all credentials come from env (`ANALYTICS_DATABASE_URL` / `WRITE_DATABASE_URL`, gitignored `.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)