### PR TITLE
Fix Show 3 opening a reminder delete instead of list 3

### DIFF
--- a/main.py
+++ b/main.py
@@ -5661,6 +5661,34 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                             last_active_list="__LISTS__",
                             pending_reminder_delete=None,
                         )
+                    else:
+                        reply_text = "You don't have any lists yet. Try 'Create a grocery list'!"
+            else:
+                # No last active list, show all lists (or single list directly)
+                lists = get_lists(phone_number)
+                if len(lists) == 1:
+                    list_id = lists[0][0]
+                    list_name = lists[0][1]
+                    create_or_update_user(phone_number, last_active_list=list_name)
+                    items = get_list_items(list_id)
+                    if items:
+                        item_lines = []
+                        for i, (item_id, item_text, completed) in enumerate(items, 1):
+                            if completed:
+                                item_lines.append(f"{i}. [x] {item_text}")
+                            else:
+                                item_lines.append(f"{i}. {item_text}")
+                        reply_text = f"{list_name}:\n\n" + "\n".join(item_lines)
+                    else:
+                        reply_text = f"Your {list_name} is empty."
+                elif lists:
+                    list_lines = [f"{i+1}. {l[1]} ({l[2]} items)" for i, l in enumerate(lists)]
+                    reply_text = "Your lists:\n\n" + "\n".join(list_lines) + "\n\nReply with a number to see that list."
+                    create_or_update_user(
+                        phone_number,
+                        last_active_list="__LISTS__",
+                        pending_reminder_delete=None,
+                    )
                 else:
                     reply_text = "You don't have any lists yet. Try 'Create a grocery list'!"
             log_interaction(phone_number, incoming_msg, reply_text, "show_current_list", True)

