### PR TITLE
Fix list-item and memory deletes that confirmed then no-op'd

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,7 +42,8 @@ from models.list_model import (
     get_next_available_list_name,
     get_accessible_list_by_name, can_user_access_list,
     get_shared_lists_for_user, get_pending_shares,
-    is_shared_list_read_only
+    is_shared_list_read_only,
+    resolve_item_for_delete, delete_list_item_from_pending,
 )
 from routes.handlers.lists import (
     handle_share_list, handle_unshare_list, handle_show_list_members,
@@ -2019,15 +2020,11 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                             reply_msg = "Couldn't delete that recurring reminder."
 
                     elif delete_type == 'list_item':
-                        from models.list_model import delete_list_item_by_id, delete_list_item_by_list_id
-                        item_id = delete_data.get('id')
-                        shared_list_id = delete_data.get('shared_list_id')
-                        if item_id and delete_list_item_by_id(item_id, phone_number):
-                            reply_msg = f"Removed '{delete_data['text']}' from {delete_data['list_name']}"
-                        elif shared_list_id and delete_list_item_by_list_id(shared_list_id, delete_data['text']):
-                            reply_msg = f"Removed '{delete_data['text']}' from shared list '{delete_data['list_name']}'"
-                        elif delete_list_item(phone_number, delete_data['list_name'], delete_data['text']):
-                            reply_msg = f"Removed '{delete_data['text']}' from {delete_data['list_name']}"
+                        if delete_list_item_from_pending(phone_number, delete_data):
+                            is_shared = bool(delete_data.get('is_shared') or delete_data.get('shared_list_id'))
+                            list_label = delete_data.get('list_name', 'the list')
+                            display = f"shared list '{list_label}'" if is_shared else list_label
+                            reply_msg = f"Removed '{delete_data['text']}' from {display}"
                         else:
                             reply_msg = "Couldn't delete that item."
 
@@ -2076,8 +2073,11 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                                 reply_msg = "Couldn't delete that reminder."
 
                         elif delete_type == 'list_item':
-                            if delete_list_item(phone_number, selected['list_name'], selected['text']):
-                                reply_msg = f"Removed '{selected['text']}' from {selected['list_name']}"
+                            if delete_list_item_from_pending(phone_number, selected):
+                                is_shared = bool(selected.get('is_shared') or selected.get('shared_list_id'))
+                                list_label = selected.get('list_name', 'the list')
+                                display = f"shared list '{list_label}'" if is_shared else list_label
+                                reply_msg = f"Removed '{selected['text']}' from {display}"
                             else:
                                 reply_msg = "Couldn't delete that list item."
 
@@ -2119,7 +2119,8 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
 
                 # Check if this is a confirmation (single memory awaiting YES)
                 if memory_data.get('awaiting_confirmation'):
-                    if incoming_msg.upper() == "YES":
+                    memory_reply = incoming_msg.strip().upper()
+                    if memory_reply == "YES":
                         memory_id = memory_data['id']
                         memory_text = memory_data['text']
                         if delete_memory(phone_number, memory_id):
@@ -2131,7 +2132,7 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                         resp.message(reply_msg)
                         log_interaction(phone_number, incoming_msg, reply_msg, "delete_memory_confirmed", True)
                         return Response(content=str(resp), media_type="application/xml")
-                    elif incoming_msg.upper() in ["NO", "CANCEL"]:
+                    elif memory_reply in ["NO", "CANCEL"]:
                         create_or_update_user(phone_number, pending_memory_delete=None)
                         resp = MessagingResponse()
                         resp.message("Cancelled. Your memory is safe!")
@@ -5796,32 +5797,52 @@ def process_single_action(ai_response, phone_number, incoming_msg):
             list_name = ai_response.get("list_name")
             item_text = ai_response.get("item_text")
 
-            # Check if this is a shared list the user has access to
-            accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
-            is_shared_list = accessible and accessible[2]
+            resolved = resolve_item_for_delete(
+                phone_number,
+                list_name=list_name,
+                item_text=item_text,
+                last_active_list=get_last_active_list(phone_number),
+            )
 
-            # Check if shared list is read-only (owner no longer Premium)
-            if is_shared_list:
-                read_only, owner_name = is_shared_list_read_only(accessible[0])
-                if read_only:
-                    reply_text = f"The shared list '{accessible[1]}' is currently read-only because the owner's Premium plan has expired."
-                    log_interaction(phone_number, incoming_msg, reply_text, "delete_item_readonly", False)
-                    resp = MessagingResponse()
-                    resp.message(staging_prefix(reply_text))
-                    return Response(content=str(resp), media_type="application/xml")
+            if not resolved:
+                if list_name and item_text:
+                    reply_text = f"Couldn't find '{item_text}' in '{list_name}'."
+                elif item_text:
+                    reply_text = f"Couldn't find '{item_text}' in your lists."
+                else:
+                    reply_text = "I couldn't tell which item to remove. Try 'Delete 1' after viewing a list."
+                log_interaction(phone_number, incoming_msg, reply_text, "delete_item", False)
+            elif resolved.get('ambiguous'):
+                reply_text = f"'{item_text}' is in multiple lists. Please specify which list."
+                log_interaction(phone_number, incoming_msg, reply_text, "delete_item", True)
+            else:
+                list_id = resolved['list_id']
+                actual_name = resolved['list_name']
+                actual_item = resolved['item_text']
+                is_shared_list = resolved['is_shared']
 
-            # Ask for confirmation before deleting
-            confirm_data = json.dumps({
-                'awaiting_confirmation': True,
-                'type': 'list_item',
-                'list_name': list_name,
-                'text': item_text,
-                'shared_list_id': accessible[0] if is_shared_list else None
-            })
-            create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
-            prefix = "shared list " if is_shared_list else ""
-            reply_text = f"Remove '{item_text}' from {prefix}{list_name}?\n\nReply YES to confirm or CANCEL to keep it."
-            log_interaction(phone_number, incoming_msg, "Asking delete_item confirmation", "delete_item_confirm", True)
+                if is_shared_list:
+                    read_only, owner_name = is_shared_list_read_only(list_id)
+                    if read_only:
+                        reply_text = f"The shared list '{actual_name}' is currently read-only because the owner's Premium plan has expired."
+                        log_interaction(phone_number, incoming_msg, reply_text, "delete_item_readonly", False)
+                        resp = MessagingResponse()
+                        resp.message(staging_prefix(reply_text))
+                        return Response(content=str(resp), media_type="application/xml")
+
+                confirm_data = json.dumps({
+                    'awaiting_confirmation': True,
+                    'type': 'list_item',
+                    'list_name': actual_name,
+                    'list_id': list_id,
+                    'is_shared': is_shared_list,
+                    'text': actual_item,
+                    'shared_list_id': list_id if is_shared_list else None,
+                })
+                create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
+                display = f"shared list '{actual_name}'" if is_shared_list else actual_name
+                reply_text = f"Remove '{actual_item}' from {display}?\n\nReply YES to confirm or CANCEL to keep it."
+                log_interaction(phone_number, incoming_msg, "Asking delete_item confirmation", "delete_item_confirm", True)
 
         elif ai_response["action"] == "delete_list":
             list_name = ai_response.get("list_name")
@@ -6207,7 +6228,12 @@ def process_single_action(ai_response, phone_number, incoming_msg):
             log_interaction(phone_number, incoming_msg, reply_text, "update_settings", True)
 
         elif ai_response["action"] == "delete_memory":
-            search_term = ai_response.get("search_term", "")
+            search_term = (ai_response.get("search_term") or ai_response.get("query") or "").strip()
+
+            if not search_term:
+                reply_text = "Which memory would you like to delete? Text SHOW MEMORIES to see them, then 'Delete 1'."
+                log_interaction(phone_number, incoming_msg, reply_text, "delete_memory", True)
+                return reply_text
 
             # Search for matching memories
             matching_memories = search_memories(phone_number, search_term)

--- a/models/list_model.py
+++ b/models/list_model.py
@@ -3,11 +3,29 @@ List Model
 Handles all list-related database operations
 """
 
+import html
 from datetime import datetime
 from typing import Any, Optional
 
 from database import get_db_connection, return_db_connection
 from config import logger, ENCRYPTION_ENABLED, SHARED_LIST_MAX_MEMBERS, SHARED_LIST_MAX_PER_USER, SHARED_LIST_MAX_RECEIVED
+
+# last_active_list context markers are not real list names
+_CONTEXT_MARKERS = frozenset({
+    "__RECURRING__", "__REMINDERS__", "__LISTS__", "__MEMORIES__",
+})
+_PARTIAL_MATCH_MIN = 3
+
+
+def _norm_text(value: str) -> str:
+    """Lowercase, strip, and HTML-unescape for lookup comparison.
+
+    Leftover encoded names from before the storage-time escaping fix
+    (e.g. Sam&#39;s Club) then match user/AI input like "Sam's Club".
+    """
+    if not value:
+        return ""
+    return html.unescape(value).strip().lower()
 
 
 def create_list(phone_number: str, list_name: str) -> Optional[int]:
@@ -127,7 +145,28 @@ def get_list_by_name(phone_number: str, list_name: str) -> Optional[tuple[int, s
             )
             result = c.fetchone()
 
-        return result
+        if result:
+            return result
+
+        # Fallback: HTML-unescaped equality (issue #15 leftover encoded names)
+        if list_name:
+            if ENCRYPTION_ENABLED:
+                from utils.encryption import hash_phone
+                phone_hash = hash_phone(phone_number)
+                c.execute(
+                    'SELECT id, list_name FROM lists WHERE phone_hash = %s OR phone_number = %s',
+                    (phone_hash, phone_number)
+                )
+            else:
+                c.execute(
+                    'SELECT id, list_name FROM lists WHERE phone_number = %s',
+                    (phone_number,)
+                )
+            target = _norm_text(list_name)
+            for row in c.fetchall():
+                if _norm_text(row[1]) == target:
+                    return row
+        return None
     except Exception as e:
         logger.error(f"Error getting list by name: {e}")
         return None
@@ -395,43 +434,12 @@ def find_item_in_any_list(phone_number: str, item_text: str) -> list[tuple[int, 
 
 def delete_list_item(phone_number: str, list_name: str, item_text: str) -> bool:
     """Delete an item from a list"""
-    conn = None
-    try:
-        conn = get_db_connection()
-        c = conn.cursor()
-
-        # Find the list first
-        if ENCRYPTION_ENABLED:
-            from utils.encryption import hash_phone
-            phone_hash = hash_phone(phone_number)
-            c.execute(
-                'SELECT id FROM lists WHERE phone_hash = %s AND LOWER(list_name) = LOWER(%s)',
-                (phone_hash, list_name)
-            )
-        else:
-            c.execute(
-                'SELECT id FROM lists WHERE phone_number = %s AND LOWER(list_name) = LOWER(%s)',
-                (phone_number, list_name)
-            )
-
-        list_result = c.fetchone()
-        if not list_result:
-            return False
-
-        list_id = list_result[0]
-        c.execute(
-            'DELETE FROM list_items WHERE list_id = %s AND LOWER(item_text) = LOWER(%s)',
-            (list_id, item_text)
-        )
-        deleted = c.rowcount > 0
-        conn.commit()
-        return deleted
-    except Exception as e:
-        logger.error(f"Error deleting list item: {e}")
+    # Resolve list via the same lookup as show/add so HTML-encoded leftover
+    # names and encryption fallbacks stay consistent.
+    list_info = get_list_by_name(phone_number, list_name)
+    if not list_info:
         return False
-    finally:
-        if conn:
-            return_db_connection(conn)
+    return delete_list_item_by_list_id(list_info[0], item_text)
 
 
 def delete_list(phone_number: str, list_name: str) -> bool:
@@ -1068,6 +1076,12 @@ def get_accessible_list_by_name(phone_number: str, list_name: str) -> Optional[t
         result = c.fetchone()
         if result:
             return (result[0], result[1], True, result[2])
+
+        # Fallback: HTML-unescaped equality for leftover encoded names
+        if list_name:
+            for lid, name, _count, _done, owner in get_shared_lists_for_user(phone_number):
+                if _norm_text(name) == _norm_text(list_name):
+                    return (lid, name, True, owner)
         return None
     except Exception as e:
         logger.error(f"Error getting accessible list: {e}")
@@ -1240,6 +1254,13 @@ def delete_list_item_by_list_id(list_id: int, item_text: str) -> bool:
             'DELETE FROM list_items WHERE list_id = %s AND LOWER(item_text) = LOWER(%s)',
             (list_id, item_text)
         )
+        if c.rowcount == 0 and item_text:
+            # Exact SQL miss — HTML-unescaped equality on this list's items
+            target = _norm_text(item_text)
+            c.execute('SELECT id, item_text FROM list_items WHERE list_id = %s', (list_id,))
+            matches = [row for row in c.fetchall() if _norm_text(row[1]) == target]
+            if len(matches) == 1:
+                c.execute('DELETE FROM list_items WHERE id = %s', (matches[0][0],))
         deleted = c.rowcount > 0
         conn.commit()
         return deleted
@@ -1249,3 +1270,145 @@ def delete_list_item_by_list_id(list_id: int, item_text: str) -> bool:
     finally:
         if conn:
             return_db_connection(conn)
+
+
+def match_item_in_list(
+    list_id: int,
+    item_text: str,
+    exact_only: bool = False
+) -> Optional[tuple[int, str, bool]]:
+    """Find an item in a list by exact (HTML-unescaped) match, then unique partial.
+
+    Returns (item_id, item_text, completed) or None.
+    """
+    if not item_text:
+        return None
+    items = get_list_items(list_id)
+    target = _norm_text(item_text)
+    if not target:
+        return None
+
+    exact = [i for i in items if _norm_text(i[1]) == target]
+    if exact:
+        return exact[0]
+    if exact_only or len(target) < _PARTIAL_MATCH_MIN:
+        return None
+
+    partial = [
+        i for i in items
+        if target in _norm_text(i[1]) or _norm_text(i[1]) in target
+    ]
+    if len(partial) == 1:
+        return partial[0]
+    return None
+
+
+def _iter_accessible_lists(phone_number: str):
+    """Yield (list_id, list_name, is_shared, owner_phone) for owned + accepted shared lists."""
+    for lid, name, *_rest in get_lists(phone_number):
+        yield lid, name, False, None
+    for lid, name, _count, _done, owner in get_shared_lists_for_user(phone_number):
+        yield lid, name, True, owner
+
+
+def _unique_partial_list(phone_number: str, fragment: str) -> Optional[tuple[int, str, bool, Optional[str]]]:
+    """Unique partial/substring list-name match across owned + shared lists."""
+    frag = _norm_text(fragment)
+    if len(frag) < _PARTIAL_MATCH_MIN:
+        return None
+    matches = []
+    for lid, name, is_shared, owner in _iter_accessible_lists(phone_number):
+        n = _norm_text(name)
+        if frag == n or frag in n or n in frag:
+            matches.append((lid, name, is_shared, owner))
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def resolve_item_for_delete(
+    phone_number: str,
+    list_name: Optional[str] = None,
+    item_text: Optional[str] = None,
+    last_active_list: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """Resolve which list item a delete request refers to.
+
+    Returns:
+        None if nothing matched.
+        {'ambiguous': True} if the item exists in more than one list.
+        {'list_id', 'list_name', 'item_text', 'is_shared'} on a unique match.
+    """
+    if not item_text:
+        return None
+
+    accessible = None
+    used_explicit_list = False
+    if list_name:
+        accessible = get_accessible_list_by_name(phone_number, list_name)
+        if not accessible:
+            accessible = _unique_partial_list(phone_number, list_name)
+        used_explicit_list = accessible is not None
+
+    if not accessible and last_active_list and last_active_list not in _CONTEXT_MARKERS:
+        accessible = get_accessible_list_by_name(phone_number, last_active_list)
+        if not accessible:
+            accessible = _unique_partial_list(phone_number, last_active_list)
+
+    if accessible:
+        list_id, actual_name, is_shared, _owner = accessible
+        item = match_item_in_list(list_id, item_text)
+        if item:
+            return {
+                'list_id': list_id,
+                'list_name': actual_name,
+                'item_text': item[1],
+                'is_shared': is_shared,
+            }
+        if used_explicit_list:
+            return None
+
+    matches = []
+    for lid, name, is_shared, _owner in _iter_accessible_lists(phone_number):
+        item = match_item_in_list(lid, item_text)
+        if item:
+            matches.append((lid, name, is_shared, item[1]))
+    if len(matches) == 1:
+        lid, name, is_shared, actual_item = matches[0]
+        return {
+            'list_id': lid,
+            'list_name': name,
+            'item_text': actual_item,
+            'is_shared': is_shared,
+        }
+    if len(matches) > 1:
+        return {'ambiguous': True}
+    return None
+
+
+def delete_list_item_from_pending(phone_number: str, delete_data: dict) -> bool:
+    """Delete a list item from a pending confirmation/selection payload.
+
+    Prefers list_id (works for owned and shared lists), then item id (undo),
+    then name+text lookup. Accepts both `list_id` and legacy `shared_list_id`.
+    """
+    if not delete_data:
+        return False
+
+    list_id = delete_data.get('list_id') or delete_data.get('shared_list_id')
+    item_text = delete_data.get('text')
+    if list_id is not None and item_text:
+        if delete_list_item_by_list_id(list_id, item_text):
+            return True
+        matched = match_item_in_list(list_id, item_text)
+        if matched and delete_list_item_by_list_id(list_id, matched[1]):
+            return True
+
+    item_id = delete_data.get('id')
+    if item_id and delete_list_item_by_id(item_id, phone_number):
+        return True
+
+    list_name = delete_data.get('list_name')
+    if list_name and item_text:
+        return delete_list_item(phone_number, list_name, item_text)
+    return False

--- a/routes/handlers/lists.py
+++ b/routes/handlers/lists.py
@@ -19,7 +19,8 @@ from models.list_model import (
     accept_share, decline_share, leave_shared_list,
     add_list_item as db_add_list_item,
     mark_item_complete_by_list_id, mark_item_incomplete_by_list_id,
-    delete_list_item_by_list_id, is_shared_list_read_only
+    delete_list_item_by_list_id, is_shared_list_read_only,
+    resolve_item_for_delete,
 )
 from services.ai_service import parse_list_items
 from utils.validation import (
@@ -489,36 +490,51 @@ def handle_delete_item(
     list_name = ai_response.get("list_name")
     item_text = ai_response.get("item_text")
 
-    accessible = get_accessible_list_by_name(phone_number, list_name) if list_name else None
-    if accessible:
-        list_id, actual_name, is_shared, _owner_phone = accessible
-        if is_shared:
-            read_only, _ = is_shared_list_read_only(list_id)
-            if read_only:
-                reply_text = f"The shared list '{actual_name}' is currently read-only because the owner's Premium plan has expired."
-                log_interaction(phone_number, incoming_msg, reply_text, "delete_item_confirm", False)
-                return reply_text
-        confirm_data = json.dumps({
-            'awaiting_confirmation': True,
-            'type': 'list_item',
-            'list_name': actual_name,
-            'list_id': list_id,
-            'is_shared': is_shared,
-            'text': item_text,
-        })
-        create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
-        display = f"shared list '{actual_name}'" if is_shared else actual_name
-        reply_text = f"Remove '{item_text}' from {display}?\n\nReply YES to confirm or CANCEL to keep it."
-    else:
-        # Preserve old behavior: store with name only; confirmation will report not-found
-        confirm_data = json.dumps({
-            'awaiting_confirmation': True,
-            'type': 'list_item',
-            'list_name': list_name,
-            'text': item_text,
-        })
-        create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
-        reply_text = f"Remove '{item_text}' from {list_name}?\n\nReply YES to confirm or CANCEL to keep it."
+    resolved = resolve_item_for_delete(
+        phone_number,
+        list_name=list_name,
+        item_text=item_text,
+        last_active_list=get_last_active_list(phone_number),
+    )
+
+    if not resolved:
+        if list_name and item_text:
+            reply_text = f"Couldn't find '{item_text}' in '{list_name}'."
+        elif item_text:
+            reply_text = f"Couldn't find '{item_text}' in your lists."
+        else:
+            reply_text = "I couldn't tell which item to remove. Try 'Delete 1' after viewing a list."
+        log_interaction(phone_number, incoming_msg, reply_text, "delete_item", False)
+        return reply_text
+    if resolved.get('ambiguous'):
+        reply_text = f"'{item_text}' is in multiple lists. Please specify which list."
+        log_interaction(phone_number, incoming_msg, reply_text, "delete_item", True)
+        return reply_text
+
+    list_id = resolved['list_id']
+    actual_name = resolved['list_name']
+    actual_item = resolved['item_text']
+    is_shared = resolved['is_shared']
+
+    if is_shared:
+        read_only, _ = is_shared_list_read_only(list_id)
+        if read_only:
+            reply_text = f"The shared list '{actual_name}' is currently read-only because the owner's Premium plan has expired."
+            log_interaction(phone_number, incoming_msg, reply_text, "delete_item_confirm", False)
+            return reply_text
+
+    confirm_data = json.dumps({
+        'awaiting_confirmation': True,
+        'type': 'list_item',
+        'list_name': actual_name,
+        'list_id': list_id,
+        'is_shared': is_shared,
+        'text': actual_item,
+        'shared_list_id': list_id if is_shared else None,
+    })
+    create_or_update_user(phone_number, pending_reminder_delete=confirm_data)
+    display = f"shared list '{actual_name}'" if is_shared else actual_name
+    reply_text = f"Remove '{actual_item}' from {display}?\n\nReply YES to confirm or CANCEL to keep it."
 
     log_interaction(phone_number, incoming_msg, "Asking delete_item confirmation", "delete_item_confirm", True)
     return reply_text

--- a/routes/handlers/memories.py
+++ b/routes/handlers/memories.py
@@ -70,7 +70,12 @@ def handle_delete_memory(
     ai_response: dict[str, Any]
 ) -> str:
     """Handle delete_memory action."""
-    search_term = ai_response.get("search_term", "")
+    search_term = (ai_response.get("search_term") or ai_response.get("query") or "").strip()
+
+    if not search_term:
+        reply_text = "Which memory would you like to delete? Text SHOW MEMORIES to see them, then 'Delete 1'."
+        log_interaction(phone_number, incoming_msg, reply_text, "delete_memory", True)
+        return reply_text
 
     matching_memories = search_memories(phone_number, search_term)
 

--- a/routes/handlers/pending_states.py
+++ b/routes/handlers/pending_states.py
@@ -88,17 +88,12 @@ def handle_pending_delete(
                     reply_msg = "Couldn't delete that recurring reminder."
 
             elif delete_type == 'list_item':
-                list_id = delete_data.get('list_id')
-                is_shared = delete_data.get('is_shared', False)
-                if list_id is not None:
-                    from models.list_model import delete_list_item_by_list_id
-                    if delete_list_item_by_list_id(list_id, delete_data['text']):
-                        display = f"shared list '{delete_data['list_name']}'" if is_shared else delete_data['list_name']
-                        reply_msg = f"Removed '{delete_data['text']}' from {display}"
-                    else:
-                        reply_msg = "Couldn't delete that item."
-                elif delete_list_item(phone_number, delete_data['list_name'], delete_data['text']):
-                    reply_msg = f"Removed '{delete_data['text']}' from {delete_data['list_name']}"
+                from models.list_model import delete_list_item_from_pending
+                if delete_list_item_from_pending(phone_number, delete_data):
+                    is_shared = bool(delete_data.get('is_shared') or delete_data.get('shared_list_id'))
+                    list_label = delete_data.get('list_name', 'the list')
+                    display = f"shared list '{list_label}'" if is_shared else list_label
+                    reply_msg = f"Removed '{delete_data['text']}' from {display}"
                 else:
                     reply_msg = "Couldn't delete that item."
 
@@ -134,17 +129,12 @@ def handle_pending_delete(
                         reply_msg = "Couldn't delete that reminder."
 
                 elif delete_type == 'list_item':
-                    list_id = selected.get('list_id')
-                    is_shared = selected.get('is_shared', False)
-                    if list_id is not None:
-                        from models.list_model import delete_list_item_by_list_id
-                        if delete_list_item_by_list_id(list_id, selected['text']):
-                            display = f"shared list '{selected['list_name']}'" if is_shared else selected['list_name']
-                            reply_msg = f"Removed '{selected['text']}' from {display}"
-                        else:
-                            reply_msg = "Couldn't delete that list item."
-                    elif delete_list_item(phone_number, selected['list_name'], selected['text']):
-                        reply_msg = f"Removed '{selected['text']}' from {selected['list_name']}"
+                    from models.list_model import delete_list_item_from_pending
+                    if delete_list_item_from_pending(phone_number, selected):
+                        is_shared = bool(selected.get('is_shared') or selected.get('shared_list_id'))
+                        list_label = selected.get('list_name', 'the list')
+                        display = f"shared list '{list_label}'" if is_shared else list_label
+                        reply_msg = f"Removed '{selected['text']}' from {display}"
                     else:
                         reply_msg = "Couldn't delete that list item."
 
@@ -188,7 +178,8 @@ def handle_pending_memory_delete(
 
         # Handle YES/NO confirmation for single memory
         if memory_data.get('awaiting_confirmation'):
-            if incoming_msg.upper() == "YES":
+            memory_reply = incoming_msg.strip().upper()
+            if memory_reply == "YES":
                 memory_id = memory_data['id']
                 memory_text = memory_data['text']
                 if delete_memory(phone_number, memory_id):
@@ -199,7 +190,7 @@ def handle_pending_memory_delete(
                 log_interaction(phone_number, incoming_msg, reply_msg, "delete_memory_confirmed", True)
                 return (True, reply_msg)
 
-            elif incoming_msg.upper() in ["NO", "CANCEL"]:
+            elif memory_reply in ["NO", "CANCEL"]:
                 create_or_update_user(phone_number, pending_memory_delete=None)
                 log_interaction(phone_number, incoming_msg, "Delete cancelled", "delete_memory_cancelled", True)
                 return (True, "Cancelled. Your memory is safe!")

--- a/tests/test_delete_items.py
+++ b/tests/test_delete_items.py
@@ -1,0 +1,245 @@
+"""
+Tests for list-item and memory deletion.
+
+Covers the SMS keyword path (Delete N + YES), the AI delete_item /
+delete_memory actions, partial name matching, HTML-encoded leftover
+list names, and confirmation follow-up turns.
+"""
+
+import pytest
+
+from models.list_model import (
+    create_list, add_list_item, get_list_items, get_list_by_name,
+    resolve_item_for_delete, delete_list_item_from_pending,
+)
+from models.memory import save_memory, get_memories
+from models.user import create_or_update_user
+
+
+def _item_texts(list_id):
+    return [item[1] for item in get_list_items(list_id)]
+
+
+class TestOwnedListDeleteByNumber:
+    """Show a list, Delete N, YES should remove that item."""
+
+    @pytest.mark.asyncio
+    async def test_show_then_delete_by_number_then_yes(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        list_id = create_list(phone, "Grocery List")
+        add_list_item(list_id, phone, "Milk")
+        add_list_item(list_id, phone, "Eggs")
+
+        ai_mock.set_response("show grocery list", {
+            "action": "show_list",
+            "list_name": "Grocery List",
+        })
+        await simulator.send_message(phone, "Show Grocery List")
+
+        result = await simulator.send_message(phone, "Delete 1")
+        out = result["output"].lower()
+        assert "milk" in out and "yes" in out, f"Expected confirmation. Got: {result['output']}"
+
+        confirm = await simulator.send_message(phone, "YES")
+        assert "couldn't delete" not in confirm["output"].lower(), confirm["output"]
+        assert "removed" in confirm["output"].lower()
+        assert "Milk" not in _item_texts(list_id)
+        assert "Eggs" in _item_texts(list_id)
+
+
+class TestAiDeleteItemResolution:
+    """AI delete_item must resolve the real list/item before confirming."""
+
+    @pytest.mark.asyncio
+    async def test_exact_names_then_yes(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        list_id = create_list(phone, "Grocery List")
+        add_list_item(list_id, phone, "Milk")
+        add_list_item(list_id, phone, "Eggs")
+
+        ai_mock.set_response("delete eggs from grocery list", {
+            "action": "delete_item",
+            "list_name": "Grocery List",
+            "item_text": "Eggs",
+        })
+        result = await simulator.send_message(phone, "Delete eggs from grocery list")
+        assert "eggs" in result["output"].lower()
+        assert "yes" in result["output"].lower()
+
+        confirm = await simulator.send_message(phone, "YES")
+        assert "couldn't delete" not in confirm["output"].lower(), confirm["output"]
+        assert "Eggs" not in _item_texts(list_id)
+        assert "Milk" in _item_texts(list_id)
+
+    @pytest.mark.asyncio
+    async def test_partial_list_name_grocery_vs_grocery_list(self, simulator, onboarded_user, ai_mock):
+        """AI often extracts 'grocery' when the stored name is 'Grocery List'."""
+        phone = onboarded_user["phone"]
+        list_id = create_list(phone, "Grocery List")
+        add_list_item(list_id, phone, "Milk")
+        add_list_item(list_id, phone, "Bread")
+
+        ai_mock.set_response("remove milk from grocery", {
+            "action": "delete_item",
+            "list_name": "grocery",
+            "item_text": "milk",
+        })
+        result = await simulator.send_message(phone, "Remove milk from grocery")
+        assert "couldn't find" not in result["output"].lower(), result["output"]
+        assert "milk" in result["output"].lower()
+        assert "yes" in result["output"].lower()
+
+        confirm = await simulator.send_message(phone, "YES")
+        assert "couldn't delete" not in confirm["output"].lower(), confirm["output"]
+        assert "Milk" not in _item_texts(list_id)
+
+    @pytest.mark.asyncio
+    async def test_partial_item_name(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        list_id = create_list(phone, "Grocery List")
+        add_list_item(list_id, phone, "2% milk")
+        add_list_item(list_id, phone, "Eggs")
+
+        ai_mock.set_response("remove milk from grocery list", {
+            "action": "delete_item",
+            "list_name": "Grocery List",
+            "item_text": "milk",
+        })
+        result = await simulator.send_message(phone, "Remove milk from grocery list")
+        assert "couldn't find" not in result["output"].lower(), result["output"]
+        assert "2% milk" in result["output"].lower()
+
+        await simulator.send_message(phone, "YES")
+        texts = [t.lower() for t in _item_texts(list_id)]
+        assert "2% milk" not in texts
+        assert "eggs" in texts
+
+    @pytest.mark.asyncio
+    async def test_uses_last_active_list_when_ai_omits_list_name(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        list_id = create_list(phone, "Grocery List")
+        add_list_item(list_id, phone, "Milk")
+        add_list_item(list_id, phone, "Eggs")
+        create_or_update_user(phone, last_active_list="Grocery List")
+
+        ai_mock.set_response("delete eggs", {
+            "action": "delete_item",
+            "list_name": None,
+            "item_text": "Eggs",
+        })
+        result = await simulator.send_message(phone, "Delete eggs")
+        assert "couldn't find" not in result["output"].lower(), result["output"]
+        assert "eggs" in result["output"].lower()
+
+        await simulator.send_message(phone, "YES")
+        assert "Eggs" not in _item_texts(list_id)
+
+    @pytest.mark.asyncio
+    async def test_does_not_confirm_when_item_missing(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        list_id = create_list(phone, "Grocery List")
+        add_list_item(list_id, phone, "Milk")
+
+        ai_mock.set_response("delete tofu from grocery list", {
+            "action": "delete_item",
+            "list_name": "Grocery List",
+            "item_text": "tofu",
+        })
+        result = await simulator.send_message(phone, "Delete tofu from grocery list")
+        assert "couldn't find" in result["output"].lower(), result["output"]
+        assert "Milk" in _item_texts(list_id)
+
+    @pytest.mark.asyncio
+    async def test_html_encoded_list_name_lookup(self, simulator, onboarded_user, ai_mock):
+        """Leftover encoded names (issue #15) should still match user/AI apostrophes."""
+        phone = onboarded_user["phone"]
+        list_id = create_list(phone, "Sam&#39;s Club")
+        add_list_item(list_id, phone, "Paper towels")
+
+        found = get_list_by_name(phone, "Sam's Club")
+        assert found is not None, "get_list_by_name should unescape leftover HTML entities"
+
+        ai_mock.set_response("remove paper towels from sam's club", {
+            "action": "delete_item",
+            "list_name": "Sam's Club",
+            "item_text": "Paper towels",
+        })
+        result = await simulator.send_message(phone, "Remove paper towels from Sam's Club")
+        assert "couldn't find" not in result["output"].lower(), result["output"]
+
+        await simulator.send_message(phone, "YES")
+        assert _item_texts(list_id) == []
+
+
+class TestMemoryDelete:
+    @pytest.mark.asyncio
+    async def test_show_memories_then_delete_by_number(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        save_memory(phone, "wifi password is Home2024", {})
+
+        result = await simulator.send_message(phone, "SHOW MEMORIES")
+        assert "wifi" in result["output"].lower()
+
+        confirm_prompt = await simulator.send_message(phone, "Delete 1")
+        assert "yes" in confirm_prompt["output"].lower() or "delete" in confirm_prompt["output"].lower()
+
+        confirm = await simulator.send_message(phone, "YES")
+        assert "couldn't delete" not in confirm["output"].lower(), confirm["output"]
+        assert "deleted" in confirm["output"].lower()
+        leftover = [m for m in get_memories(phone) if "wifi" in (m[1] or "").lower()]
+        assert leftover == []
+
+    @pytest.mark.asyncio
+    async def test_ai_delete_memory_accepts_query_field(self, simulator, onboarded_user, ai_mock):
+        """The model (and some tests) send 'query' instead of 'search_term'."""
+        phone = onboarded_user["phone"]
+        save_memory(phone, "wifi password is Home2024", {})
+
+        ai_mock.set_response("forget my wifi password", {
+            "action": "delete_memory",
+            "query": "wifi password",
+        })
+        result = await simulator.send_message(phone, "Forget my wifi password")
+        assert "wifi" in result["output"].lower()
+        assert "yes" in result["output"].lower()
+
+        confirm = await simulator.send_message(phone, "YES")
+        assert "deleted" in confirm["output"].lower()
+        leftover = [m for m in get_memories(phone) if "wifi" in (m[1] or "").lower()]
+        assert leftover == []
+
+    @pytest.mark.asyncio
+    async def test_ai_delete_memory_yes_with_trailing_whitespace(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        save_memory(phone, "locker combo is 42-15-33", {})
+
+        ai_mock.set_response("forget my locker combo", {
+            "action": "delete_memory",
+            "search_term": "locker",
+        })
+        await simulator.send_message(phone, "Forget my locker combo")
+
+        confirm = await simulator.send_message(phone, "YES ")
+        assert "couldn't delete" not in confirm["output"].lower(), confirm["output"]
+        assert "deleted" in confirm["output"].lower()
+
+
+class TestDeleteHelpers:
+    def test_resolve_partial_and_encoded_names(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        list_id = create_list(phone, "Sam&#39;s Club")
+        add_list_item(list_id, phone, "Milk")
+
+        resolved = resolve_item_for_delete(phone, list_name="Sam's Club", item_text="milk")
+        assert resolved is not None
+        assert not resolved.get("ambiguous")
+        assert resolved["list_id"] == list_id
+        assert resolved["item_text"] == "Milk"
+
+        ok = delete_list_item_from_pending(phone, {
+            "list_id": list_id,
+            "list_name": resolved["list_name"],
+            "text": resolved["item_text"],
+        })
+        assert ok is True
+        assert _item_texts(list_id) == []

--- a/tests/test_shared_lists.py
+++ b/tests/test_shared_lists.py
@@ -1019,6 +1019,7 @@ class TestSharedListEditPaths:
     async def test_show_then_delete_by_number_targets_shared_list(self, accepted_share, simulator, ai_mock):
         """After 'Show <shared>', 'Delete N' should target the shared list, not fall back to
         a cross-type disambiguation menu. Regression for Heather's screenshot bug."""
+        from models.list_model import get_list_items
         ai_mock.set_response("show grocery list", {
             "action": "show_list",
             "list_name": "Grocery List",
@@ -1033,6 +1034,17 @@ class TestSharedListEditPaths:
         # Should ask for YES/CANCEL confirmation targeted at the shared list
         assert "milk" in out and ("yes" in out or "remove" in out), (
             f"Expected confirmation prompt for Milk from shared list. Got: {result['output']}"
+        )
+
+        confirm = await simulator.send_message(PHONE_SHARED, "YES")
+        confirm_out = confirm["output"].lower()
+        assert "couldn't delete" not in confirm_out, (
+            f"YES after Delete-by-number failed on shared list. Got: {confirm['output']}"
+        )
+        assert "removed" in confirm_out or "milk" in confirm_out
+        items_after = get_list_items(accepted_share["list_id"])
+        assert not any(item[1].lower() == "milk" for item in items_after), (
+            f"Milk still on shared list after YES: {items_after}"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Diagnosis

Deleting list items and memories often *looked* like it was about to work (the bot asked YES) and then failed on the confirmation turn, or never found the row because names didn’t match exactly.

This is not primarily AI-intent flakiness. The live `/sms` path in `main.py` and the DB lookup helpers disagreed with each other, and with the already-written (but unwired) handler in `routes/handlers/pending_states.py`.

### What the code actually does

Users delete in three ways:

1. **Keyword `Delete N`** after viewing a list or memories (`main.py` ~2554). Stores pending JSON and asks YES.
2. **AI `delete_item` / `delete_memory`** after natural language (`main.py` process_single_action).
3. **Number picker** from a disambiguation menu or `DELETE MEMORIES`.

Confirmation is handled earlier in `sms_reply` via `pending_reminder_delete` / `pending_memory_delete`.

### Bug 1 — YES ignored `list_id` (shared lists, and any ID-based delete)

After `Show Grocery List` → `Delete 1`, the keyword path already stored:

```python
{'type': 'list_item', 'list_id': list_id, 'is_shared': is_shared, 'text': item_text, ...}
```

The **live** YES handler in `main.py` did not read `list_id`. It looked for `id` (item id) and `shared_list_id`, then fell back to `delete_list_item(phone, list_name, text)`, which only searches **owned** lists.

So a shared-list member who confirmed “Remove Milk from shared list Grocery List?” got **“Couldn't delete that item.”** and the row stayed. The existing test `test_show_then_delete_by_number_targets_shared_list` only asserted the prompt, not YES — that’s why this survived.

The unwired `handle_pending_delete` in `routes/handlers/pending_states.py` already used `list_id`. The live path did not.

Same gap on the number-selection branch (`main.py` used name+text only).

### Bug 2 — AI `delete_item` confirmed with unresolved names

`complete_item` already falls back to `find_item_in_any_list`. `delete_item` did not:

- It stored whatever the model extracted (`list_name="grocery"`, `item_text="milk"`).
- It asked YES anyway, even if that list/item did not exist.
- On YES, `LOWER(list_name) = LOWER(%s)` and `LOWER(item_text) = LOWER(%s)` failed for `"grocery"` vs `"Grocery List"` and `"milk"` vs `"2% milk"`.
- It did not use `last_active_list` when the model omitted the list name.

Users experienced: confirm → “Couldn't delete that item.”

### Bug 3 — Memory confirm / search were brittle

- Pending memory YES used `incoming_msg.upper() == "YES"` **without `.strip()`**, so `"YES "` fell through.
- Handler read only `search_term`. Empty term became SQL `LIKE '%%'` (match-all). The model (and some tests) send `query` instead.

### Issue #15 (HTML-encoded names) — hypothesis, verified as related not root

Issue #15 is leftover DB data (`Sam&#39;s Club`), not current writes. `sanitize_text()` no longer HTML-escapes (comment in `utils/validation.py` is explicit). Exact `LOWER(list_name) = LOWER(%s)` still fails against those leftover rows, which **would** break delete/show/add lookup for apostrophe lists created before the storage fix. This is not the general “deletes don’t work” bug, but it is a real lookup miss for that data. Lookup now HTML-unescapes as a fallback. Cleaning existing rows (the SQL in #15) is still worth doing for display.

## Fix

Tight changes only:

- Confirm/YES and number-selection use `list_id` (and legacy `shared_list_id` / item `id`) via `delete_list_item_from_pending()`.
- `delete_item` **resolves** the real list+item before asking YES: exact match, unique partial name (`grocery` → `Grocery List`), `last_active_list`, unique item substring (`milk` → `2% milk`). If nothing unique matches, it says so instead of confirming a no-op.
- List lookups HTML-unescape leftover encoded names.
- Memory YES strips whitespace; `query` is accepted as `search_term`; empty search no longer matches everything.

## Tests

- New `tests/test_delete_items.py` — owned Delete N+YES, AI exact/partial/last-active/missing item, HTML-encoded names, memory Show→Delete N, `query` field, YES with trailing space.
- Extended `test_show_then_delete_by_number_targets_shared_list` to complete YES and assert the row is gone.

23 related tests passed locally (`test_delete_items.py` + `TestSharedListEditPaths`).

## Not in this PR

- Wiring `routes/handlers/*` into `main.py` (issue #17).
- Running the issue #15 data cleanup SQL in production (still recommended for display).
- AI misclassifying “forget milk” as `delete_memory` vs `delete_item` — still possible; resolution + last_active_list make the list path much more forgiving when the action is right.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47e7ca9d-71c3-48a5-9683-631c282cc1ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47e7ca9d-71c3-48a5-9683-631c282cc1ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

