### PR TITLE
Attribute WORK start keyword to linkedin

### DIFF
--- a/main.py
+++ b/main.py
@@ -896,6 +896,7 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             "hello": "website-ios",
             "hey, sign me up!": "facebook",
             "go": "facebook",
+            "work": "linkedin",
             "hi, i'd like to sign up!": "reddit",
             "try": "reddit",
             "hey, i'd like to sign up!": "google",
@@ -912,6 +913,7 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             ("reddit", "reddit", None),
             ("tiktok", "tiktok", None),
             ("google", "google", None),
+            ("linkedin", "linkedin", None),
         ]
         if not is_user_onboarded(phone_number):
             msg_lower = incoming_msg.lower().strip()
@@ -924,6 +926,8 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                     referral_source = "website-ios"
                 elif re.match(r'^go\b', msg_lower):
                     referral_source = "facebook"
+                elif re.match(r'^work\b', msg_lower):
+                    referral_source = "linkedin"
 
             # Fuzzy fallback: check if message contains key phrases
             if not referral_source:


### PR DESCRIPTION
Companion to remyndrs-website PR #5 (professionals landing page for the LinkedIn channel). Maps the WORK start keyword to referral_source `linkedin` the same three ways GO maps to facebook: exact match, CTA-body prefix match, and fuzzy fallback. Non-onboarded senders only. Onboarding tests: 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)