### PR TITLE
Never let Sentry init failure crash the app

### DIFF
--- a/sentry_setup.py
+++ b/sentry_setup.py
@@ -7,21 +7,33 @@ main.py (web) and celery_app.py (worker/beat/monitoring).
 
 The FastAPI and Celery integrations auto-enable when their packages are
 installed; no explicit integration list is needed.
+
+IMPORTANT: this must never take the app down. A malformed SENTRY_DSN crashed
+the 2026-07-23 web deploy at import time (BadDsn: Unsupported scheme '') —
+init failures now degrade to a logged warning and the app runs without Sentry.
 """
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 
 def init_sentry():
-    dsn = os.environ.get("SENTRY_DSN")
+    # Strip whitespace and stray quotes from copy/paste into the env editor.
+    dsn = (os.environ.get("SENTRY_DSN") or "").strip().strip("'\"")
     if not dsn or os.environ.get("ENVIRONMENT") == "test":
         return
 
-    import sentry_sdk
+    try:
+        import sentry_sdk
 
-    sentry_sdk.init(
-        dsn=dsn,
-        environment=os.environ.get("ENVIRONMENT", "production"),
-        send_default_pii=False,  # never ship phone numbers or message bodies
-        traces_sample_rate=0.0,  # errors + crons only, no perf tracing cost
-    )
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=os.environ.get("ENVIRONMENT", "production"),
+            send_default_pii=False,  # never ship phone numbers or message bodies
+            traces_sample_rate=0.0,  # errors + crons only, no perf tracing cost
+        )
+        logger.info("Sentry initialized")
+    except Exception as e:
+        logger.warning(f"Sentry disabled — init failed: {e}")


### PR DESCRIPTION
Hotfix completing #270's deploy: the web service failed to boot because the SENTRY_DSN env var holds a malformed value (BadDsn: Unsupported scheme ''). init_sentry() now wraps sentry_sdk.init in try/except (degrades to a logged warning) and strips whitespace/stray quotes from the DSN. Verified locally: a bad DSN logs 'Sentry disabled' and the app continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)