### PR TITLE
Fix retired Claude model IDs (Sonnet 4 retired 2026-06-15)

### DIFF
--- a/agents/fix_planner.py
+++ b/agents/fix_planner.py
@@ -392,7 +392,7 @@ Intent: {issue.get('intent', details.get('intent', 'N/A'))}
             all_files.append(str(rel_path))
 
     response = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-6",
         max_tokens=500,
         messages=[{
             "role": "user",

--- a/services/analytics_summary_service.py
+++ b/services/analytics_summary_service.py
@@ -288,7 +288,7 @@ Format your response as:
 
     try:
         response = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-6",
             max_tokens=1500,
             messages=[{"role": "user", "content": prompt}],
         )
@@ -341,7 +341,7 @@ def _parse_claude_response(response_text: str) -> tuple:
 _MODEL_ID_BY_CHOICE = {
     "haiku": "claude-haiku-4-5",
     "sonnet": "claude-sonnet-4-6",
-    "opus": "claude-opus-4-7",
+    "opus": "claude-opus-4-8",
 }
 
 _VALID_OPUS_EFFORTS = ("low", "medium", "high", "xhigh", "max")


### PR DESCRIPTION
## What
The AI Analytics Summary was failing with a `404 not_found_error` because it called `claude-sonnet-4-20250514` (Claude Sonnet 4), which was **retired on 2026-06-15**.

## Changes
- `services/analytics_summary_service.py` — summary call swapped to the drop-in replacement `claude-sonnet-4-6`
- `agents/fix_planner.py` — same retired model, same swap (would have 404''d identically)
- `services/analytics_summary_service.py` — admin model selector `opus` bumped from previous-gen `claude-opus-4-7` to current `claude-opus-4-8`

No other code changes needed — both calls are minimal (`model`, `max_tokens`, `messages`) with no `temperature`/`top_p`/`budget_tokens`/prefills that the 4.6 family would otherwise require updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)