### PR TITLE
Auto-detect and escalate user-reported issues from inbound SMS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ SMS -> Twilio webhook (/sms) -> main.py validates -> ai_service.py processes wit
 | `utils/db_helpers.py` | Encryption-aware database query helpers |
 
 ### Database Tables
-`users`, `reminders`, `recurring_reminders`, `memories`, `lists`, `list_items`, `list_shares`, `interactions`, `support_tickets`, `contact_messages`, `broadcast_messages`, `conversation_flags`, `smart_nudges`, `monitoring_issues`, `monitoring_runs`, `issue_patterns`, `issue_pattern_links`, `validation_runs`, `issue_resolutions`, `pattern_resolutions`, `health_snapshots`, `fix_proposals`, `fix_proposal_runs`
+`users`, `reminders`, `recurring_reminders`, `memories`, `lists`, `list_items`, `list_shares`, `interactions`, `support_tickets`, `contact_messages`, `broadcast_messages`, `conversation_analysis`, `smart_nudges`, `monitoring_issues`, `monitoring_runs`, `issue_patterns`, `issue_pattern_links`, `validation_runs`, `issue_resolutions`, `pattern_resolutions`, `health_snapshots`, `fix_proposals`, `fix_proposal_runs`
 
 ## Deployment
 
@@ -178,6 +178,19 @@ When users view a numbered list (memories, lists, reminders, recurring reminders
 **YES confirmation handler** supports all types: `reminder`, `recurring`, `list_item`, `memory`, `list`.
 
 **When adding new viewable lists:** set `last_active_list` to a `__MARKER__` when displaying, add a handler in the delete-by-number section, add the marker to the exclusion list, and add the type to the YES confirmation handler.
+
+### Auto-Detected Issue Reports
+Users report outages in plain language ("my reminders haven't come through in days") instead of texting `SUPPORT`/`BUG`, so those reports never reached the support inbox. `services/issue_detector.py` is a side-channel observer on the `/sms` path that notices them.
+
+Three stages, cheapest first: a regex prefilter (`looks_like_issue_report()`), a small confirmation AI call (`classify_issue_report()`), then `record_and_notify()`. Hooked into `main.py` right after the SUPPORT MODE CHECK — users with an open ticket have already returned, so they can't be double-reported.
+
+- **Silent to the user.** The reply is unchanged; only the support inbox learns about it.
+- **Runs as a FastAPI background task** (`background_tasks` param on `sms_reply`). It makes its own AI call, and the webhook must still fit inside Twilio's 15s timeout. The param is `None` when the handler is called directly (tests), in which case detection runs inline.
+- Flags are stored in `contact_messages` with `source='sms_auto'` and `category='auto_{category}'`, so they appear in the existing CS portal with the resolved/reply workflow. No new table.
+- Email per flag is rate-limited per user; **3+ distinct users inside 24h escalates** with an urgent email + admin SMS (the outage signature). A daily digest runs at 13:00 UTC.
+- Settings (DB, no deploy needed): `auto_issue_detection_enabled` (kill switch), `auto_issue_email_cooldown_hours` (6), `auto_issue_outage_threshold` (3).
+
+When editing the prefilter, keep the `NOT_AN_ISSUE` guards in sync — they're what stops "remind me to fix the broken sink" from being treated as a complaint.
 
 ### Keyword Handlers vs AI Processing
 `main.py` has keyword-based handlers that run **before** AI processing. When adding new commands:

--- a/celery_config.py
+++ b/celery_config.py
@@ -215,6 +215,19 @@ beat_schedule = {
         },
     },
 
+    # Daily rollup of auto-detected issue reports at 1 PM UTC (~9 AM Eastern)
+    # Individual flags email as they happen; this makes a slow-burning
+    # pattern across the day visible in one place. No email when there
+    # were no flags.
+    "issue-flag-digest-daily": {
+        "task": "tasks.monitoring_tasks.send_issue_flag_digest",
+        "schedule": crontab(hour=13, minute=0),  # 1:00 PM UTC
+        "kwargs": {"hours": 24},
+        "options": {
+            "expires": 3600,  # 1 hour expiry
+        },
+    },
+
     # Run code analyzer (Agent 4) every 8 hours
     # Generates root cause analyses and Claude Code prompts for open issues
     "monitoring-agent4-analyze": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,32 @@
 # Changelog — Recent Improvements & Bug Fixes
 
+## Auto-Detected Issue Reports (Jul 2026)
+Reminders silently stopped going out for roughly a week, affecting 4-6 users. Reviewing those conversations afterward showed the users had *told us* — in plain language, in the normal SMS thread — that something was broken. Nobody typed `SUPPORT` or `BUG`, so nothing reached the support inbox and the outage ran for days.
+
+New side-channel observer in `services/issue_detector.py`, hooked into `/sms` right after the SUPPORT MODE CHECK. It never changes routing or the user's reply — it only records and notifies.
+
+**Three stages, cheapest first:**
+1. `looks_like_issue_report()` — regex prefilter, free. Generous on purpose, with `NOT_AN_ISSUE` guards so "remind me to fix the broken sink" and "add bug spray to my grocery list" don't match.
+2. `classify_issue_report()` — one `gpt-4o-mini` call (6s timeout, JSON mode) with the last 4 exchanges as context. Returns category (`service_outage`/`reminder_delivery`/`billing`/`confusion`/`other`), severity, and a one-line summary. Any error returns `None` — silence is the safe failure mode.
+3. `record_and_notify()` — writes to `contact_messages` (`source='sms_auto'`, `category='auto_{category}'`), emails, escalates.
+
+**Notification behavior:**
+- Per-flag email, rate-limited to one per user per 6h — a frustrated user texting six times produces six rows but one email.
+- **Outage escalation:** 3+ distinct users flagged inside 24h sends an urgent email plus an admin SMS, once per day. Independent users complaining simultaneously is what an outage looks like from the inbox — this is the alert that should have fired on day one.
+- Daily digest at 13:00 UTC (~9 AM Eastern), grouped by category. Sends nothing when there were no flags.
+
+**Deliberately silent to the user** — the reply is byte-identical whether or not a message was flagged, so a misclassification produces no visible weirdness. Revisit after reviewing real-world accuracy.
+
+**Runs as a FastAPI background task** — it makes its own AI call on top of the main `process_with_ai()` call, and the webhook must fit inside Twilio's 15s timeout. `background_tasks` is `None` when `sms_reply` is called directly (tests), where it falls back to inline.
+
+**Settings (DB, flippable without a deploy):** `auto_issue_detection_enabled` (kill switch), `auto_issue_email_cooldown_hours` (default 6), `auto_issue_outage_threshold` (default 3).
+
+**No schema migration** — `contact_messages` already had every column needed.
+
+**Files:** `services/issue_detector.py` (new), `services/email_service.py` (3 new senders), `main.py`, `tasks/monitoring_tasks.py`, `celery_config.py`, `tests/test_issue_detection.py` (new), `CLAUDE.md`.
+
+Also fixed a stale entry in `CLAUDE.md`: the table list named `conversation_flags`, which does not exist. The real table is `conversation_analysis`.
+
 ## Day 1 & Day 2 Lifecycle Messages (Mar 2026)
 Added two new lifecycle messages to fill the 48-hour gap between onboarding (Day 0) and the Day 3 feature discovery nudge, targeting the 62% of users who don't return after Day 1.
 

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import json
 import pytz
 import asyncio
 from datetime import datetime, timedelta
