### PR TITLE
Consolidate week-1 onboarding messages (5 -> 3) before marketing

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -95,22 +95,24 @@ beat_schedule = {
             "expires": 3500,
         },
     },
-    # Send Day 2 feature prompt hourly — timezone-aware (9-10 AM local)
-    "send-day-2-feature-prompt": {
-        "task": "tasks.reminder_tasks.send_day_2_feature_prompt",
-        "schedule": crontab(minute=7),  # Every hour, at :07
-        "options": {
-            "expires": 3500,
-        },
-    },
-    # Send Day 3 engagement nudges hourly — timezone-aware (9-10 AM local)
-    "send-day-3-engagement-nudges": {
-        "task": "tasks.reminder_tasks.send_day_3_engagement_nudges",
-        "schedule": crontab(minute=10),  # Every hour, at :10
-        "options": {
-            "expires": 3500,
-        },
-    },
+    # Week-1 consolidation 2026-05-30: Day 2 (feature prompt) and Day 3
+    # (engagement nudge) unscheduled to cut the new-user barrage from 5 first-week
+    # proactive messages to 3 (Day 1 welcome + Day 4 email ask + Day 7 value recap).
+    # Task functions kept intact; re-add these entries to restore the full sequence.
+    # "send-day-2-feature-prompt": {
+    #     "task": "tasks.reminder_tasks.send_day_2_feature_prompt",
+    #     "schedule": crontab(minute=7),  # Every hour, at :07
+    #     "options": {
+    #         "expires": 3500,
+    #     },
+    # },
+    # "send-day-3-engagement-nudges": {
+    #     "task": "tasks.reminder_tasks.send_day_3_engagement_nudges",
+    #     "schedule": crontab(minute=10),  # Every hour, at :10
+    #     "options": {
+    #         "expires": 3500,
+    #     },
+    # },
     # Send Day 4 email collection hourly — timezone-aware (9-10 AM local)
     "send-day-4-email-collection": {
         "task": "tasks.reminder_tasks.send_day_4_email_collection",

--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -1378,6 +1378,11 @@ def send_day_1_morning_nudge(self):
             if not (0 <= days_in_trial <= 1):
                 continue
 
+            # Anti-bunching: skip if another proactive message went out in last 48h
+            if recently_pushed_message(phone_number):
+                logger.info(f"Skipping Day 1 nudge for ...{phone_number[-4:]} — another lifecycle message sent recently")
+                continue
+
             try:
                 greeting = f"Good morning {first_name}!" if first_name else "Good morning!"
 
@@ -1720,6 +1725,11 @@ def send_day_4_email_collection(self):
 
             # Only send on Day 3-4 (range check to handle signup time-of-day)
             if not (3 <= days_in_trial <= 4):
+                continue
+
+            # Anti-bunching: skip if another proactive message went out in last 48h
+            if recently_pushed_message(phone_number):
+                logger.info(f"Skipping Day 4 email ask for ...{phone_number[-4:]} — another lifecycle message sent recently")
                 continue
 
             try:


### PR DESCRIPTION
New signups currently get **5 proactive messages in their first week** (Day 1/2/3/4 + Day 7). With marketing about to drive signups, that's a fast path to STOP.

## Changes
- **Unschedule Day 2** (feature prompt) and **Day 3** (engagement nudge) in Celery Beat — the two most redundant/generic touches. Task functions kept intact; re-add the beat entries to restore.
- **Keep** Day 1 welcome, Day 4 email ask (account-recovery email capture — business value), Day 7 value recap.
- **Add 48h anti-bunching** (`recently_pushed_message`) to Day 1 and Day 4 so they can't stack onto other proactive sends.

Net: first-week proactive load **5 → 3**, all gated by opt-out + soft-pause + anti-bunching.

## Tests
Quick suite: 293 passed; the only 2 failures (`test_context_switching`) are pre-existing on main (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)