### PR TITLE
Handle opted-out users in onboarding followups (Twilio 21610)

### DIFF
--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -711,6 +711,10 @@ def send_abandoned_onboarding_followups(self):
                 mark_followup_sent(user['phone_number'], '24h')
                 sent_count += 1
                 logger.info(f"Sent 24h onboarding followup to ...{user['phone_number'][-4:]}")
+            except UserOptedOutError:
+                # Expected: user replied STOP. Mark as sent so we don't retry every hour.
+                logger.info(f"24h followup skipped: user ...{user['phone_number'][-4:]} opted out")
+                mark_followup_sent(user['phone_number'], '24h')
             except Exception as e:
                 logger.error(f"Error sending 24h followup: {e}")
 
@@ -723,6 +727,10 @@ def send_abandoned_onboarding_followups(self):
                 mark_followup_sent(user['phone_number'], '7d')
                 sent_count += 1
                 logger.info(f"Sent 7d onboarding followup to ...{user['phone_number'][-4:]}")
+            except UserOptedOutError:
+                # Expected: user replied STOP. Mark as sent so we don't retry every hour.
+                logger.info(f"7d followup skipped: user ...{user['phone_number'][-4:]} opted out")
+                mark_followup_sent(user['phone_number'], '7d')
             except Exception as e:
                 logger.error(f"Error sending 7d followup: {e}")
 


### PR DESCRIPTION
## Problem

`send_abandoned_onboarding_followups` (hourly Celery Beat task) texts users who abandoned onboarding. When a target user has replied **STOP**, `send_sms` raises `UserOptedOutError` (Twilio error 21610). The loops only had a generic `except Exception as e: logger.error(...)`, so:

1. An expected condition (user unsubscribed) was logged at **error** level → surfaced as a production Sentry error.
2. `mark_followup_sent` never ran, so the user stayed in the abandoned pool and the error **re-fired every hour, indefinitely**.

Caught in production via Sentry: `PYTHON-FASTAPI-2` (24h) and `PYTHON-FASTAPI-3` (7d).

## Fix

Catch `UserOptedOutError` before the generic handler in both the 24h and 7d loops, log at info level, and call `mark_followup_sent` so the user leaves the abandoned pool. Mirrors the existing pattern in `send_engagement_nudge`. `UserOptedOutError` is already imported in this module.

Note: `send_sms` already calls `mark_user_opted_out()` before raising, so the user's opt-out flag is set regardless — this just stops the noise and the hourly retry.

Fixes PYTHON-FASTAPI-2
Fixes PYTHON-FASTAPI-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)