-from fastapi import FastAPI, Form, Request, HTTPException
+from fastapi import FastAPI, Form, Request, HTTPException, BackgroundTasks
 from fastapi.responses import Response, HTMLResponse, FileResponse, JSONResponse, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -390,8 +390,14 @@ logger.info(f"✅ Application initialized in {ENVIRONMENT} mode")
 # =====================================================
 
 @app.post("/sms")
-async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(...)):
-    """Handle incoming SMS from Twilio"""
+async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(...),
+                    background_tasks: BackgroundTasks = None):
+    """Handle incoming SMS from Twilio
+
+    background_tasks is injected by FastAPI from the type annotation; it stays
+    None when the handler is called directly (tests), in which case background
+    work runs inline.
+    """
     request_start_time = time.time()
     try:
         # Validate Twilio signature (skip in development and staging)
@@ -892,6 +898,26 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                     resp.message(staging_prefix(f"[Support Ticket #{ticket_id}]\n\nMessage received. We'll respond shortly.\n\n(You're now in support mode - replies will continue to go to support. Text EXIT to leave support or CLOSE to close ticket)"))
                     log_interaction(phone_number, incoming_msg, f"Support message (ticket #{ticket_id})", "support", True)
                 return Response(content=str(resp), media_type="application/xml")
+
+        # ==========================================
+        # AUTO-DETECTED ISSUE REPORTS
+        # ==========================================
+        # Users report outages in plain language instead of texting SUPPORT/BUG,
+        # so those reports never reach the support inbox. This observer notices
+        # them and notifies. It is placed after the support mode check so users
+        # who already have an open ticket aren't double-reported.
+        #
+        # Runs as a background task: it makes its own AI call, and the webhook
+        # still has to fit inside Twilio's 15s timeout. Never affects the reply.
+        try:
+            from services.issue_detector import maybe_flag_issue_report
+            if background_tasks is not None:
+                background_tasks.add_task(maybe_flag_issue_report, phone_number, incoming_msg)
+            else:
+                # Direct invocation (tests) - no background task runner available
+                maybe_flag_issue_report(phone_number, incoming_msg)
+        except Exception as e:
+            logger.warning(f"Issue detector hook error: {e}")
 
         # ==========================================
         # REFERRAL SOURCE DETECTION

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -183,3 +183,308 @@ View in CS Portal: {APP_BASE_URL}/cs
     except Exception as e:
         logger.error(f"Failed to send feedback notification: {e}")
         return False
