### PR TITLE
Add email fallback for reminder delivery during SMS outages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,9 @@ All timestamps stored in UTC, converted to user timezone on display. Timezone de
 ### Reminder Atomicity
 Uses `SELECT FOR UPDATE SKIP LOCKED` for distributed reminder claiming. Stale tasks released every 15 minutes.
 
+### Email Reminder Fallback
+When an SMS send fails in `send_single_reminder`, the task tries email delivery for users with an email on file (`_try_reminder_email_fallback()` in `tasks/reminder_tasks.py` → `send_reminder_email()` in `services/email_service.py`), then marks the reminder sent. Gated by the `reminder_email_fallback_enabled` DB setting (default `false`) — flip it in the `settings` table during an SMS provider outage, no deploy needed, and flip it back after. Covers reminder delivery only; lifecycle messages just retry.
+
 ### Subscription Tiers
 - **Free (v1 - grandfathered existing users):** 2 reminders/day, 2 lists, 5 items/list, 5 memories
 - **Free (v2 - new users):** 3 reminders/week (counted by scheduled date), 1 list, 3 items/list, 3 memories

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Changelog — Recent Improvements & Bug Fixes
 
+## Email Reminder Fallback (Aug 2026)
+Built during the Aug 2026 Twilio account suspension (suspicious-activity flag; every outbound SMS API call failed while inbound stopped reaching the webhook entirely). Reminders were never at risk of being lost — `send_single_reminder` only marks `sent = TRUE` after a successful send, so they queue and retry — but users with due reminders heard nothing.
+
+When an SMS send fails inside `send_single_reminder`, the task now attempts email delivery before scheduling a retry:
+- `_try_reminder_email_fallback()` in `tasks/reminder_tasks.py` — checks the kill switch, looks up the user's email (encryption-aware via new `get_user_email()` in `models/user.py`), and sends via new `send_reminder_email()` in `services/email_service.py`.
+- On successful email handoff the code falls through to the existing mark-as-sent block (same transaction, same fresh-connection fallback), so delivery accounting is unchanged.
+- On any failure (switch off, no email, SMTP error) behavior is identical to before: rollback, `track_reminder_delivery("failed")`, Celery retry, stale-claim release.
+
+**Setting (DB, flippable without a deploy):** `reminder_email_fallback_enabled` (default `false`). Flip to `"true"` in the `settings` table during an SMS provider outage; flip back after restoration so email never masks a real delivery problem.
+
+**Scope:** one-off reminder delivery only. Recurring reminders funnel through the same send task, so they're covered; trial lifecycle messages, nudges, and daily summaries just retry as before. The email tells the user why they're getting it by email and that replies aren't monitored (SNOOZE is omitted — inbound is down during an outage anyway).
+
+**Files:** `tasks/reminder_tasks.py`, `services/email_service.py`, `models/user.py`, `tests/test_email_fallback.py` (new), `CLAUDE.md`.
+
 ## Auto-Detected Issue Reports (Jul 2026)
 Reminders silently stopped going out for roughly a week, affecting 4-6 users. Reviewing those conversations afterward showed the users had *told us* — in plain language, in the normal SMS thread — that something was broken. Nobody typed `SUPPORT` or `BUG`, so nothing reached the support inbox and the outage ran for days.
 

--- a/models/user.py
+++ b/models/user.py
@@ -260,6 +260,40 @@ def get_user_first_name(phone_number: str) -> Optional[str]:
             return_db_connection(conn)
 
 
+def get_user_email(phone_number: str) -> Optional[str]:
+    """Get user's email address (decrypted if encryption is enabled)"""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+
+        if ENCRYPTION_ENABLED:
+            from utils.encryption import hash_phone, decrypt_field
+            phone_hash = hash_phone(phone_number)
+            c.execute('SELECT email, email_encrypted FROM users WHERE phone_hash = %s', (phone_hash,))
+            result = c.fetchone()
+            if not result:
+                c.execute('SELECT email, email_encrypted FROM users WHERE phone_number = %s', (phone_number,))
+                result = c.fetchone()
+            if result:
+                # Prefer encrypted field if available
+                if result[1]:
+                    return decrypt_field(result[1])
+                return result[0]
+        else:
+            c.execute('SELECT email FROM users WHERE phone_number = %s', (phone_number,))
+            result = c.fetchone()
+            if result:
+                return result[0]
+        return None
+    except Exception as e:
+        logger.error(f"Error getting user email: {e}")
+        return None
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
 def get_last_active_list(phone_number: str) -> Optional[str]:
     """Get user's last active list name"""
     conn = None

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -488,3 +488,87 @@ def send_issue_digest_notification(flags: list, hours: int = 24):
     except Exception as e:
         logger.error(f"Failed to send issue digest: {e}")
         return False
