### PR TITLE
Fix week-long reminder outage: harden Celery Redis connections + Sentry heartbeat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Proactive AI intelligence layer — sends ONE contextual insight per day. 8 nudg
 
 **Required:** `OPENAI_API_KEY`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_NUMBER`, `DATABASE_URL`
 
-**Optional:** `UPSTASH_REDIS_URL`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `ENCRYPTION_KEY`, `HASH_KEY`, `STRIPE_*` keys, `SMTP_*` for email, `ANTHROPIC_API_KEY` (Agent 4 AI file identification)
+**Optional:** `UPSTASH_REDIS_URL`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `ENCRYPTION_KEY`, `HASH_KEY`, `STRIPE_*` keys, `SMTP_*` for email, `ANTHROPIC_API_KEY` (Agent 4 AI file identification), `SENTRY_DSN` (error tracking + reminder-pipeline heartbeat via Sentry Crons; no-op when unset)
 
 ## Rate Limiting
 

--- a/celery_app.py
+++ b/celery_app.py
@@ -52,6 +52,32 @@ celery_app.conf.update(
     # Broker connection settings
     broker_connection_retry_on_startup=True,
 
+    # Upstash closes idle/long-lived connections ("Connection closed by server").
+    # Without socket timeouts, a half-open socket makes Beat hang forever without
+    # an error (outage of 2026-07-16: beat froze for a week while Render showed
+    # the service as live). Timeouts turn the hang into an exception that
+    # Celery's retry machinery recovers from; health_check_interval proactively
+    # PINGs so dead connections are replaced before they're used.
+    broker_transport_options={
+        "socket_timeout": 30,
+        "socket_connect_timeout": 15,
+        "socket_keepalive": True,
+        "retry_on_timeout": True,
+        "health_check_interval": 25,
+    },
+
+    # Same protection for the Redis result backend connections.
+    redis_socket_timeout=30,
+    redis_socket_connect_timeout=15,
+    redis_socket_keepalive=True,
+    redis_retry_on_timeout=True,
+    redis_backend_health_check_interval=25,
+
+    # On connection loss, cancel acks_late tasks so they're redelivered cleanly
+    # (send_single_reminder already guards against duplicate sends via the
+    # `sent` flag + row lock). This is also the Celery 6.0 default.
+    worker_cancel_long_running_tasks_on_connection_loss=True,
+
     # Beat scheduler settings
     beat_scheduler="celery.beat:PersistentScheduler",
     beat_schedule_filename="celerybeat-schedule",

--- a/celery_app.py
+++ b/celery_app.py
@@ -10,6 +10,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+from sentry_setup import init_sentry
+init_sentry()
+
 # Get Redis URL from environment (Upstash format: rediss://:<password>@<host>:<port>)
 REDIS_URL = os.environ.get("UPSTASH_REDIS_URL", "redis://localhost:6379/0")
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ from twilio.request_validator import RequestValidator
 # Local imports
 import secrets
 from config import logger, ENVIRONMENT, MAX_LISTS_PER_USER, MAX_ITEMS_PER_LIST, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER, PUBLIC_PHONE_NUMBER, ADMIN_USERNAME, ADMIN_PASSWORD, RATE_LIMIT_MESSAGES, RATE_LIMIT_WINDOW, REQUEST_TIMEOUT, TWILIO_WEBHOOK_TIMEOUT
+from sentry_setup import init_sentry
+init_sentry()
 from collections import defaultdict
 import time
 from fastapi.security import HTTPBasic, HTTPBasicCredentials

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -13,6 +13,7 @@ celery[redis]>=5.3.0,<6.0.0
 redis>=5.0.0,<6.0.0
 stripe>=7.0.0,<12.0.0
 anthropic>=0.18.0,<1.0.0
+sentry-sdk>=2.0.0,<3.0.0
 pyperclip>=1.8.0,<2.0.0
 google-analytics-data>=0.18.0,<1.0.0
 google-api-python-client>=2.100.0,<3.0.0

--- a/sentry_setup.py
+++ b/sentry_setup.py
@@ -1,0 +1,27 @@
+"""
+Sentry initialization: error tracking + Crons heartbeat for the reminder pipeline.
+
+No-ops unless SENTRY_DSN is set (and never runs in tests), so local dev and CI
+are unaffected. Must be called in every process type, so it's invoked from both
+main.py (web) and celery_app.py (worker/beat/monitoring).
+
+The FastAPI and Celery integrations auto-enable when their packages are
+installed; no explicit integration list is needed.
+"""
+
+import os
+
+
+def init_sentry():
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn or os.environ.get("ENVIRONMENT") == "test":
+        return
+
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.environ.get("ENVIRONMENT", "production"),
+        send_default_pii=False,  # never ship phone numbers or message bodies
+        traces_sample_rate=0.0,  # errors + crons only, no perf tracing cost
+    )

--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -26,6 +26,27 @@ from services.metrics_service import track_reminder_delivery
 
 logger = get_task_logger(__name__)
 
+try:
+    from sentry_sdk import monitor as _sentry_monitor
+except ImportError:  # sentry-sdk not installed; heartbeat becomes a no-op
+    def _sentry_monitor(monitor_slug=None, monitor_config=None):
+        def _deco(f):
+            return f
+        return _deco
+
+# Sentry Crons heartbeat: the task runs every 30s, so a single missed minute
+# (plus margin) means the beat/worker pipeline is down — this is the alert that
+# catches silent hangs like the 2026-07-16 outage, which no exception tracker
+# can see. No-ops when SENTRY_DSN is unset.
+_REMINDER_MONITOR_CONFIG = {
+    "schedule": {"type": "interval", "value": 1, "unit": "minute"},
+    "checkin_margin": 3,       # minutes late before a check-in counts as missed
+    "max_runtime": 5,          # minutes before an in-progress run counts as failed
+    "failure_issue_threshold": 2,
+    "recovery_threshold": 1,
+    "timezone": "UTC",
+}
+
 
 @celery_app.task(
     bind=True,
@@ -35,6 +56,7 @@ logger = get_task_logger(__name__)
     time_limit=120,
     soft_time_limit=100,
 )
+@_sentry_monitor(monitor_slug="check-and-send-reminders", monitor_config=_REMINDER_MONITOR_CONFIG)
 def check_and_send_reminders(self):
     """
     Periodic task to check for due reminders and dispatch them.


### PR DESCRIPTION
## Summary

Root-cause fix + alerting for the week-long reminder outage (2026-07-16 → 2026-07-23), where reminders were acknowledged but never delivered.

**What happened:** Upstash Redis periodically closes broker connections. The Celery worker recovers (its blocking read raises `ConnectionError` and reconnects — visible in worker logs on Jul 20), but on Jul 16 at 09:42 UTC Beat's connection died half-open. With no socket timeout or health check configured, Beat blocked forever on a dead socket: no error, no log, no Render event — the service showed "Deployed" for a week while nothing was scheduled. The web service was unaffected, which is why creation acks kept working.

**Recovery already done (not in this PR):** 13 week-old stale reminders were marked `delivery_status='skipped_stale'` so they wouldn't blast out, Beat was manually restarted on 2026-07-23, and the 5 still-relevant overdue reminders delivered. Overdue-unsent count is now 0.

## Changes

1. **`celery_app.py` — connection hardening (the actual fix):** `broker_transport_options` with socket timeouts, TCP keepalive, `retry_on_timeout`, and `health_check_interval=25`, plus the matching `redis_*` settings for the result backend. A dead connection now raises and reconnects instead of hanging forever. Also enables `worker_cancel_long_running_tasks_on_connection_loss` (Celery 6 default; `send_single_reminder` already dedupes via the `sent` flag + row lock).
2. **Sentry (needs `SENTRY_DSN` to activate, no-op until then):**
   - `sentry_setup.py` called from `main.py` and `celery_app.py` — exception tracking for web + all Celery processes. No PII, no tracing.
   - Sentry Crons monitor on `check_and_send_reminders` (runs every 30s) — missed check-ins alert within ~4 minutes if the pipeline goes silent again. This is the layer that would have caught this outage; an exception tracker alone cannot.
3. `requirements-prod.txt`: add `sentry-sdk`; `CLAUDE.md`: document `SENTRY_DSN`.

## Verification

- `celery_app` config loads with all 25 beat entries intact; transport options verified via import.
- `tasks.reminder_tasks` imports and registers `check_and_send_reminders` with the monitor decorator under `ENVIRONMENT=test` (decorator + init both no-op without a DSN).

## Post-merge

- Merging auto-deploys and restarts all 4 services — safe now that the stale backlog is cleared.
- To activate alerting: create a Sentry project (free tier is fine — 1 cron monitor included, this uses exactly 1) and add `SENTRY_DSN` to the Render env for all services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