+
+
+# Colors by severity, used by the two auto-detected issue emails below
+_SEVERITY_COLORS = {
+    'high': '#c0392b',
+    'medium': '#e67e22',
+    'low': '#3498db',
+}
+
+_CATEGORY_LABELS = {
+    'service_outage': 'Service Outage',
+    'reminder_delivery': 'Reminder Delivery',
+    'billing': 'Billing',
+    'confusion': 'Confusion',
+    'other': 'Other',
+}
+
+
+def send_issue_flag_notification(phone_number: str, message: str, category: str,
+                                 severity: str, summary: str = '',
+                                 user_name: str = None):
+    """
+    Send email notification for an auto-detected issue report.
+
+    Unlike FEEDBACK/BUG these were never explicitly submitted - the user just
+    said something was wrong in normal conversation and we noticed.
+    """
+    if not SMTP_ENABLED:
+        logger.warning("SMTP not configured - skipping issue flag notification")
+        return False
+
+    try:
+        category_label = _CATEGORY_LABELS.get(category, category.replace('_', ' ').title())
+        color = _SEVERITY_COLORS.get(severity, '#e67e22')
+        last4 = phone_number[-4:] if phone_number else '????'
+
+        msg = MIMEMultipart('alternative')
+        msg['Subject'] = f"[Auto-detected {severity.upper()}] {category_label} reported by ...{last4}"
+        msg['From'] = SMTP_FROM_EMAIL
+        msg['To'] = SUPPORT_EMAIL
+
+        text_content = f"""
+Auto-detected issue report
+
+This user did not text SUPPORT or BUG - they described a problem in normal
+conversation and it was flagged automatically. They received no acknowledgement,
+so they are not expecting a reply yet.
+
+From: {user_name or 'Unknown'} (...{last4})
+Phone: {phone_number}
+Category: {category_label}
+Severity: {severity}
+Summary: {summary or 'n/a'}
+
+What they said:
+{message}
+
+---
+View in CS Portal: {APP_BASE_URL}/cs
+        """
+
+        html_content = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }}
+        .container {{ max-width: 600px; margin: 0 auto; padding: 20px; }}
+        .header {{ background: {color}; color: white; padding: 15px; border-radius: 8px 8px 0 0; }}
+        .content {{ background: #f9f9f9; padding: 20px; border: 1px solid #ddd; }}
+        .message {{ background: white; padding: 15px; border-radius: 8px; margin: 15px 0; border-left: 4px solid {color}; }}
+        .note {{ font-size: 13px; color: #555; background: #fff8e1; padding: 10px; border-radius: 6px; }}
+        .footer {{ padding: 15px; font-size: 12px; color: #666; }}
+        .btn {{ display: inline-block; background: #27ae60; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px; }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h2 style="margin: 0;">{category_label} &mdash; severity {severity}</h2>
+        </div>
+        <div class="content">
+            <p><strong>From:</strong> {user_name or 'Unknown'} (...{last4})</p>
+            <p><strong>Summary:</strong> {summary or 'n/a'}</p>
+            <div class="message">
+                {message}
+            </div>
+            <p class="note">
+                Auto-detected &mdash; the user did not text SUPPORT or BUG, and received
+                no acknowledgement, so they are not expecting a reply yet.
+            </p>
+            <p>
+                <a href="{APP_BASE_URL}/cs" class="btn">View in CS Portal</a>
+            </p>
+        </div>
+        <div class="footer">
+            <p>This is an automated notification from Remyndrs.</p>
+        </div>
+    </div>
+</body>
+</html>
+        """
+
+        msg.attach(MIMEText(text_content, 'plain'))
+        msg.attach(MIMEText(html_content, 'html'))
+
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=30) as server:
+            server.starttls()
+            server.login(SMTP_USERNAME, SMTP_PASSWORD)
+            server.sendmail(SMTP_FROM_EMAIL, SUPPORT_EMAIL, msg.as_string())
+
+        logger.info(f"Issue flag notification sent ({category}/{severity}) for ...{last4}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to send issue flag notification: {e}")
+        return False
+
+
+def send_outage_escalation_notification(reporter_count: int, hours: int = 24):
+    """
+    Send the loud email for the multi-user case.
+
+    Several unrelated users complaining inside one day is what a real outage
+    looks like from the inbox - this is the message that should have gone out
+    on day one of the reminder outage.
+    """
+    if not SMTP_ENABLED:
+        logger.warning("SMTP not configured - skipping outage escalation")
+        return False
+
+    try:
+        msg = MIMEMultipart('alternative')
+        msg['Subject'] = f"[URGENT] Possible outage - {reporter_count} users reported problems in {hours}h"
+        msg['From'] = SMTP_FROM_EMAIL
+        msg['To'] = SUPPORT_EMAIL
+
+        text_content = f"""
+POSSIBLE OUTAGE
+
+{reporter_count} different users have reported a problem in the last {hours} hours.
+
+Independent users complaining at the same time usually means something is
+actually broken rather than individual confusion. Worth checking now:
+
+- Are reminders going out? (Celery beat + worker on Render)
+- Recent deploys?
+- Twilio and OpenAI status
+
+Review the individual reports in the CS Portal: {APP_BASE_URL}/cs
+        """
+
+        html_content = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }}
+        .container {{ max-width: 600px; margin: 0 auto; padding: 20px; }}
+        .header {{ background: #c0392b; color: white; padding: 15px; border-radius: 8px 8px 0 0; }}
+        .content {{ background: #f9f9f9; padding: 20px; border: 1px solid #ddd; }}
+        .big {{ font-size: 32px; font-weight: 700; color: #c0392b; }}
+        .footer {{ padding: 15px; font-size: 12px; color: #666; }}
+        .btn {{ display: inline-block; background: #c0392b; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px; }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h2 style="margin: 0;">Possible Outage</h2>
+        </div>
+        <div class="content">
+            <p><span class="big">{reporter_count}</span> different users reported a problem in the last {hours} hours.</p>
+            <p>Independent users complaining at the same time usually means something is
+               actually broken rather than individual confusion. Worth checking now:</p>
+            <ul>
+                <li>Are reminders going out? (Celery beat + worker on Render)</li>
+                <li>Recent deploys?</li>
+                <li>Twilio and OpenAI status</li>
+            </ul>
+            <p>
+                <a href="{APP_BASE_URL}/cs" class="btn">View reports in CS Portal</a>
+            </p>
+        </div>
+        <div class="footer">
+            <p>This is an automated notification from Remyndrs.</p>
+        </div>
+    </div>
+</body>
+</html>
+        """
+
+        msg.attach(MIMEText(text_content, 'plain'))
+        msg.attach(MIMEText(html_content, 'html'))
+
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=30) as server:
+            server.starttls()
+            server.login(SMTP_USERNAME, SMTP_PASSWORD)
+            server.sendmail(SMTP_FROM_EMAIL, SUPPORT_EMAIL, msg.as_string())
+
+        logger.info(f"Outage escalation email sent ({reporter_count} reporters)")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to send outage escalation: {e}")
+        return False
+
+
+def send_issue_digest_notification(flags: list, hours: int = 24):
+    """Send the daily rollup of auto-detected issue reports."""
+    if not SMTP_ENABLED:
+        logger.warning("SMTP not configured - skipping issue digest")
+        return False
+
+    if not flags:
+        return False
+
+    try:
+        reporters = len({f['phone_number'] for f in flags})
+
+        msg = MIMEMultipart('alternative')
+        msg['Subject'] = f"[Daily digest] {len(flags)} auto-detected issue report(s) from {reporters} user(s)"
+        msg['From'] = SMTP_FROM_EMAIL
+        msg['To'] = SUPPORT_EMAIL
+
+        # Group by category so an outage pattern is visible at a glance
+        by_category = {}
+        for f in flags:
+            by_category.setdefault(f['category'], []).append(f)
+
+        text_lines = [
+            f"Auto-detected issue reports - last {hours}h",
+            f"{len(flags)} report(s) from {reporters} distinct user(s)",
+            "",
+        ]
+        html_sections = []
+
+        for category, items in sorted(by_category.items(), key=lambda kv: -len(kv[1])):
+            label = _CATEGORY_LABELS.get(
+                category.replace('auto_', ''), category.replace('auto_', '').replace('_', ' ').title()
+            )
+            text_lines.append(f"{label} ({len(items)})")
+            rows = []
+            for item in items:
+                last4 = (item['phone_number'] or '????')[-4:]
+                preview = (item['message'] or '').strip().replace('\n', ' ')[:160]
+                text_lines.append(f"  - ...{last4}: {preview}")
+                rows.append(f"<li><strong>...{last4}</strong>: {preview}</li>")
+            text_lines.append("")
+            html_sections.append(
+                f"<h3 style='margin-bottom:4px;'>{label} ({len(items)})</h3><ul>{''.join(rows)}</ul>"
+            )
+
+        text_lines.append("---")
+        text_lines.append(f"View in CS Portal: {APP_BASE_URL}/cs")
+        text_content = "\n".join(text_lines)
+
+        html_content = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }}
+        .container {{ max-width: 600px; margin: 0 auto; padding: 20px; }}
+        .header {{ background: #34495e; color: white; padding: 15px; border-radius: 8px 8px 0 0; }}
+        .content {{ background: #f9f9f9; padding: 20px; border: 1px solid #ddd; }}
+        .footer {{ padding: 15px; font-size: 12px; color: #666; }}
+        .btn {{ display: inline-block; background: #27ae60; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px; }}
+        li {{ margin-bottom: 6px; }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h2 style="margin: 0;">Auto-detected issue reports</h2>
+            <p style="margin: 4px 0 0;">Last {hours}h &mdash; {len(flags)} report(s) from {reporters} user(s)</p>
+        </div>
+        <div class="content">
+            {''.join(html_sections)}
+            <p>
+                <a href="{APP_BASE_URL}/cs" class="btn">View in CS Portal</a>
+            </p>
+        </div>
+        <div class="footer">
+            <p>This is an automated notification from Remyndrs.</p>
+        </div>
+    </div>
+</body>
+</html>
+        """
+
+        msg.attach(MIMEText(text_content, 'plain'))
+        msg.attach(MIMEText(html_content, 'html'))
+
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=30) as server:
+            server.starttls()
+            server.login(SMTP_USERNAME, SMTP_PASSWORD)
+            server.sendmail(SMTP_FROM_EMAIL, SUPPORT_EMAIL, msg.as_string())
+
+        logger.info(f"Issue digest sent ({len(flags)} flags, {reporters} users)")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to send issue digest: {e}")
+        return False

--- a/services/issue_detector.py
+++ b/services/issue_detector.py
@@ -1,0 +1,415 @@
+"""
+Issue Detector
+
+Side-channel observer on the inbound SMS path. Users report outages in plain
+language ("my reminders haven't come through in days") rather than with the
+SUPPORT/BUG keywords, so those reports never reached the support inbox. This
+module notices them, records them, and pushes a notification.
+
+It never changes what the user sees. Every entry point swallows its own
+exceptions -- a failure here must not affect message handling.
+
+Three stages, cheapest first:
+  1. looks_like_issue_report()  - free regex prefilter, generous by design
+  2. classify_issue_report()    - one small AI call, kills the false positives
+  3. record_and_notify()        - contact_messages row + rate-limited email,
+                                  plus an outage escalation when several
+                                  distinct users complain inside 24h
+"""
+
+import json
+import re
+from datetime import datetime, timedelta
+
+from config import (
+    OPENAI_API_KEY, OPENAI_MODEL, logger
+)
+from database import get_db_connection, return_db_connection, get_setting, set_setting
+
+# Timeout for the confirmation call. Deliberately short: this runs as a
+# FastAPI background task, but a hung call would still tie up a threadpool
+# worker, and the classification is worthless if it isn't quick.
+CLASSIFIER_TIMEOUT = 6
+
+# Marks rows this module created, so they can be counted and digested
+# separately from FEEDBACK/BUG submissions in the same table.
+AUTO_SOURCE = 'sms_auto'
+
+VALID_CATEGORIES = {
+    'service_outage',
+    'reminder_delivery',
+    'billing',
+    'confusion',
+    'other',
+}
+
+VALID_SEVERITIES = {'low', 'medium', 'high'}
+
+# Generous on purpose -- the AI stage is what decides. Anything that makes it
+# past here costs one small API call, nothing more.
+ISSUE_SIGNALS = re.compile(
+    r"""
+    (?:not|isn't|isnt|aren't|arent|ain't|aint|wasn't|wasnt|weren't|werent
+      |doesn't|doesnt|don't|dont|didn't|didnt|won't|wont)\s+work(?:s|ing)?
+  | stopped\s+working
+  | quit\s+working
+  | nothing\s+(?:\w+\s+){0,2}?
+      (?:work(?:s|ing|ed)?|come|comes|coming|came|arriv\w+|show(?:s|ed|ing)?\s+up
+        |went\s+(?:off|out|through)|happen(?:s|ed|ing)?)
+  | (?:didn't|didnt|did\s+not|never|haven't|havent|have\s+not|hasn't|hasnt)
+      \s+(?:\w+\s+){0,2}?(?:get|got|gotten|receive|received|come|coming|show(?:n|ed)?\s+up|go\s+off|went\s+off)
+  | no\s+(?:reminder|reminders|text|texts|notification|notifications)
+  | (?:reminder|reminders|text|texts|app|service|system|site|website)\s+(?:\w+\s+){0,2}?(?:broke|broken|down|dead|stuck)
+  | is\s+(?:this|it|the\s+\w+)\s+(?:down|broken|working)
+  | are\s+(?:you|y'all|yall|things)\s+(?:down|having)
+  | outage
+  | glitch(?:ing|y|es)?
+  | having\s+(?:some\s+)?(?:issues?|trouble|problems?)
+  | (?:issues?|problems?|trouble)\s+with
+  | something(?:'s|s)?\s+(?:is\s+)?wrong
+  | tech(?:nical)?\s+support
+  | customer\s+(?:service|support)
+  | (?:double|twice)\s+charged
+  | charged\s+(?:me\s+)?twice
+  | refund
+  | what\s+happened\s+to
+  | why\s+(?:didn't|didnt|isn't|isnt|aren't|arent|hasn't|hasnt|am\s+i\s+not)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# If any of these match, the message is something else entirely and the
+# signal above was incidental -- "remind me to fix the broken sink" is a
+# reminder, not an outage report.
+NOT_AN_ISSUE = re.compile(
+    r"""
+    ^\s*remind(?:\s+me)?\b
+  | ^\s*(?:add|put)\b.{0,60}\blist\b
+  | ^\s*(?:create|make|start)\s+(?:a\s+)?(?:new\s+)?list\b
+  | ^\s*remember\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# These already notify through their own handlers in main.py; flagging them
+# again would double-email.
+ALREADY_HANDLED_COMMANDS = {
+    'SUPPORT', 'BUG', 'FEEDBACK', 'QUESTION', 'HELP', 'STOP', 'START',
+    'UNSUBSCRIBE', 'CANCEL', 'EXIT', 'CLOSE',
+}
+
+
+def is_detection_enabled() -> bool:
+    """Kill switch, flippable from admin settings without a deploy."""
+    return get_setting("auto_issue_detection_enabled", "true").lower() == "true"
+
+
+def looks_like_issue_report(message: str) -> bool:
+    """Cheap prefilter. True means 'worth one AI call', not 'is an issue'."""
+    if not message:
+        return False
+
+    text = message.strip()
+    if not text or len(text) < 4:
+        return False
+
+    # Bare keyword commands own their own notification path.
+    first_word = text.split()[0].strip('.,!?:;').upper()
+    if first_word in ALREADY_HANDLED_COMMANDS:
+        return False
+
+    if NOT_AN_ISSUE.search(text):
+        return False
+
+    return bool(ISSUE_SIGNALS.search(text))
+
+
+def _recent_context(phone_number: str, limit: int = 4) -> str:
+    """Last few exchanges, to help the model judge an ambiguous complaint."""
+    try:
+        from database import get_recent_logs
+        logs = get_recent_logs(limit=limit, phone_filter=phone_number)
+    except Exception as e:
+        logger.warning(f"Issue detector: could not load context: {e}")
+        return ""
+
+    if not logs:
+        return ""
+
+    lines = []
+    for row in reversed(logs):  # oldest first reads more naturally
+        incoming = (row.get('message_in') or '').strip()
+        outgoing = (row.get('message_out') or '').strip()
+        if incoming:
+            lines.append(f"User: {incoming[:160]}")
+        if outgoing:
+            lines.append(f"Remyndrs: {outgoing[:160]}")
+
+    return "\n".join(lines)
+
+
+CLASSIFIER_PROMPT = """You review inbound text messages sent to Remyndrs, an SMS reminder service.
+
+Decide whether the LATEST message is the user reporting a problem, complaining that \
+something is broken, or asking for technical/billing help.
+
+Answer true for things like:
+- "my reminders haven't come through in days"
+- "is this thing broken? nothing went off this morning"
+- "I got charged twice"
+- "why didn't I get my 8am text"
+
+Answer false for:
+- normal requests to create/read/delete reminders, lists, or memories, even if the \
+content mentions something broken (e.g. "remind me to fix the broken sink")
+- general questions about how to use the service
+- casual chat, thanks, greetings
+
+Reply with JSON only:
+{"is_issue_report": true|false, "category": "service_outage"|"reminder_delivery"|"billing"|"confusion"|"other", "severity": "low"|"medium"|"high", "summary": "one short sentence"}
+
+severity: high = service appears broken or money is involved; medium = a specific \
+failure the user is annoyed about; low = mild confusion."""
+
+
+def classify_issue_report(message: str, phone_number: str) -> dict | None:
+    """
+    Confirm a prefilter hit with one small AI call.
+
+    Returns the parsed classification, or None when it is not an issue report
+    (including on any error -- silence is the safe failure mode here).
+    """
+    if not OPENAI_API_KEY:
+        return None
+
+    try:
+        # Imported at call time so tests patching openai.OpenAI take effect.
+        from openai import OpenAI
+        from database import log_api_usage
+
+        context = _recent_context(phone_number)
+        user_content = message if not context else (
+            f"Recent conversation:\n{context}\n\nLATEST message:\n{message}"
+        )
+
+        client = OpenAI(api_key=OPENAI_API_KEY, timeout=CLASSIFIER_TIMEOUT)
+        response = client.chat.completions.create(
+            model=OPENAI_MODEL,
+            messages=[
+                {"role": "system", "content": CLASSIFIER_PROMPT},
+                {"role": "user", "content": user_content},
+            ],
+            temperature=0,
+            max_tokens=150,
+            response_format={"type": "json_object"},
+        )
+
+        try:
+            if response.usage:
+                log_api_usage(
+                    phone_number,
+                    'detect_issue_report',
+                    response.usage.prompt_tokens,
+                    response.usage.completion_tokens,
+                    response.usage.total_tokens,
+                    OPENAI_MODEL,
+                )
+        except Exception:
+            pass  # cost logging must never block detection
+
+        parsed = json.loads(response.choices[0].message.content)
+        if not isinstance(parsed, dict) or parsed.get('is_issue_report') is not True:
+            return None
+
+        category = str(parsed.get('category', 'other')).strip().lower()
+        severity = str(parsed.get('severity', 'medium')).strip().lower()
+
+        return {
+            'category': category if category in VALID_CATEGORIES else 'other',
+            'severity': severity if severity in VALID_SEVERITIES else 'medium',
+            'summary': str(parsed.get('summary', '')).strip()[:300],
+        }
+
+    except Exception as e:
+        logger.warning(f"Issue detector: classification failed: {e}")
+        return None
+
+
+def _insert_flag(phone_number: str, message: str, classification: dict) -> int | None:
+    """Record the flag in contact_messages. Returns the new row id."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """INSERT INTO contact_messages (phone_number, message, category, source)
+               VALUES (%s, %s, %s, %s) RETURNING id""",
+            (
+                phone_number,
+                message,
+                f"auto_{classification['category']}",
+                AUTO_SOURCE,
+            )
+        )
+        row_id = c.fetchone()[0]
+        conn.commit()
+        return row_id
+    except Exception as e:
+        logger.error(f"Issue detector: failed to record flag: {e}")
+        if conn:
+            conn.rollback()
+        return None
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def _emailed_recently(phone_number: str, hours: int) -> bool:
+    """True if this user already generated an email inside the cooldown."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """SELECT EXISTS(
+                   SELECT 1 FROM contact_messages
+                   WHERE phone_number = %s AND source = %s
+                     AND created_at > %s
+               )""",
+            (phone_number, AUTO_SOURCE, datetime.utcnow() - timedelta(hours=hours))
+        )
+        return bool(c.fetchone()[0])
+    except Exception as e:
+        logger.warning(f"Issue detector: cooldown check failed: {e}")
+        return False  # prefer a duplicate email over a missed one
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def count_distinct_reporters(hours: int = 24) -> int:
+    """How many different users have been auto-flagged recently."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """SELECT COUNT(DISTINCT phone_number) FROM contact_messages
+               WHERE source = %s AND created_at > %s""",
+            (AUTO_SOURCE, datetime.utcnow() - timedelta(hours=hours))
+        )
+        return int(c.fetchone()[0] or 0)
+    except Exception as e:
+        logger.warning(f"Issue detector: reporter count failed: {e}")
+        return 0
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def _maybe_escalate(reporter_count: int):
+    """
+    Several distinct users complaining in one day is the signature of an
+    outage, not of individual confusion. That case gets a louder channel.
+    """
+    try:
+        threshold = int(get_setting("auto_issue_outage_threshold", "3"))
+    except (TypeError, ValueError):
+        threshold = 3
+
+    if reporter_count < threshold:
+        return
+
+    last = get_setting("auto_issue_last_escalation", "")
+    if last:
+        try:
+            if datetime.fromisoformat(last) > datetime.utcnow() - timedelta(hours=24):
+                return  # already escalated today
+        except ValueError:
+            pass
+
+    set_setting("auto_issue_last_escalation", datetime.utcnow().isoformat())
+
+    try:
+        from services.email_service import send_outage_escalation_notification
+        send_outage_escalation_notification(reporter_count)
+    except Exception as e:
+        logger.error(f"Issue detector: escalation email failed: {e}")
+
+    try:
+        from services.sms_service import notify_admin
+        notify_admin(
+            f"[Remyndrs] POSSIBLE OUTAGE: {reporter_count} different users have "
+            f"reported a problem in the last 24h. Check /cs."
+        )
+    except Exception as e:
+        logger.error(f"Issue detector: escalation SMS failed: {e}")
+
+
+def record_and_notify(phone_number: str, message: str, classification: dict) -> dict:
+    """Persist the flag, email (rate-limited), and escalate if warranted."""
+    try:
+        cooldown_hours = int(get_setting("auto_issue_email_cooldown_hours", "6"))
+    except (TypeError, ValueError):
+        cooldown_hours = 6
+
+    # Checked before the insert, or the row we are about to write would
+    # always be its own "recent" match.
+    suppress_email = _emailed_recently(phone_number, cooldown_hours)
+
+    row_id = _insert_flag(phone_number, message, classification)
+    if row_id is None:
+        return {'recorded': False, 'emailed': False}
+
+    emailed = False
+    if not suppress_email:
+        try:
+            from services.email_service import send_issue_flag_notification
+            from services.support_service import get_user_name
+            emailed = send_issue_flag_notification(
+                phone_number=phone_number,
+                message=message,
+                category=classification['category'],
+                severity=classification['severity'],
+                summary=classification.get('summary', ''),
+                user_name=get_user_name(phone_number),
+            )
+        except Exception as e:
+            logger.error(f"Issue detector: notification email failed: {e}")
+    else:
+        logger.info(
+            f"Issue detector: email suppressed (cooldown) for ...{phone_number[-4:]}"
+        )
+
+    _maybe_escalate(count_distinct_reporters(24))
+
+    return {'recorded': True, 'emailed': emailed, 'id': row_id}
+
+
+def maybe_flag_issue_report(phone_number: str, message: str) -> dict | None:
+    """
+    Entry point for the /sms hook. Runs the full pipeline.
+
+    Never raises. Returns the record result when something was flagged,
+    otherwise None.
+    """
+    try:
+        if not is_detection_enabled():
+            return None
+
+        if not looks_like_issue_report(message):
+            return None
+
+        classification = classify_issue_report(message, phone_number)
+        if not classification:
+            return None
+
+        logger.info(
+            f"Issue detector: flagged {classification['category']}/"
+            f"{classification['severity']} from ...{phone_number[-4:]}"
+        )
+        return record_and_notify(phone_number, message, classification)
+
+    except Exception as e:
+        logger.error(f"Issue detector: unexpected failure: {e}")
+        return None

--- a/tasks/monitoring_tasks.py
+++ b/tasks/monitoring_tasks.py
@@ -393,3 +393,65 @@ def check_critical_issues(self):
     except Exception as exc:
         logger.exception("Error checking critical issues")
         raise
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=1,
+    default_retry_delay=300,
+    acks_late=True,
+    time_limit=300,
+    soft_time_limit=240,
+)
+def send_issue_flag_digest(self, hours: int = 24):
+    """
+    Daily rollup of auto-detected issue reports.
+
+    Individual flags already email as they happen (rate-limited per user), so
+    this exists to make a slow-burning pattern visible - a handful of users
+    complaining across a day reads very differently in one message than as
+    scattered emails.
+
+    Sends nothing when there were no flags.
+    """
+    try:
+        from datetime import timedelta
+        from database import get_db_connection, return_db_connection
+        from services.issue_detector import AUTO_SOURCE
+        from services.email_service import send_issue_digest_notification
+
+        conn = None
+        try:
+            conn = get_db_connection()
+            c = conn.cursor()
+            c.execute(
+                """SELECT phone_number, message, category, created_at
+                   FROM contact_messages
+                   WHERE source = %s AND created_at > %s
+                   ORDER BY created_at DESC""",
+                (AUTO_SOURCE, datetime.utcnow() - timedelta(hours=hours))
+            )
+            flags = [
+                {
+                    'phone_number': row[0],
+                    'message': row[1],
+                    'category': row[2],
+                    'created_at': row[3],
+                }
+                for row in c.fetchall()
+            ]
+        finally:
+            if conn:
+                return_db_connection(conn)
+
+        if not flags:
+            logger.info("Issue digest: no flags in the last %sh, skipping", hours)
+            return {'flags': 0, 'sent': False}
+
+        sent = send_issue_digest_notification(flags, hours=hours)
+        logger.info(f"Issue digest: {len(flags)} flag(s), sent={sent}")
+        return {'flags': len(flags), 'sent': bool(sent)}
+
+    except Exception as exc:
+        logger.exception("Error sending issue flag digest")
+        raise

--- a/tests/test_issue_detection.py
+++ b/tests/test_issue_detection.py
@@ -1,0 +1,262 @@
+"""
+Tests for auto-detected issue reports (services/issue_detector.py).
+
+Users report outages in plain language rather than texting SUPPORT/BUG. The
+detector notices those messages, records them, and notifies -- without ever
+changing what the user sees.
+
+The false-negative cost here is a week-long silent outage; the false-positive
+cost is a junk email. The prefilter is tuned accordingly, so the negative
+cases below matter as much as the positive ones.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from database import get_db_connection, return_db_connection
+from services.issue_detector import (
+    AUTO_SOURCE,
+    looks_like_issue_report,
+    record_and_notify,
+    maybe_flag_issue_report,
+    count_distinct_reporters,
+)
+
+
+def _fetch_flags(phone):
+    conn = get_db_connection()
+    try:
+        c = conn.cursor()
+        c.execute(
+            'SELECT message, category, source FROM contact_messages '
+            'WHERE phone_number = %s AND source = %s ORDER BY id',
+            (phone, AUTO_SOURCE)
+        )
+        return c.fetchall()
+    finally:
+        return_db_connection(conn)
+
+
+def _clear_flags(*phones):
+    conn = get_db_connection()
+    try:
+        c = conn.cursor()
+        for phone in phones:
+            c.execute(
+                'DELETE FROM contact_messages WHERE phone_number = %s AND source = %s',
+                (phone, AUTO_SOURCE)
+            )
+        conn.commit()
+    finally:
+        return_db_connection(conn)
+
+
+def _clear_escalation_marker():
+    from database import set_setting
+    set_setting("auto_issue_last_escalation", "")
+
+
+ISSUE_CLASSIFICATION = {
+    'category': 'reminder_delivery',
+    'severity': 'high',
+    'summary': 'User says reminders stopped arriving',
+}
+
+
+class TestPrefilter:
+    """Stage 1: free regex. Generous, but must not fire on ordinary requests."""
+
+    @pytest.mark.parametrize("message", [
+        "my reminders aren't working",
+        "I never got my reminder this morning",
+        "is this service down?",
+        "hey are you having issues? nothing came through",
+        "the app is broken",
+        "reminders stopped working a few days ago",
+        "I didn't receive my 8am text",
+        "why didn't I get my reminder",
+        "something's wrong with my account",
+        "I got double charged this month",
+        "I need to talk to customer service",
+        "what happened to my reminders",
+        "no reminders for 3 days now",
+    ])
+    def test_flags_issue_language(self, message):
+        assert looks_like_issue_report(message) is True
+
+    @pytest.mark.parametrize("message", [
+        # The critical false positive: issue words inside reminder content
+        "remind me to fix the broken sink",
+        "Remind me to call about the refund tomorrow at 3pm",
+        "remind me that the dishwasher is broken",
+        "add bug spray to my grocery list",
+        "add drain cleaner to my list for the broken sink",
+        "remember that the garage door is broken",
+        "create a list for things that are broken",
+        # Ordinary traffic
+        "remind me to call mom at 5pm",
+        "show my lists",
+        "what's on my grocery list",
+        "thanks!",
+        "yes",
+        "",
+    ])
+    def test_ignores_normal_messages(self, message):
+        assert looks_like_issue_report(message) is False
+
+    @pytest.mark.parametrize("message", [
+        "SUPPORT my reminders are broken",
+        "BUG nothing is working",
+        "FEEDBACK this doesn't work",
+        "HELP",
+        "STOP",
+    ])
+    def test_ignores_keyword_commands(self, message):
+        """These already notify through their own handlers - don't double-report."""
+        assert looks_like_issue_report(message) is False
+
+
+class TestRecording:
+    """Stage 3: persistence, email rate limiting, escalation."""
+
+    def test_records_flag_row(self, test_phone):
+        _clear_flags(test_phone)
+        with patch('services.email_service.send_issue_flag_notification', return_value=True):
+            result = record_and_notify(test_phone, "my reminders aren't working", ISSUE_CLASSIFICATION)
+
+        assert result['recorded'] is True
+        rows = _fetch_flags(test_phone)
+        assert len(rows) == 1
+        assert rows[0][0] == "my reminders aren't working"
+        assert rows[0][1] == "auto_reminder_delivery"
+        assert rows[0][2] == AUTO_SOURCE
+        _clear_flags(test_phone)
+
+    def test_email_cooldown_suppresses_second_email(self, test_phone):
+        """A frustrated user texting repeatedly produces rows, but one email."""
+        _clear_flags(test_phone)
+        with patch('services.email_service.send_issue_flag_notification', return_value=True) as mock_email:
+            record_and_notify(test_phone, "reminders aren't working", ISSUE_CLASSIFICATION)
+            record_and_notify(test_phone, "still not working!", ISSUE_CLASSIFICATION)
+            record_and_notify(test_phone, "hello?? nothing is working", ISSUE_CLASSIFICATION)
+
+        assert len(_fetch_flags(test_phone)) == 3, "every report should be recorded"
+        assert mock_email.call_count == 1, "only the first should email"
+        _clear_flags(test_phone)
+
+    def test_counts_distinct_reporters(self, test_phone):
+        phones = [test_phone, "+15550002222", "+15550003333"]
+        _clear_flags(*phones)
+        with patch('services.email_service.send_issue_flag_notification', return_value=True), \
+             patch('services.issue_detector._maybe_escalate'):
+            for phone in phones:
+                record_and_notify(phone, "nothing is working", ISSUE_CLASSIFICATION)
+
+        assert count_distinct_reporters(24) >= 3
+        _clear_flags(*phones)
+
+    def test_escalates_once_when_multiple_users_report(self, test_phone):
+        """Three distinct users inside 24h is the outage signature."""
+        phones = [test_phone, "+15550002222", "+15550003333", "+15550004444"]
+        _clear_flags(*phones)
+        _clear_escalation_marker()
+
+        with patch('services.email_service.send_issue_flag_notification', return_value=True), \
+             patch('services.email_service.send_outage_escalation_notification', return_value=True) as mock_escalate, \
+             patch('services.sms_service.notify_admin') as mock_sms:
+            for phone in phones:
+                record_and_notify(phone, "nothing is working", ISSUE_CLASSIFICATION)
+
+        assert mock_escalate.call_count == 1, "escalate once, not once per reporter"
+        assert mock_sms.call_count == 1
+        _clear_flags(*phones)
+        _clear_escalation_marker()
+
+    def test_survives_db_failure(self, test_phone):
+        """Recording must never raise into the webhook."""
+        with patch('services.issue_detector.get_db_connection', side_effect=RuntimeError('db down')):
+            result = record_and_notify(test_phone, "not working", ISSUE_CLASSIFICATION)
+        assert result['recorded'] is False
+
+
+class TestPipeline:
+    """maybe_flag_issue_report end to end, with the AI stage mocked."""
+
+    def test_flags_when_classifier_confirms(self, test_phone):
+        _clear_flags(test_phone)
+        with patch('services.issue_detector.classify_issue_report', return_value=ISSUE_CLASSIFICATION), \
+             patch('services.email_service.send_issue_flag_notification', return_value=True):
+            result = maybe_flag_issue_report(test_phone, "my reminders aren't working")
+
+        assert result is not None and result['recorded'] is True
+        assert len(_fetch_flags(test_phone)) == 1
+        _clear_flags(test_phone)
+
+    def test_no_flag_when_classifier_rejects(self, test_phone):
+        """The AI stage is what kills prefilter false positives."""
+        _clear_flags(test_phone)
+        with patch('services.issue_detector.classify_issue_report', return_value=None):
+            result = maybe_flag_issue_report(test_phone, "the app is broken")
+
+        assert result is None
+        assert _fetch_flags(test_phone) == []
+
+    def test_classifier_not_called_when_prefilter_misses(self, test_phone):
+        """Ordinary traffic must not cost an API call."""
+        with patch('services.issue_detector.classify_issue_report') as mock_classify:
+            maybe_flag_issue_report(test_phone, "remind me to call mom at 5pm")
+        mock_classify.assert_not_called()
+
+    def test_kill_switch_disables_everything(self, test_phone):
+        with patch('services.issue_detector.is_detection_enabled', return_value=False), \
+             patch('services.issue_detector.classify_issue_report') as mock_classify:
+            result = maybe_flag_issue_report(test_phone, "nothing is working")
+
+        assert result is None
+        mock_classify.assert_not_called()
+
+    def test_never_raises(self, test_phone):
+        with patch('services.issue_detector.looks_like_issue_report', side_effect=RuntimeError('boom')):
+            assert maybe_flag_issue_report(test_phone, "anything") is None
+
+
+class TestWebhookIntegration:
+    """The observer must be invisible to the user."""
+
+    @pytest.mark.asyncio
+    async def test_reply_unchanged_when_flagged(self, simulator, onboarded_user):
+        """
+        Regression guard: the user-visible reply is identical whether or not
+        the message was flagged. Silent flagging was a deliberate choice.
+        """
+        phone = onboarded_user["phone"]
+        _clear_flags(phone)
+        message = "my reminders aren't working"
+
+        # Baseline: detector stubbed out entirely
+        with patch('services.issue_detector.maybe_flag_issue_report') as mock_detector:
+            baseline = await simulator.send_message(phone, message)
+        assert mock_detector.called, "the hook should reach the detector"
+
+        with patch('services.issue_detector.classify_issue_report', return_value=ISSUE_CLASSIFICATION), \
+             patch('services.email_service.send_issue_flag_notification', return_value=True):
+            flagged = await simulator.send_message(phone, message)
+
+        assert flagged["output"] == baseline["output"]
+        assert len(_fetch_flags(phone)) == 1, "flagged exactly once, silently"
+        _clear_flags(phone)
+
+    @pytest.mark.asyncio
+    async def test_detector_failure_does_not_break_webhook(self, simulator, onboarded_user):
+        phone = onboarded_user["phone"]
+        with patch('services.issue_detector.maybe_flag_issue_report',
+                   side_effect=RuntimeError('detector exploded')):
+            result = await simulator.send_message(phone, "my reminders aren't working")
+        assert result["output"]  # user still got a reply
+
+    @pytest.mark.asyncio
+    async def test_normal_message_creates_no_flag(self, simulator, onboarded_user):
+        phone = onboarded_user["phone"]
+        _clear_flags(phone)
+        await simulator.send_message(phone, "remind me to fix the broken sink tomorrow at 9am")
+        assert _fetch_flags(phone) == []


### PR DESCRIPTION
## Why

Reminders silently stopped going out for about a week, affecting 4-6 users. Reviewing those conversations afterward showed the users had *told us* — in plain language, in the normal SMS thread — that something was broken. Nobody typed `SUPPORT` or `BUG`, so nothing reached the support inbox and the outage ran for days.

The gap wasn't detection infrastructure, it was routing: an issue report only reached the support inbox if the user happened to prefix it with a magic keyword.

## What

A side-channel observer (`services/issue_detector.py`) on the `/sms` path, hooked in after the SUPPORT MODE CHECK so users with an open ticket aren't double-reported. It never changes routing or the user's reply — it only records and notifies.

Three stages, cheapest first:

1. **Regex prefilter** — free. Generous, with `NOT_AN_ISSUE` guards so "remind me to fix the broken sink" and "add bug spray to my grocery list" don't match.
2. **`gpt-4o-mini` confirm** — 6s timeout, JSON mode, last 4 exchanges as context. Returns category / severity / one-line summary. Any error returns `None`; silence is the safe failure mode.
3. **Record + notify** — row in `contact_messages`, email, escalation.

### Notification behavior

- Per-flag email, rate-limited to one per user per 6h. A frustrated user texting six times produces six rows and one email.
- **Outage escalation:** 3+ *distinct* users flagged inside 24h sends an urgent email plus an admin SMS, once per day. Independent users complaining simultaneously is an outage signature rather than individual confusion — this is the alert that should have fired on day one.
- Daily digest at 13:00 UTC (~9am Eastern), grouped by category. Sends nothing when there were no flags.

### Design notes

- **Silent to the user** — the reply is unchanged whether or not a message was flagged, so a misclassification produces no visible weirdness. Worth revisiting after a week of real-world accuracy data.
- **Runs as a FastAPI background task.** The detector makes its own AI call on top of `process_with_ai()`; inline execution risked exceeding Twilio's 15s webhook timeout. `background_tasks` stays `None` when `sms_reply` is called directly (tests), where detection falls back to inline.
- **The main AI prompt is untouched.** Adding a `support` action to the large shared routing prompt in `ai_service.py` would have risked regressing core reminder/list/memory routing and collided with the existing `help` / `show_help` actions.
- Flags land in `contact_messages` with `source='sms_auto'`, so they appear in the CS portal with the existing resolve/reply workflow. **No schema migration.**

### Settings (DB, flippable without a deploy)

`auto_issue_detection_enabled` (kill switch), `auto_issue_email_cooldown_hours` (6), `auto_issue_outage_threshold` (3).

## Verification

⚠️ **`tests/test_issue_detection.py` (24 tests) has never been executed** — no local Postgres available, so every DB-backed test errors in setup. This is pre-existing and affects existing tests too (`tests/test_inbound_log.py` fails identically on a clean checkout). CI is the first real run of this suite.

Verified directly instead:

- **Prefilter across 68 messages** — all issue phrasings caught; of 30 ordinary messages only one flagged ("what happened to my dentist appointment reminder"), which is genuinely ambiguous and is what the AI stage exists to settle. Caught a real miss in the process: `aren't` was absent from the negation list, so "my reminders aren't working" slipped through.
- **Cooldown + escalation** against an in-memory DB — 6 reports from one user → 6 rows / 1 email; 4 distinct users → escalation once; 8 users → still once; 2 users → none.
- **All four email templates** render, including with unexpected category/severity values.
- **`BackgroundTasks` injection** — confirmed FastAPI injects it despite the `= None` default and runs the task even though the handler returns a `Response` directly, and that it stays `None` on direct calls.

## Post-merge

Confirm `SUPPORT_EMAIL` is set in the Render env for the API and worker services. Every email path here no-ops silently when `SMTP_ENABLED` is false (which it is whenever `SUPPORT_EMAIL` is missing) — flags would still be recorded but nothing would reach the inbox.

## Also

Fixes a stale entry in `CLAUDE.md`: the table list named `conversation_flags`, which exists nowhere in the codebase. The real table is `conversation_analysis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)