+
+
+def send_reminder_email(to_email: str, reminder_text: str, first_name: str = None):
+    """Send a reminder to the user by email.
+
+    Fallback channel used when SMS delivery is unavailable (e.g. Twilio outage).
+    Returns True only on successful SMTP handoff — callers use the return value
+    to decide whether the reminder can be marked as sent.
+    """
+    if not SMTP_ENABLED:
+        logger.warning("SMTP not configured - cannot send reminder email")
+        return False
+
+    if not to_email or '@' not in to_email:
+        return False
+
+    try:
+        greeting = f"Hi {first_name}," if first_name else "Hi,"
+
+        msg = MIMEMultipart('alternative')
+        msg['Subject'] = "Reminder from Remyndrs"
+        msg['From'] = SMTP_FROM_EMAIL
+        msg['To'] = to_email
+
+        text_content = f"""{greeting}
+
+Here's your reminder:
+
+{reminder_text}
+
+---
+You're receiving this by email because text message delivery is temporarily
+unavailable. Your reminders are safe and texting will resume automatically.
+Replies to this email are not monitored.
+"""
+
+        html_content = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }}
+        .container {{ max-width: 600px; margin: 0 auto; padding: 20px; }}
+        .header {{ background: #3498db; color: white; padding: 15px; border-radius: 8px 8px 0 0; }}
+        .content {{ background: #f9f9f9; padding: 20px; border: 1px solid #ddd; }}
+        .message {{ background: white; padding: 15px; border-radius: 8px; margin: 15px 0; border-left: 4px solid #3498db; font-size: 16px; }}
+        .footer {{ padding: 15px; font-size: 12px; color: #666; }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h2 style="margin: 0;">&#9200; Your Remyndr</h2>
+        </div>
+        <div class="content">
+            <p>{greeting}</p>
+            <div class="message">
+                {reminder_text}
+            </div>
+        </div>
+        <div class="footer">
+            <p>You're receiving this by email because text message delivery is temporarily
+            unavailable. Your reminders are safe and texting will resume automatically.
+            Replies to this email are not monitored.</p>
+        </div>
+    </div>
+</body>
+</html>
+        """
+
+        msg.attach(MIMEText(text_content, 'plain'))
+        msg.attach(MIMEText(html_content, 'html'))
+
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=30) as server:
+            server.starttls()
+            server.login(SMTP_USERNAME, SMTP_PASSWORD)
+            server.sendmail(SMTP_FROM_EMAIL, to_email, msg.as_string())
+
+        logger.info(f"Reminder email sent to {to_email.split('@')[0][:2]}***@{to_email.split('@')[1]}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to send reminder email: {e}")
+        return False

--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -95,6 +95,28 @@ def check_and_send_reminders(self):
         raise self.retry(exc=exc)
 
 
+def _try_reminder_email_fallback(phone_number: str, reminder_text: str) -> bool:
+    """Attempt email delivery of a reminder when SMS fails.
+
+    Gated by the 'reminder_email_fallback_enabled' DB setting (default off)
+    so it can be flipped on during an SMS provider outage without a deploy.
+    Returns True only if the email was actually handed to SMTP.
+    """
+    try:
+        from database import get_setting
+        if get_setting("reminder_email_fallback_enabled", "false").lower() != "true":
+            return False
+        from models.user import get_user_email, get_user_first_name
+        from services.email_service import send_reminder_email
+        email = get_user_email(phone_number)
+        if not email:
+            return False
+        return send_reminder_email(email, reminder_text, get_user_first_name(phone_number))
+    except Exception:
+        logger.exception("Email fallback attempt failed")
+        return False
+
+
 @celery_app.task(
     bind=True,
     max_retries=3,
@@ -184,11 +206,16 @@ def send_single_reminder(self, reminder_id: int, phone_number: str, reminder_tex
             return {"status": "skipped", "reason": "user_opted_out"}
 
         except Exception as exc:
-            # SMS failed - rollback to release lock, then retry
-            conn.rollback()
-            logger.exception(f"Error sending SMS for reminder {reminder_id}")
-            track_reminder_delivery(reminder_id, "failed", str(exc))
-            raise self.retry(exc=exc)
+            # SMS failed - try email fallback while the lock is still held.
+            # On success we fall through to the shared mark-as-sent block below.
+            if _try_reminder_email_fallback(phone_number, reminder_text):
+                logger.warning(f"Reminder {reminder_id}: SMS failed, delivered via email fallback")
+            else:
+                # No email delivery - rollback to release lock, then retry
+                conn.rollback()
+                logger.exception(f"Error sending SMS for reminder {reminder_id}")
+                track_reminder_delivery(reminder_id, "failed", str(exc))
+                raise self.retry(exc=exc)
 
         # SMS sent successfully - mark as sent in the SAME transaction
         # This keeps the FOR UPDATE lock held until both SMS send and flag update

--- a/tests/test_email_fallback.py
+++ b/tests/test_email_fallback.py
@@ -1,0 +1,126 @@
+"""
+Tests for the email reminder fallback (SMS provider outage mitigation).
+
+When a Twilio send fails, send_single_reminder attempts email delivery for
+users with an email on file. Gated by the 'reminder_email_fallback_enabled'
+DB setting (default off) so it can be flipped without a deploy.
+"""
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from tasks.reminder_tasks import _try_reminder_email_fallback, send_single_reminder
+
+TEST_PHONE = "+15559876543"
+
+
+class TestEmailFallbackHelper:
+
+    def test_disabled_by_default(self):
+        with patch('database.get_setting', return_value="false"), \
+             patch('services.email_service.send_reminder_email') as send:
+            assert _try_reminder_email_fallback(TEST_PHONE, "take out trash") is False
+            send.assert_not_called()
+
+    def test_enabled_without_email_on_file(self):
+        with patch('database.get_setting', return_value="true"), \
+             patch('models.user.get_user_email', return_value=None), \
+             patch('services.email_service.send_reminder_email') as send:
+            assert _try_reminder_email_fallback(TEST_PHONE, "take out trash") is False
+            send.assert_not_called()
+
+    def test_enabled_with_email_delivers(self):
+        with patch('database.get_setting', return_value="true"), \
+             patch('models.user.get_user_email', return_value="user@example.com"), \
+             patch('models.user.get_user_first_name', return_value="Pat"), \
+             patch('services.email_service.send_reminder_email', return_value=True) as send:
+            assert _try_reminder_email_fallback(TEST_PHONE, "take out trash") is True
+            send.assert_called_once_with("user@example.com", "take out trash", "Pat")
+
+    def test_email_send_failure_reports_false(self):
+        with patch('database.get_setting', return_value="true"), \
+             patch('models.user.get_user_email', return_value="user@example.com"), \
+             patch('models.user.get_user_first_name', return_value=None), \
+             patch('services.email_service.send_reminder_email', return_value=False):
+            assert _try_reminder_email_fallback(TEST_PHONE, "take out trash") is False
+
+    def test_unexpected_error_reports_false(self):
+        with patch('database.get_setting', side_effect=RuntimeError("db down")):
+            assert _try_reminder_email_fallback(TEST_PHONE, "take out trash") is False
+
+
+def _reminder_sent(reminder_id):
+    from database import get_db_connection, return_db_connection
+    conn = get_db_connection()
+    try:
+        c = conn.cursor()
+        c.execute('SELECT sent FROM reminders WHERE id = %s', (reminder_id,))
+        row = c.fetchone()
+        return row[0] if row else None
+    finally:
+        return_db_connection(conn)
+
+
+class TestSendSingleReminderFallback:
+
+    def _save_due_reminder(self, phone):
+        from models.reminder import save_reminder
+        from database import get_db_connection, return_db_connection
+        save_reminder(
+            phone,
+            "Fallback test reminder",
+            (datetime.utcnow() - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M:%S")
+        )
+        # save_reminder doesn't return the id — look it up
+        conn = get_db_connection()
+        try:
+            c = conn.cursor()
+            c.execute('SELECT id FROM reminders WHERE phone_number = %s ORDER BY id DESC LIMIT 1', (phone,))
+            return c.fetchone()[0]
+        finally:
+            return_db_connection(conn)
+
+    def test_sms_failure_with_fallback_marks_sent(self, onboarded_user):
+        """SMS fails, fallback enabled, email on file -> delivered by email, marked sent."""
+        phone = onboarded_user["phone"]
+        reminder_id = self._save_due_reminder(phone)
+
+        with patch('tasks.reminder_tasks.send_sms', side_effect=Exception("twilio suspended")), \
+             patch('database.get_setting', return_value="true"), \
+             patch('models.user.get_user_email', return_value="user@example.com"), \
+             patch('models.user.get_user_first_name', return_value="Pat"), \
+             patch('services.email_service.send_reminder_email', return_value=True) as send:
+            result = send_single_reminder(reminder_id, phone, "Fallback test reminder")
+
+        assert result["status"] == "sent"
+        send.assert_called_once()
+        assert _reminder_sent(reminder_id) is True
+
+    def test_sms_failure_without_fallback_stays_unsent(self, onboarded_user):
+        """SMS fails, fallback disabled -> task retries, reminder stays unsent."""
+        phone = onboarded_user["phone"]
+        reminder_id = self._save_due_reminder(phone)
+
+        with patch('tasks.reminder_tasks.send_sms', side_effect=Exception("twilio suspended")), \
+             patch('database.get_setting', return_value="false"), \
+             patch('services.email_service.send_reminder_email') as send:
+            # Called directly (not via worker), retry() re-raises the original exception
+            with pytest.raises(Exception):
+                send_single_reminder(reminder_id, phone, "Fallback test reminder")
+
+        send.assert_not_called()
+        assert _reminder_sent(reminder_id) is False
+
+    def test_sms_success_never_touches_email(self, onboarded_user, sms_capture):
+        """Normal path: SMS delivers, email fallback is never consulted."""
+        phone = onboarded_user["phone"]
+        reminder_id = self._save_due_reminder(phone)
+
+        with patch('tasks.reminder_tasks.send_sms', side_effect=sms_capture.send_sms), \
+             patch('services.email_service.send_reminder_email') as send:
+            result = send_single_reminder(reminder_id, phone, "Fallback test reminder")
+
+        assert result["status"] == "sent"
+        send.assert_not_called()
+        assert _reminder_sent(reminder_id) is True


### PR DESCRIPTION
## Context
Twilio suspended the account (suspicious-activity flag, ticket open), so every outbound SMS fails. Reminders were never at risk of loss — they only mark sent after a successful send and keep retrying — but affected users heard nothing. 5 of the 7 users with reminders due in the next two weeks have an email on file.

## What this does
When a Twilio send fails inside `send_single_reminder`, the task attempts email delivery before scheduling a retry:

- `_try_reminder_email_fallback()` (`tasks/reminder_tasks.py`): checks the kill switch, looks up the user email (encryption-aware `get_user_email()`, new in `models/user.py`), sends via `send_reminder_email()` (new in `services/email_service.py`).
- On successful email handoff, execution falls through to the **existing** atomic mark-as-sent block (same transaction, same fresh-connection fallback) — delivery accounting is unchanged.
- On any failure (switch off, no email, SMTP error) behavior is byte-identical to today: rollback, `track_reminder_delivery(failed)`, Celery retry, stale-claim release.

## Kill switch (no deploy needed)
DB setting `reminder_email_fallback_enabled`, **default off**. Enable during the outage:

```sql
INSERT INTO settings (key, value, updated_at) VALUES ('reminder_email_fallback_enabled', 'true', CURRENT_TIMESTAMP)
ON CONFLICT (key) DO UPDATE SET value = 'true', updated_at = CURRENT_TIMESTAMP;
```

Flip back to `'false'` once Twilio restores, so email never masks a real delivery problem.

## Notes
- The email explains why it arrived by email and that replies are not monitored; the SNOOZE line is omitted (inbound SMS is down during an outage anyway).
- Recurring reminders are covered (they funnel through the same send task). Lifecycle messages/nudges/daily summaries are not — they just retry as before.

## Testing
- New `tests/test_email_fallback.py`: 5 helper unit tests + 3 task-level tests (fallback-on marks sent, fallback-off stays unsent and retries, normal SMS path never consults email). All 8 pass.
- `tests/test_reminders.py` + `tests/test_background_tasks.py`: 32/32 pass, including `test_sms_failure_retried` which exercises the modified branch with the setting at its default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)