--- a/main.py
+++ b/main.py
@@ -48,7 +48,8 @@ from models.list_model import (
 from routes.handlers.lists import (
     handle_share_list, handle_unshare_list, handle_show_list_members,
     handle_leave_shared_list, handle_accept_share, handle_decline_share,
-    handle_pending_share_name, format_all_lists_display
+    handle_pending_share_name, format_all_lists_display,
+    parse_list_picker_reply, format_numbered_list_reply, get_all_lists_with_shared,
 )
 from services.sms_service import send_sms, log_inbound_sms
 from services.ai_service import process_with_ai, parse_list_items
@@ -1979,6 +1980,36 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                 return Response(content=str(resp), media_type="application/xml")
 
         # ==========================================
+        # LIST PICKER ("Show 3", "show 3", "#3")
+        # ==========================================
+        # Bare numbers still mean "pick N" from a pending delete/show menu.
+        # Prefixed forms are a new intent: open that list and drop any leftover
+        # pending delete so we never confirm-delete reminder #N instead.
+        if not get_pending_list_item(phone_number):
+            picker_num = parse_list_picker_reply(incoming_msg, allow_bare_number=False)
+            if picker_num is not None:
+                create_or_update_user(
+                    phone_number,
+                    pending_reminder_delete=None,
+                    pending_memory_delete=None,
+                )
+                reply = format_numbered_list_reply(phone_number, picker_num)
+                resp = MessagingResponse()
+                if reply:
+                    resp.message(reply)
+                    log_interaction(phone_number, incoming_msg, reply, "show_list", True)
+                else:
+                    total = len(get_all_lists_with_shared(phone_number))
+                    range_msg = (
+                        f"Please reply with a number between 1 and {total}."
+                        if total else
+                        "You don't have any lists yet."
+                    )
+                    resp.message(range_msg)
+                    log_interaction(phone_number, incoming_msg, range_msg, "show_list", False)
+                return Response(content=str(resp), media_type="application/xml")
+
+        # ==========================================
         # PENDING DELETE SELECTION (reminders, list items, memories)
         # ==========================================
         # Check if user has pending deletion and sent a number or CANCEL
@@ -2051,7 +2082,8 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                     create_or_update_user(phone_number, pending_reminder_delete=None)
                     # Fall through to normal message processing
 
-            # Handle number selection
+            # Handle number selection from a delete-options menu. Bare numbers
+            # still pick item N; anything else is a new intent (clear and continue).
             if incoming_msg.strip().isdigit():
                 try:
                     delete_options = json.loads(pending_delete_data)
@@ -2107,6 +2139,14 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                 except (json.JSONDecodeError, KeyError) as e:
                     logger.error(f"Error parsing pending delete data: {e}")
                     create_or_update_user(phone_number, pending_reminder_delete=None)
+            elif not (
+                delete_data
+                and isinstance(delete_data, dict)
+                and delete_data.get('awaiting_confirmation')
+            ):
+                # Numbered delete menu is still pending but this isn't a pick —
+                # treat it as a new intent instead of re-prompting YES/CANCEL.
+                create_or_update_user(phone_number, pending_reminder_delete=None)
 
         # ==========================================
         # PENDING MEMORY DELETE SELECTION/CONFIRMATION
@@ -2138,6 +2178,9 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                         resp.message("Cancelled. Your memory is safe!")
                         log_interaction(phone_number, incoming_msg, "Delete cancelled", "delete_memory_cancelled", True)
                         return Response(content=str(resp), media_type="application/xml")
+                    else:
+                        # New intent — don't keep re-prompting YES to delete.
+                        create_or_update_user(phone_number, pending_memory_delete=None)
 
                 # Check if this is a number selection (multiple memories)
                 elif memory_data.get('options') and incoming_msg.strip().isdigit():
@@ -2168,6 +2211,9 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                         resp = MessagingResponse()
                         resp.message(f"Please reply with a number between 1 and {len(memory_options)}")
                         return Response(content=str(resp), media_type="application/xml")
+                else:
+                    # New intent — drop the memory-delete menu/confirm.
+                    create_or_update_user(phone_number, pending_memory_delete=None)
 
             except (json.JSONDecodeError, KeyError) as e:
                 logger.error(f"Error parsing pending memory delete data: {e}")
@@ -4180,8 +4226,15 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
         # LIST COMMANDS (MY LISTS, SHOW LISTS)
         # ==========================================
         if incoming_msg.upper() in ["MY LISTS", "SHOW LISTS", "LIST LISTS", "LISTS"]:
-            # Clear any pending list item state so number responses show lists, not add items
-            create_or_update_user(phone_number, pending_list_item=None, pending_delete=False)
+            # Clear pending add/delete state so number replies open a list, not
+            # confirm a leftover reminder delete or add an item.
+            create_or_update_user(
+                phone_number,
+                pending_list_item=None,
+                pending_delete=False,
+                pending_reminder_delete=None,
+                pending_memory_delete=None,
+            )
 
             # Use shared-list-aware display
             reply = format_all_lists_display(phone_number)
@@ -4216,7 +4269,11 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                 if pending:
                     reply += f"\n\nYou have {len(pending)} pending shared list invitation{'s' if len(pending) > 1 else ''}. Reply ACCEPT or DECLINE."
             elif total_lists > 1:
-                create_or_update_user(phone_number, last_active_list="__LISTS__")
+                create_or_update_user(
+                    phone_number,
+                    last_active_list="__LISTS__",
+                    pending_reminder_delete=None,
+                )
             else:
                 pass  # format_all_lists_display already handles empty case
 
@@ -4228,31 +4285,11 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
         # ==========================================
         # NUMBER RESPONSE TO SHOW LIST
         # ==========================================
-        # If user sends just a number and has lists (but no pending item), show that list
-        if incoming_msg.strip().isdigit() and not get_pending_list_item(phone_number):
-            list_num = int(incoming_msg.strip())
-            from routes.handlers.lists import get_all_lists_with_shared
-            all_lists = get_all_lists_with_shared(phone_number)
-            if all_lists and 1 <= list_num <= len(all_lists):
-                selected = all_lists[list_num - 1]
-                list_id = selected['list_id']
-                list_name = selected['list_name']
-                is_shared = selected['is_shared']
-                prefix = "[Shared] " if is_shared else ""
-                # Set context so "Delete #" knows we're viewing this specific list
-                create_or_update_user(phone_number, last_active_list=list_name)
-                items = get_list_items(list_id)
-                if items:
-                    item_lines = []
-                    for i, (item_id, item_text, completed) in enumerate(items, 1):
-                        if completed:
-                            item_lines.append(f"{i}. [x] {item_text}")
-                        else:
-                            item_lines.append(f"{i}. {item_text}")
-                    reply = f"{prefix}{list_name}:\n\n" + "\n".join(item_lines)
-                else:
-                    reply = f"{prefix}{list_name} is empty." if is_shared else f"Your {list_name} is empty."
-
+        # Bare number, or "Show N" / "#N". Skip if the user is picking a list to add to.
+        picker_num = parse_list_picker_reply(incoming_msg)
+        if picker_num is not None and not get_pending_list_item(phone_number):
+            reply = format_numbered_list_reply(phone_number, picker_num)
+            if reply:
                 resp = MessagingResponse()
                 resp.message(reply)
                 log_interaction(phone_number, incoming_msg, reply, "show_list", True)
@@ -4321,37 +4358,8 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
         if pending_date_check:
             pending_states['date_clarification'] = pending_date_check
 
-        # Check for reminder delete confirmation
-        pending_reminder_del = get_pending_reminder_delete(phone_number)
-        if pending_reminder_del:
-            try:
-                del_data = json.loads(pending_reminder_del)
-                if isinstance(del_data, list):
-                    # It's a list of options for selection
-                    pending_states['reminder_delete_selection'] = del_data
-                elif isinstance(del_data, dict):
-                    if del_data.get('awaiting_confirmation'):
-                        pending_states['reminder_delete_confirmation'] = del_data
-                    elif 'options' in del_data:
-                        pending_states['reminder_delete_selection'] = del_data
-            except json.JSONDecodeError:
-                pass
-
-        # Check for memory delete confirmation
-        pending_memory_del = get_pending_memory_delete(phone_number)
-        if pending_memory_del:
-            try:
-                mem_data = json.loads(pending_memory_del)
-                if isinstance(mem_data, list):
-                    # It's a list of options for selection
-                    pending_states['memory_delete_selection'] = mem_data
-                elif isinstance(mem_data, dict):
-                    if mem_data.get('awaiting_confirmation'):
-                        pending_states['memory_delete_confirmation'] = mem_data
-                    elif 'options' in mem_data:
-                        pending_states['memory_delete_selection'] = mem_data
-            except json.JSONDecodeError:
-                pass
+        # Pending reminder/memory/list-item deletes are handled above (YES / CANCEL /
+        # bare number). Do not re-prompt them here — a new intent should proceed.
 
         # Check for list item selection (pending_list_item without pending_delete)
         pending_list_item_check = get_pending_list_item(phone_number)
@@ -4422,16 +4430,6 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                 elif 'date_clarification' in pending_states:
                     state = pending_states['date_clarification']
                     reminder = f"I still need to know what time for '{state['text']}' on {state['date']}.\n\nWhat time? (e.g., '9am', '3:30pm')\n\n(Say 'cancel' to skip)"
-                elif 'reminder_delete_confirmation' in pending_states:
-                    state = pending_states['reminder_delete_confirmation']
-                    reminder = f"I still need your confirmation: Delete reminder '{state.get('text', 'your reminder')}'?\n\nReply YES to delete or NO to keep it. (Say 'cancel' to skip)"
-                elif 'reminder_delete_selection' in pending_states:
-                    reminder = "I still need you to select which reminder to delete.\n\nReply with the number of the reminder to delete, or say 'cancel' to skip."
-                elif 'memory_delete_confirmation' in pending_states:
-                    state = pending_states['memory_delete_confirmation']
-                    reminder = f"I still need your confirmation: Delete this memory?\n\nReply YES to delete or NO to keep it. (Say 'cancel' to skip)"
-                elif 'memory_delete_selection' in pending_states:
-                    reminder = "I still need you to select which memory to delete.\n\nReply with the number of the memory to delete, or say 'cancel' to skip."
                 elif 'list_selection' in pending_states:
                     state = pending_states['list_selection']
                     reminder = f"I still need to know which list to add '{state['item']}' to.\n\nReply with the list number, or say 'cancel' to skip."
@@ -5658,29 +5656,11 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                     elif lists:
                         list_lines = [f"{i+1}. {l[1]} ({l[2]} items)" for i, l in enumerate(lists)]
                         reply_text = "Your lists:\n\n" + "\n".join(list_lines) + "\n\nReply with a number to see that list."
-                    else:
-                        reply_text = "You don't have any lists yet. Try 'Create a grocery list'!"
-            else:
-                # No last active list, show all lists (or single list directly)
-                lists = get_lists(phone_number)
-                if len(lists) == 1:
-                    list_id = lists[0][0]
-                    list_name = lists[0][1]
-                    create_or_update_user(phone_number, last_active_list=list_name)
-                    items = get_list_items(list_id)
-                    if items:
-                        item_lines = []
-                        for i, (item_id, item_text, completed) in enumerate(items, 1):
-                            if completed:
-                                item_lines.append(f"{i}. [x] {item_text}")
-                            else:
-                                item_lines.append(f"{i}. {item_text}")
-                        reply_text = f"{list_name}:\n\n" + "\n".join(item_lines)
-                    else:
-                        reply_text = f"Your {list_name} is empty."
-                elif lists:
-                    list_lines = [f"{i+1}. {l[1]} ({l[2]} items)" for i, l in enumerate(lists)]
-                    reply_text = "Your lists:\n\n" + "\n".join(list_lines) + "\n\nReply with a number to see that list."
+                        create_or_update_user(
+                            phone_number,
+                            last_active_list="__LISTS__",
+                            pending_reminder_delete=None,
+                        )
                 else:
                     reply_text = "You don't have any lists yet. Try 'Create a grocery list'!"
             log_interaction(phone_number, incoming_msg, reply_text, "show_current_list", True)
@@ -5732,7 +5712,11 @@ def process_single_action(ai_response, phone_number, incoming_msg):
                 header = f"Your{filter_desc} lists:" if list_filter else "Your lists:"
                 reply_text = header + "\n\n" + "\n".join(list_lines) + "\n\nReply with a number to see that list."
                 # Track that user is viewing list of lists for number selection
-                create_or_update_user(phone_number, last_active_list="__LISTS__")
+                create_or_update_user(
+                    phone_number,
+                    last_active_list="__LISTS__",
+                    pending_reminder_delete=None,
+                )
             else:
                 if list_filter:
                     reply_text = f"You don't have any {list_filter} lists. Try 'Create a {list_filter} list'!"

--- a/routes/handlers/lists.py
+++ b/routes/handlers/lists.py
@@ -4,7 +4,8 @@ Handles list-related AI actions: create, add items, view, complete, delete
 """
 
 import json
-from typing import Any
+import re
+from typing import Any, Optional
 
 from config import logger, ENVIRONMENT
 from models.user import create_or_update_user, get_last_active_list
@@ -1042,6 +1043,66 @@ def handle_decline_share(phone_number: str, incoming_msg: str) -> str:
 # =====================================================
 # SHARED LIST DISPLAY HELPERS
 # =====================================================
+
+
+# SHOW LISTS picker: "3", "Show 3", "show 3", "#3", "show #3", "show list 3"
+_LIST_PICKER_RE = re.compile(
+    r'^(?:(?:show|open|view)\s+(?:list\s+)?)?#?(\d+)$',
+    re.IGNORECASE,
+)
+
+
+def parse_list_picker_reply(incoming_msg: str, *, allow_bare_number: bool = True) -> Optional[int]:
+    """Parse a SHOW LISTS number-picker reply.
+
+    Matches '3', 'Show 3', 'show 3', '#3' (and close variants). Returns a 1-based
+    index, or None if the message is not a picker reply.
+    """
+    msg = incoming_msg.strip()
+    if not allow_bare_number and msg.isdigit():
+        return None
+    match = _LIST_PICKER_RE.match(msg)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def format_numbered_list_reply(phone_number: str, list_num: int) -> Optional[str]:
+    """Open the Nth list in SHOW LISTS order (owned, then shared).
+
+    Sets last_active_list to the selected list and clears pending_reminder_delete
+    so a leftover delete confirmation cannot hijack the next turn.
+    Returns None if list_num is out of range.
+    """
+    all_lists = get_all_lists_with_shared(phone_number)
+    if not all_lists or not (1 <= list_num <= len(all_lists)):
+        return None
+
+    selected = all_lists[list_num - 1]
+    list_id = selected['list_id']
+    list_name = selected['list_name']
+    is_shared = selected['is_shared']
+    prefix = "[Shared] " if is_shared else ""
+
+    create_or_update_user(
+        phone_number,
+        last_active_list=list_name,
+        pending_reminder_delete=None,
+        pending_memory_delete=None,
+    )
+
+    items = get_list_items(list_id)
+    if items:
+        item_lines = []
+        for i, (_item_id, item_text, completed) in enumerate(items, 1):
+            if completed:
+                item_lines.append(f"{i}. [x] {item_text}")
+            else:
+                item_lines.append(f"{i}. {item_text}")
+        return f"{prefix}{list_name}:\n\n" + "\n".join(item_lines)
+    if is_shared:
+        return f"{prefix}{list_name} is empty."
+    return f"Your {list_name} is empty."
 
 
 def get_all_lists_with_shared(phone_number: str) -> list[dict]:

--- a/routes/handlers/pending_states.py
+++ b/routes/handlers/pending_states.py
@@ -154,6 +154,9 @@ def handle_pending_delete(
             logger.error(f"Error parsing pending delete data: {e}")
             create_or_update_user(phone_number, pending_reminder_delete=None)
 
+    else:
+        create_or_update_user(phone_number, pending_reminder_delete=None)
+
     return (False, None)
 
 
@@ -194,6 +197,9 @@ def handle_pending_memory_delete(
                 create_or_update_user(phone_number, pending_memory_delete=None)
                 log_interaction(phone_number, incoming_msg, "Delete cancelled", "delete_memory_cancelled", True)
                 return (True, "Cancelled. Your memory is safe!")
+            else:
+                create_or_update_user(phone_number, pending_memory_delete=None)
+                return (False, None)
 
         # Handle number selection from multiple memories
         elif memory_data.get('options') and incoming_msg.strip().isdigit():
@@ -219,6 +225,10 @@ def handle_pending_memory_delete(
                 return (True, reply_msg)
             else:
                 return (True, f"Please reply with a number between 1 and {len(memory_options)}")
+
+        else:
+            create_or_update_user(phone_number, pending_memory_delete=None)
+            return (False, None)
 
     except (json.JSONDecodeError, KeyError) as e:
         logger.error(f"Error parsing pending memory delete data: {e}")

--- a/tests/test_context_switching.py
+++ b/tests/test_context_switching.py
@@ -120,7 +120,7 @@ class TestConfirmationInterrupts:
     """Test context switches during confirmation prompts."""
 
     async def test_delete_reminder_confirmation_interrupted(self, simulator, onboarded_user, ai_mock):
-        """Delete reminder confirmation pending -> user adds to grocery list -> system reminds about delete."""
+        """Delete reminder confirmation pending -> new intent proceeds, pending cleared."""
         phone = onboarded_user["phone"]
 
         # Create a reminder first
@@ -138,15 +138,22 @@ class TestConfirmationInterrupts:
         })
         result = await simulator.send_message(phone, "delete my mom reminder")
 
-        # If confirmation is pending, try to switch context
+        # If confirmation is pending, a new request should not stay in the confirm loop
         if "yes" in result["output"].lower() or "confirm" in result["output"].lower() or "delete" in result["output"].lower():
+            ai_mock.set_response("add bread to shopping list", {
+                "action": "add_to_list",
+                "list_name": "shopping list",
+                "items": ["bread"],
+            })
             result = await simulator.send_message(phone, "add bread to shopping list")
             output_lower = result["output"].lower()
-            # Should remind about delete confirmation
-            assert "still need" in output_lower or "delete" in output_lower or "yes" in output_lower or "no" in output_lower or "call mom" in output_lower
+            assert "still need" not in output_lower
+            assert "reply yes" not in output_lower
+            from models.user import get_pending_reminder_delete
+            assert get_pending_reminder_delete(phone) is None
 
     async def test_delete_memory_confirmation_interrupted(self, simulator, onboarded_user, ai_mock):
-        """Delete memory confirmation pending -> user creates reminder -> system reminds about delete."""
+        """Delete memory confirmation pending -> new intent proceeds, pending cleared."""
         phone = onboarded_user["phone"]
 
         # Store a memory
@@ -161,10 +168,16 @@ class TestConfirmationInterrupts:
         result = await simulator.send_message(phone, "delete my wifi password memory")
 
         if "yes" in result["output"].lower() or "confirm" in result["output"].lower():
+            ai_mock.set_response("what time is it in london", {
+                "action": "chitchat",
+                "response": "I don't track timezones other than yours."
+            })
             result = await simulator.send_message(phone, "what time is it in london")
             output_lower = result["output"].lower()
-            # Should remind about memory delete
-            assert "still need" in output_lower or "delete" in output_lower or "memory" in output_lower or "yes" in output_lower
+            assert "still need" not in output_lower
+            assert "reply yes" not in output_lower
+            from models.user import get_pending_memory_delete
+            assert get_pending_memory_delete(phone) is None
 
     async def test_low_confidence_confirmation_interrupted(self, simulator, onboarded_user, ai_mock):
         """Low confidence reminder confirmation -> user ignores, new request -> system reminds about confirmation."""
@@ -212,11 +225,15 @@ class TestSelectionInterrupts:
         result = await simulator.send_message(phone, "delete john's phone")
 
         if "1" in result["output"] and "2" in result["output"]:
-            # User ignores and asks something else
+            # User ignores and asks something else — new intent should proceed
+            ai_mock.set_response("tell me a story", {
+                "action": "chitchat",
+                "response": "Once upon a time there was a reminder."
+            })
             result = await simulator.send_message(phone, "tell me a story")
             output_lower = result["output"].lower()
-            # Should remind to select
-            assert "still need" in output_lower or "select" in output_lower or "which" in output_lower or "number" in output_lower
+            assert "still need" not in output_lower
+            assert "reply yes" not in output_lower
 
     async def test_list_number_selection_interrupted(self, simulator, onboarded_user, ai_mock):
         """List number selection pending -> user asks for reminders -> system reminds to select."""

--- a/tests/test_list_picker.py
+++ b/tests/test_list_picker.py
@@ -3,7 +3,7 @@ Tests for SHOW LISTS number-picker replies.
 
 Production bug: after SHOW LISTS ("Reply with a number to see that list"),
 the user texted "Show 3" expecting list #3 and instead got a reminder-delete
-confirmation. The picker only matched /^\d+$/, so "Show 3" fell through to
+confirmation. The picker only matched a bare digit, so "Show 3" fell through to
 the AI which emitted delete_reminder for scheduled reminder #3.
 """
 

--- a/tests/test_list_picker.py
+++ b/tests/test_list_picker.py
@@ -1,0 +1,396 @@
+"""
+Tests for SHOW LISTS number-picker replies.
+
+Production bug: after SHOW LISTS ("Reply with a number to see that list"),
+the user texted "Show 3" expecting list #3 and instead got a reminder-delete
+confirmation. The picker only matched /^\d+$/, so "Show 3" fell through to
+the AI which emitted delete_reminder for scheduled reminder #3.
+"""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+from models.list_model import create_list, add_list_item, get_list_items
+from models.reminder import save_reminder, get_user_reminders
+from models.memory import save_memory, get_memories
+from models.user import (
+    create_or_update_user,
+    get_pending_reminder_delete,
+    get_pending_memory_delete,
+)
+from routes.handlers.lists import parse_list_picker_reply, get_all_lists_with_shared
+
+
+CAMPING_ITEMS = [
+    "tent",
+    "sleeping bag",
+    "camp stove",
+    "lantern",
+    "cooler",
+]
+
+
+def _seed_three_lists_camping_is_third(phone):
+    """Create 3 lists so camping is row 3 in SHOW LISTS order.
+
+    get_lists() is ORDER BY created_at DESC (newest first), so create
+    camping first (oldest → last → #3).
+    """
+    camping_id = create_list(phone, "camping list")
+    create_list(phone, "Home Depot list")
+    create_list(phone, "Vancouver expense list")
+    for item in CAMPING_ITEMS:
+        add_list_item(camping_id, phone, item)
+
+    all_lists = get_all_lists_with_shared(phone)
+    names = [lst["list_name"] for lst in all_lists]
+    assert names[2] == "camping list", f"Expected camping list at #3, got {names}"
+    return camping_id
+
+
+def _seed_succeeded_reminder(phone):
+    save_reminder(
+        phone,
+        "You've succeeded.",
+        (datetime.utcnow() + timedelta(hours=2)).strftime("%Y-%m-%d %H:%M:%S"),
+    )
+    reminders = get_user_reminders(phone)
+    assert reminders, "Expected a pending reminder for the hijack fixture"
+    return reminders[0]
+
+
+def _assert_not_delete_loop(output):
+    lower = output.lower()
+    assert "still need" not in lower, f"Re-prompted pending delete: {output}"
+    assert "reply yes" not in lower, f"Asked to confirm a delete: {output}"
+    assert "reply 1 to confirm" not in lower, f"Asked to confirm a delete: {output}"
+
+
+def _assert_camping_list_not_delete(output):
+    _assert_not_delete_loop(output)
+    lower = output.lower()
+    assert "delete reminder" not in lower, f"Opened delete-reminder instead of list: {output}"
+    assert "camping list" in lower, f"Expected camping list contents, got: {output}"
+    for item in CAMPING_ITEMS:
+        assert item in lower, f"Expected camping item '{item}' in: {output}"
+
+
+def _assert_lists_menu_not_delete(output):
+    _assert_not_delete_loop(output)
+    lower = output.lower()
+    assert "camping list" in lower, f"Expected lists menu, got: {output}"
+    assert "reply with a number" in lower, f"Expected list picker footer, got: {output}"
+
+
+def _assert_reminder_kept(phone):
+    texts = [r[2] for r in get_user_reminders(phone)]
+    assert any("succeeded" in (t or "").lower() for t in texts), texts
+
+
+def _assert_tent_kept(camping_id):
+    texts = [item[1].lower() for item in get_list_items(camping_id)]
+    assert "tent" in texts, texts
+
+
+def _arm_reminder_delete(phone):
+    reminder = _seed_succeeded_reminder(phone)
+    create_or_update_user(phone, last_active_list=None, pending_reminder_delete=json.dumps({
+        "awaiting_confirmation": True,
+        "type": "reminder",
+        "id": reminder[0],
+        "text": "You've succeeded.",
+    }))
+    return reminder
+
+
+def _arm_list_item_delete(phone, camping_id):
+    create_or_update_user(phone, last_active_list=None, pending_reminder_delete=json.dumps({
+        "awaiting_confirmation": True,
+        "type": "list_item",
+        "list_name": "camping list",
+        "list_id": camping_id,
+        "is_shared": False,
+        "text": "tent",
+    }))
+
+
+def _arm_memory_delete(phone):
+    save_memory(phone, "wifi password is Home2024", {})
+    memories = get_memories(phone)
+    assert memories, "Expected a stored memory"
+    create_or_update_user(phone, last_active_list=None, pending_memory_delete=json.dumps({
+        "awaiting_confirmation": True,
+        "id": memories[0][0],
+        "text": memories[0][1],
+    }))
+    return memories[0]
+
+
+class TestParseListPickerReply:
+    """Unit tests for the SHOW LISTS picker regex."""
+
+    def test_bare_number(self):
+        assert parse_list_picker_reply("3") == 3
+        assert parse_list_picker_reply(" 12 ") == 12
+
+    def test_show_n_variants(self):
+        assert parse_list_picker_reply("Show 3") == 3
+        assert parse_list_picker_reply("show 3") == 3
+        assert parse_list_picker_reply("#3") == 3
+        assert parse_list_picker_reply("show #3") == 3
+        assert parse_list_picker_reply("show list 3") == 3
+
+    def test_prefixed_only_skips_bare_digit(self):
+        assert parse_list_picker_reply("3", allow_bare_number=False) is None
+        assert parse_list_picker_reply("Show 3", allow_bare_number=False) == 3
+        assert parse_list_picker_reply("#3", allow_bare_number=False) == 3
+
+    def test_non_picker_messages(self):
+        assert parse_list_picker_reply("Show lists") is None
+        assert parse_list_picker_reply("SHOW LISTS") is None
+        assert parse_list_picker_reply("delete 3") is None
+        assert parse_list_picker_reply("show grocery list") is None
+        assert parse_list_picker_reply("remind me at 3") is None
+
+
+class TestShowListsThenShowN:
+    """Reproduce the live SMS sequence: Show lists → Show 3."""
+
+    @pytest.mark.asyncio
+    async def test_show_lists_then_show_3_opens_camping_list(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        _seed_succeeded_reminder(phone)
+
+        # If "Show 3" falls through to AI, this is the production failure mode.
+        ai_mock.set_response("show 3", {
+            "action": "delete_reminder",
+            "search_term": "You've succeeded.",
+        })
+
+        listed = await simulator.send_message(phone, "Show lists")
+        assert "camping list" in listed["output"].lower()
+        assert "reply with a number" in listed["output"].lower()
+
+        result = await simulator.send_message(phone, "Show 3")
+        _assert_camping_list_not_delete(result["output"])
+
+    @pytest.mark.asyncio
+    async def test_show_lists_then_lowercase_show_3(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        _seed_succeeded_reminder(phone)
+        ai_mock.set_response("show 3", {
+            "action": "delete_reminder",
+            "search_term": "You've succeeded.",
+        })
+
+        await simulator.send_message(phone, "Show lists")
+        result = await simulator.send_message(phone, "show 3")
+        _assert_camping_list_not_delete(result["output"])
+
+    @pytest.mark.asyncio
+    async def test_show_lists_then_hash_3(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        _seed_succeeded_reminder(phone)
+        ai_mock.set_response("#3", {
+            "action": "delete_reminder",
+            "search_term": "You've succeeded.",
+        })
+
+        await simulator.send_message(phone, "Show lists")
+        result = await simulator.send_message(phone, "#3")
+        _assert_camping_list_not_delete(result["output"])
+
+    @pytest.mark.asyncio
+    async def test_show_lists_then_bare_3(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        _seed_succeeded_reminder(phone)
+        ai_mock.set_response("3", {
+            "action": "delete_reminder",
+            "search_term": "You've succeeded.",
+        })
+
+        await simulator.send_message(phone, "Show lists")
+        result = await simulator.send_message(phone, "3")
+        _assert_camping_list_not_delete(result["output"])
+
+
+class TestStalePendingDeleteDoesNotHijackPicker:
+    """Leftover pending_reminder_delete must not steal Show N / list-picker replies."""
+
+    @pytest.mark.asyncio
+    async def test_stale_awaiting_confirmation_then_show_3(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        reminder = _seed_succeeded_reminder(phone)
+        create_or_update_user(phone, pending_reminder_delete=json.dumps({
+            "awaiting_confirmation": True,
+            "type": "reminder",
+            "id": reminder[0],
+            "text": "You've succeeded.",
+        }))
+        ai_mock.set_response("show 3", {
+            "action": "delete_reminder",
+            "search_term": "You've succeeded.",
+        })
+
+        await simulator.send_message(phone, "Show lists")
+        assert get_pending_reminder_delete(phone) is None
+
+        result = await simulator.send_message(phone, "Show 3")
+        _assert_camping_list_not_delete(result["output"])
+
+    @pytest.mark.asyncio
+    async def test_stale_delete_options_then_bare_3(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        reminder = _seed_succeeded_reminder(phone)
+        create_or_update_user(phone, pending_reminder_delete=json.dumps([{
+            "type": "reminder",
+            "id": reminder[0],
+            "text": "You've succeeded.",
+        }]))
+        ai_mock.set_response("3", {
+            "action": "delete_reminder",
+            "search_term": "You've succeeded.",
+        })
+
+        await simulator.send_message(phone, "Show lists")
+        assert get_pending_reminder_delete(phone) is None
+
+        result = await simulator.send_message(phone, "3")
+        _assert_camping_list_not_delete(result["output"])
+
+    @pytest.mark.asyncio
+    async def test_show_3_wins_over_pending_still_set(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        """Even if pending_reminder_delete is still set, Show 3 opens the list."""
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        reminder = _seed_succeeded_reminder(phone)
+        ai_mock.set_response("show 3", {
+            "action": "delete_reminder",
+            "search_term": "You've succeeded.",
+        })
+
+        await simulator.send_message(phone, "Show lists")
+        create_or_update_user(phone, pending_reminder_delete=json.dumps({
+            "awaiting_confirmation": True,
+            "type": "reminder",
+            "id": reminder[0],
+            "text": "You've succeeded.",
+        }))
+
+        result = await simulator.send_message(phone, "Show 3")
+        _assert_camping_list_not_delete(result["output"])
+        assert get_pending_reminder_delete(phone) is None
+
+
+class TestPendingDeleteClearsOnNewIntent:
+    """Once a delete is pending, a new intent must not stay in the confirm loop."""
+
+    @pytest.mark.asyncio
+    async def test_pending_reminder_delete_then_show_3(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        _arm_reminder_delete(phone)
+        ai_mock.set_response("show 3", {
+            "action": "delete_reminder",
+            "search_term": "You've succeeded.",
+        })
+
+        result = await simulator.send_message(phone, "Show 3")
+        _assert_camping_list_not_delete(result["output"])
+        assert get_pending_reminder_delete(phone) is None
+        _assert_reminder_kept(phone)
+
+    @pytest.mark.asyncio
+    async def test_pending_reminder_delete_then_show_lists(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        _arm_reminder_delete(phone)
+
+        result = await simulator.send_message(phone, "Show lists")
+        _assert_lists_menu_not_delete(result["output"])
+        assert get_pending_reminder_delete(phone) is None
+        _assert_reminder_kept(phone)
+
+    @pytest.mark.asyncio
+    async def test_pending_list_item_delete_then_show_3(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        camping_id = _seed_three_lists_camping_is_third(phone)
+        _arm_list_item_delete(phone, camping_id)
+        ai_mock.set_response("show 3", {
+            "action": "delete_item",
+            "list_name": "camping list",
+            "item_text": "tent",
+        })
+
+        result = await simulator.send_message(phone, "Show 3")
+        _assert_camping_list_not_delete(result["output"])
+        assert get_pending_reminder_delete(phone) is None
+        _assert_tent_kept(camping_id)
+
+    @pytest.mark.asyncio
+    async def test_pending_list_item_delete_then_show_lists(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        camping_id = _seed_three_lists_camping_is_third(phone)
+        _arm_list_item_delete(phone, camping_id)
+
+        result = await simulator.send_message(phone, "Show lists")
+        _assert_lists_menu_not_delete(result["output"])
+        assert get_pending_reminder_delete(phone) is None
+        _assert_tent_kept(camping_id)
+
+    @pytest.mark.asyncio
+    async def test_pending_memory_delete_then_show_3(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        _arm_memory_delete(phone)
+        ai_mock.set_response("show 3", {
+            "action": "delete_memory",
+            "search_term": "wifi",
+        })
+
+        result = await simulator.send_message(phone, "Show 3")
+        _assert_camping_list_not_delete(result["output"])
+        assert get_pending_memory_delete(phone) is None
+        assert any("wifi" in (m[1] or "").lower() for m in get_memories(phone))
+
+    @pytest.mark.asyncio
+    async def test_pending_memory_delete_then_show_lists(
+        self, simulator, onboarded_user, ai_mock
+    ):
+        phone = onboarded_user["phone"]
+        _seed_three_lists_camping_is_third(phone)
+        _arm_memory_delete(phone)
+
+        result = await simulator.send_message(phone, "Show lists")
+        _assert_lists_menu_not_delete(result["output"])
+        assert get_pending_memory_delete(phone) is None
+        assert any("wifi" in (m[1] or "").lower() for m in get_memories(phone))
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After `SHOW LISTS` (`Reply with a number to see that list`), the user texts `Show 3` expecting list #3. Production instead asked to delete a reminder (`Delete reminder: You've succeeded.? Reply YES to confirm`).

Two related traps:

1. **List picker only matched a bare digit.** `Show 3` / `#3` missed the handler and fell through to the AI, which treated `3` as scheduled reminder #3 and emitted `delete_reminder`.
2. **Pending delete confirm loop.** Once a reminder, list-item, or memory delete was pending, anything other than YES/CANCEL/a delete index was re-prompted (`I still need your confirmation`) instead of handling the new request. Memory deletes never fell through at all.

## Fix

- Parse `3`, `Show 3`, `show 3`, `#3` as a list-picker reply. Prefixed forms open that list (owned + shared order) and clear leftover pending deletes. Bare numbers still mean “pick N” from an active delete/show menu.
- `SHOW LISTS` / `MY LISTS` clears `pending_reminder_delete` and `pending_memory_delete`.
- Unrelated intents (Show N, Show lists, new reminder, etc.) clear a pending delete and proceed. YES/CANCEL still confirm/cancel. Deletes are not executed on unrelated messages.
- Delete confirm/select is no longer a trapping pending-state reminder.

## Tests

- `Show lists` → `Show 3` / `show 3` / `#3` / `3` returns camping list contents, not a delete confirmation (AI mock would emit `delete_reminder` if routing leaked).
- Pending reminder-delete, list-item delete, and memory delete, then `Show 3` / `Show lists`: pending cleared, list shown, nothing deleted.
- Context-switching tests updated so a new intent after a delete confirm proceeds instead of re-prompting.

## Diagnosis (file evidence)

- `main.py` list-number handler previously required `incoming_msg.strip().isdigit()` (now `parse_list_picker_reply`).
- `main.py` pending-state reminder used to re-prompt delete confirmations for any non YES/NO/digit message.
- Memory pending-delete handler had no fallthrough for a new intent.

## Test run

`tests/test_list_picker.py` (17) and `tests/test_delete_items.py` (11) pass. Delete-interrupt cases in `test_context_switching.py` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a6b167d-6875-444e-8b4f-38918623cf6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a6b167d-6875-444e-8b4f-38918623cf6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

