### PR TITLE
NFL morning-after score beta v1 (plumbing, no live invites)

### DIFF
--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -950,6 +950,9 @@ class SportsScoreDryRunRequest(BaseModel):
     phone: str
     fake_game: bool = True
     scoreboard_date: Optional[str] = None  # YYYYMMDD for a real ESPN preseason date
+    send_invite: bool = False
+    full_loop: bool = False  # invite + Bengals/Lions opt-in + staggered asks
+    teams: Optional[list] = None  # default CIN, DET when full_loop
 
 
 @router.post("/admin/sports-scores/dry-run")
@@ -959,22 +962,24 @@ async def sports_score_dry_run(
 ):
     """Trigger a fake/preseason morning-after ask for one founder phone.
 
-    Does not send weekly or dormant invites. Phone must be on the founder
-    allowlist (FOUNDER_SURVEY_EXCLUDE_PHONES or nfl_score_dry_run_phones).
-    User must already be opted in via YES + team.
+    Does not send weekly or dormant invites to production. Phone must be on the
+    founder allowlist (FOUNDER_SURVEY_EXCLUDE_PHONES or nfl_score_dry_run_phones).
+
+    full_loop=true: send locked invite copy, opt that phone into Bengals + Lions,
+    then fire canned/ESPN asks staggered by a few minutes.
     """
     from services.sports_score_service import process_morning_asks, is_dry_run_allowed
-    from models.sports import get_optin
+    from models.sports import get_optin, list_optins
 
     phone = (request.phone or "").strip()
     if not phone.startswith("+"):
         raise HTTPException(status_code=400, detail="phone must be E.164 (e.g. +18593935374)")
     if not is_dry_run_allowed(phone):
         raise HTTPException(status_code=403, detail="phone is not on the founder dry-run allowlist")
-    if not get_optin(phone):
+    if not request.full_loop and not request.send_invite and not get_optin(phone):
         raise HTTPException(
             status_code=400,
-            detail="that phone is not opted in — text YES + team first (e.g. YES Bengals)",
+            detail="that phone is not opted in — text YES + team first, or pass full_loop=true",
         )
 
     parsed_date = None
@@ -988,8 +993,18 @@ async def sports_score_dry_run(
         dry_run_phone=phone,
         fake_game=request.fake_game,
         scoreboard_date=parsed_date,
+        send_invite=request.send_invite or request.full_loop,
+        full_loop=request.full_loop,
+        teams=request.teams,
     )
-    return JSONResponse(content={"ok": True, "result": result})
+    return JSONResponse(content={
+        "ok": True,
+        "result": result,
+        "optins": [
+            {"team": o["team_abbr"], "short": o["team_short"]}
+            for o in list_optins(phone)
+        ],
+    })
 
 
 @router.get("/admin/founder-survey/recipients-preview")

--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -946,6 +946,52 @@ def _founder_survey_recipients(c):
     return recipients
 
 
+class SportsScoreDryRunRequest(BaseModel):
+    phone: str
+    fake_game: bool = True
+    scoreboard_date: Optional[str] = None  # YYYYMMDD for a real ESPN preseason date
+
+
+@router.post("/admin/sports-scores/dry-run")
+async def sports_score_dry_run(
+    request: SportsScoreDryRunRequest,
+    admin: str = Depends(verify_admin),
+):
+    """Trigger a fake/preseason morning-after ask for one founder phone.
+
+    Does not send weekly or dormant invites. Phone must be on the founder
+    allowlist (FOUNDER_SURVEY_EXCLUDE_PHONES or nfl_score_dry_run_phones).
+    User must already be opted in via YES + team.
+    """
+    from services.sports_score_service import process_morning_asks, is_dry_run_allowed
+    from models.sports import get_optin
+
+    phone = (request.phone or "").strip()
+    if not phone.startswith("+"):
+        raise HTTPException(status_code=400, detail="phone must be E.164 (e.g. +18593935374)")
+    if not is_dry_run_allowed(phone):
+        raise HTTPException(status_code=403, detail="phone is not on the founder dry-run allowlist")
+    if not get_optin(phone):
+        raise HTTPException(
+            status_code=400,
+            detail="that phone is not opted in — text YES + team first (e.g. YES Bengals)",
+        )
+
+    parsed_date = None
+    if request.scoreboard_date:
+        try:
+            parsed_date = datetime.strptime(request.scoreboard_date, "%Y%m%d").date()
+        except ValueError:
+            raise HTTPException(status_code=400, detail="scoreboard_date must be YYYYMMDD")
+
+    result = process_morning_asks(
+        dry_run_phone=phone,
+        fake_game=request.fake_game,
+        scoreboard_date=parsed_date,
+    )
+    return JSONResponse(content={"ok": True, "result": result})
+
+
 @router.get("/admin/founder-survey/recipients-preview")
 async def founder_survey_preview(admin: str = Depends(verify_admin)):
     """Preview who would receive the founder survey (no sends)."""

--- a/celery_config.py
+++ b/celery_config.py
@@ -153,6 +153,16 @@ beat_schedule = {
             "expires": 3500,
         },
     },
+    # NFL morning-after score asks — 9-10 AM local, after other lifecycle
+    # tasks so Day 7/13/14 and win-back win the anti-bunch check.
+    # Invites are NOT scheduled here. Do not add an invite beat entry.
+    "send-nfl-score-asks": {
+        "task": "tasks.reminder_tasks.send_nfl_score_asks",
+        "schedule": crontab(minute=35),  # Every hour, at :35
+        "options": {
+            "expires": 3500,
+        },
+    },
 
     # ===========================================
     # AI ANALYTICS SUMMARY

--- a/database.py
+++ b/database.py
@@ -729,13 +729,14 @@ def init_db():
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS sports_invite_sent_at TIMESTAMP",
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS sports_invite_cohort TEXT",
             """CREATE TABLE IF NOT EXISTS sports_optins (
-                phone_number TEXT PRIMARY KEY,
+                phone_number TEXT NOT NULL,
                 team_abbr TEXT NOT NULL,
                 team_short TEXT NOT NULL,
                 cohort TEXT NOT NULL CHECK (cohort IN ('weekly', 'dormant')),
                 opted_in_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 ignore_streak INTEGER NOT NULL DEFAULT 0,
                 last_ask_date DATE,
+                last_ask_at TIMESTAMP,
                 last_ask_game_id TEXT,
                 last_ask_replied BOOLEAN NOT NULL DEFAULT FALSE,
                 pending_score_payload JSONB,
@@ -744,8 +745,10 @@ def init_db():
                 paused_at TIMESTAMP,
                 stopped_silently BOOLEAN NOT NULL DEFAULT FALSE,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (phone_number, team_abbr)
             )""",
+            "ALTER TABLE sports_optins ADD COLUMN IF NOT EXISTS last_ask_at TIMESTAMP",
             """CREATE TABLE IF NOT EXISTS sports_score_events (
                 id SERIAL PRIMARY KEY,
                 phone_number TEXT NOT NULL,
@@ -810,6 +813,26 @@ def init_db():
                     pass  # Expected — index already exists
                 else:
                     logger.error(f"Unexpected index migration error: {index_migration[:80]}... — {e}")
+
+        # Founder dual dry-run: one phone can have two teams. Production stays
+        # one-team via application logic. Older DBs had phone_number as PK.
+        try:
+            c.execute(
+                """
+                SELECT a.attname
+                FROM pg_index i
+                JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+                WHERE i.indrelid = 'sports_optins'::regclass AND i.indisprimary
+                ORDER BY a.attnum
+                """
+            )
+            pk_cols = [row[0] for row in c.fetchall()]
+            if pk_cols == ['phone_number']:
+                c.execute("ALTER TABLE sports_optins DROP CONSTRAINT sports_optins_pkey")
+                c.execute("ALTER TABLE sports_optins ADD PRIMARY KEY (phone_number, team_abbr)")
+                logger.info("Migrated sports_optins primary key to (phone_number, team_abbr)")
+        except Exception as e:
+            logger.error(f"sports_optins PK migration skipped/failed: {e}")
 
         conn.commit()
         return_db_connection(conn)

--- a/database.py
+++ b/database.py
@@ -724,6 +724,36 @@ def init_db():
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS lifecycle_messages_opted_out BOOLEAN DEFAULT FALSE",
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS lifecycle_messages_opted_out_at TIMESTAMP",
             "UPDATE users SET lifecycle_messages_opted_out = FALSE WHERE lifecycle_messages_opted_out IS NULL",
+            # NFL morning-after score beta (closed beta). Invite sending is NOT
+            # scheduled — these columns only record a send if a later PR does it.
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS sports_invite_sent_at TIMESTAMP",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS sports_invite_cohort TEXT",
+            """CREATE TABLE IF NOT EXISTS sports_optins (
+                phone_number TEXT PRIMARY KEY,
+                team_abbr TEXT NOT NULL,
+                team_short TEXT NOT NULL,
+                cohort TEXT NOT NULL CHECK (cohort IN ('weekly', 'dormant')),
+                opted_in_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                ignore_streak INTEGER NOT NULL DEFAULT 0,
+                last_ask_date DATE,
+                last_ask_game_id TEXT,
+                last_ask_replied BOOLEAN NOT NULL DEFAULT FALSE,
+                pending_score_payload JSONB,
+                beta_started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                pause_at TIMESTAMP,
+                paused_at TIMESTAMP,
+                stopped_silently BOOLEAN NOT NULL DEFAULT FALSE,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )""",
+            """CREATE TABLE IF NOT EXISTS sports_score_events (
+                id SERIAL PRIMARY KEY,
+                phone_number TEXT NOT NULL,
+                cohort TEXT NOT NULL CHECK (cohort IN ('weekly', 'dormant')),
+                event_type TEXT NOT NULL,
+                metadata JSONB,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )""",
         ]
 
         # Create indexes on phone_hash columns for efficient lookups
@@ -756,6 +786,9 @@ def init_db():
             "CREATE INDEX IF NOT EXISTS idx_list_shares_shared_with ON list_shares(shared_with_phone)",
             "CREATE INDEX IF NOT EXISTS idx_list_shares_list_id ON list_shares(list_id)",
             "CREATE INDEX IF NOT EXISTS idx_list_shares_owner ON list_shares(owner_phone)",
+            "CREATE INDEX IF NOT EXISTS idx_sports_score_events_cohort_type ON sports_score_events(cohort, event_type, created_at)",
+            "CREATE INDEX IF NOT EXISTS idx_sports_score_events_phone ON sports_score_events(phone_number)",
+            "CREATE INDEX IF NOT EXISTS idx_sports_optins_stopped ON sports_optins(stopped_silently) WHERE stopped_silently = FALSE",
         ]
 
         for migration in migrations:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,13 +4,13 @@
 
 Closed-beta plumbing for NFL scores the morning after a user's team plays. **Invites are not sent by this change.** Users who text `YES + team` opt in; the 9–10 AM local Celery job (`send_nfl_score_asks`, :35 past the hour) asks; `SCORE` returns only the final (`Bengals 27, Chiefs 24`). ESPN public scoreboard, finals only.
 
-**Schema:** `sports_optins` (team, cohort weekly|dormant, ignore streak, last ask, pause, silent stop) and `sports_score_events` (cohort-tagged: `score_ask`, `score_reply`, `score_ignore`, `upgrade_to_keep`, `sports_yes`). Invite tracking columns on `users` for a later send PR; inactivity KEEP/CLEAR is skipped the same week if an invite was recorded.
+**Schema:** `sports_optins` one row per `(phone, team)` — production stays one team in the service layer. Founder dry-run phones (`FOUNDER_SURVEY_EXCLUDE_PHONES` + `nfl_score_dry_run_phones`) may hold two (Bengals + Lions). Events stay cohort-tagged (`score_ask`, `score_reply`, `score_ignore`, `upgrade_to_keep`, `sports_yes`). Invite tracking columns on `users` for a later send PR; inactivity KEEP/CLEAR is skipped the same week if an invite was recorded.
 
-**Dry-run (founder phones only, no invite blast):**
+**Founder dual dry-run (same allowlist, not a production blast):**
 ```
-celery -A celery_app call tasks.reminder_tasks.send_nfl_score_asks --kwargs='{"dry_run_phone":"+18593935374","fake_game":true}'
+celery -A celery_app call tasks.reminder_tasks.send_nfl_score_asks --kwargs='{"dry_run_phone":"+18593935374","fake_game":true,"full_loop":true}'
 ```
-or `POST /admin/sports-scores/dry-run` with `{"phone":"+18593935374","fake_game":true}` after texting `YES Bengals`. Allowlist: `FOUNDER_SURVEY_EXCLUDE_PHONES` plus setting `nfl_score_dry_run_phones`. Kill switch: `nfl_score_asks_enabled` (default true).
+or `POST /admin/sports-scores/dry-run` with `{"phone":"+18593935374","fake_game":true,"full_loop":true}`. Sends locked weekly invite copy to that phone only, opts into Bengals + Lions, then spoiler-free asks staggered by 3 minutes. Optional `scoreboard_date=YYYYMMDD` uses ESPN finals instead of canned. `YES Bengals` then `YES Lions` also keeps both on a founder phone; a normal user still replaces. SCORE one / ignore the other is the intended dual path.
 
 **Files:** `services/sports_score_service.py`, `services/nfl_teams.py`, `services/espn_nfl.py`, `models/sports.py`, `tasks/reminder_tasks.py`, `celery_config.py`, `main.py`, `admin_dashboard.py`, `database.py`, `tests/test_nfl_scores.py`.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Changelog — Recent Improvements & Bug Fixes
 
+## NFL Morning-After Score Beta v1 (Aug 2026)
+
+Closed-beta plumbing for NFL scores the morning after a user's team plays. **Invites are not sent by this change.** Users who text `YES + team` opt in; the 9–10 AM local Celery job (`send_nfl_score_asks`, :35 past the hour) asks; `SCORE` returns only the final (`Bengals 27, Chiefs 24`). ESPN public scoreboard, finals only.
+
+**Schema:** `sports_optins` (team, cohort weekly|dormant, ignore streak, last ask, pause, silent stop) and `sports_score_events` (cohort-tagged: `score_ask`, `score_reply`, `score_ignore`, `upgrade_to_keep`, `sports_yes`). Invite tracking columns on `users` for a later send PR; inactivity KEEP/CLEAR is skipped the same week if an invite was recorded.
+
+**Dry-run (founder phones only, no invite blast):**
+```
+celery -A celery_app call tasks.reminder_tasks.send_nfl_score_asks --kwargs='{"dry_run_phone":"+18593935374","fake_game":true}'
+```
+or `POST /admin/sports-scores/dry-run` with `{"phone":"+18593935374","fake_game":true}` after texting `YES Bengals`. Allowlist: `FOUNDER_SURVEY_EXCLUDE_PHONES` plus setting `nfl_score_dry_run_phones`. Kill switch: `nfl_score_asks_enabled` (default true).
+
+**Files:** `services/sports_score_service.py`, `services/nfl_teams.py`, `services/espn_nfl.py`, `models/sports.py`, `tasks/reminder_tasks.py`, `celery_config.py`, `main.py`, `admin_dashboard.py`, `database.py`, `tests/test_nfl_scores.py`.
+
 ## Email Reminder Fallback (Aug 2026)
 Built during the Aug 2026 Twilio account suspension (suspicious-activity flag; every outbound SMS API call failed while inbound stopped reaching the webhook entirely). Reminders were never at risk of being lost — `send_single_reminder` only marks `sent = TRUE` after a successful send, so they queue and retry — but users with due reminders heard nothing.
 

--- a/main.py
+++ b/main.py
@@ -845,7 +845,7 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             return Response(content=str(resp), media_type="application/xml")
 
         if is_score_message(incoming_msg):
-            reply_text = handle_score_keyword(phone_number)
+            reply_text = handle_score_keyword(phone_number, incoming_msg)
             resp = MessagingResponse()
             resp.message(staging_prefix(reply_text))
             log_interaction(phone_number, incoming_msg, reply_text, "sports_score", True)

--- a/main.py
+++ b/main.py
@@ -622,6 +622,12 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                 c.execute("DELETE FROM memories WHERE phone_number = %s", (phone_number,))
                 c.execute("DELETE FROM list_items WHERE phone_number = %s", (phone_number,))
                 c.execute("DELETE FROM lists WHERE phone_number = %s", (phone_number,))
+                try:
+                    c.execute("SAVEPOINT del_sports")
+                    c.execute("DELETE FROM sports_score_events WHERE phone_number = %s", (phone_number,))
+                    c.execute("DELETE FROM sports_optins WHERE phone_number = %s", (phone_number,))
+                except Exception:
+                    c.execute("ROLLBACK TO SAVEPOINT del_sports")
                 c.execute("DELETE FROM logs WHERE phone_number = %s", (phone_number,))
                 c.execute("DELETE FROM onboarding_progress WHERE phone_number = %s", (phone_number,))
                 c.execute("DELETE FROM feedback WHERE user_phone = %s", (phone_number,))
@@ -745,6 +751,12 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
                     c.execute("DELETE FROM memories WHERE phone_number = %s", (phone_number,))
                     c.execute("DELETE FROM list_items WHERE phone_number = %s", (phone_number,))
                     c.execute("DELETE FROM lists WHERE phone_number = %s", (phone_number,))
+                    try:
+                        c.execute("SAVEPOINT del_sports_reset")
+                        c.execute("DELETE FROM sports_score_events WHERE phone_number = %s", (phone_number,))
+                        c.execute("DELETE FROM sports_optins WHERE phone_number = %s", (phone_number,))
+                    except Exception:
+                        c.execute("ROLLBACK TO SAVEPOINT del_sports_reset")
                     c.execute("DELETE FROM logs WHERE phone_number = %s", (phone_number,))
                     c.execute("DELETE FROM onboarding_progress WHERE phone_number = %s", (phone_number,))
                     c.execute("DELETE FROM users WHERE phone_number = %s", (phone_number,))
@@ -814,6 +826,29 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
 
             log_interaction(phone_number, incoming_msg, "[Handled by Twilio]", "stop", True)
             resp = MessagingResponse()
+            return Response(content=str(resp), media_type="application/xml")
+
+        # ==========================================
+        # NFL SCORE BETA (YES + team / SCORE) — keyword path BEFORE AI
+        # ==========================================
+        # Bare YES still falls through to confirmations below. CANCEL/STOP
+        # already returned. Invites are not sent from inbound handling.
+        from services.sports_score_service import (
+            is_yes_team_message, is_score_message,
+            handle_yes_team, handle_score_keyword,
+        )
+        if is_yes_team_message(incoming_msg) and is_user_onboarded(phone_number):
+            reply_text = handle_yes_team(phone_number, incoming_msg)
+            resp = MessagingResponse()
+            resp.message(staging_prefix(reply_text))
+            log_interaction(phone_number, incoming_msg, reply_text, "sports_yes_team", True)
+            return Response(content=str(resp), media_type="application/xml")
+
+        if is_score_message(incoming_msg):
+            reply_text = handle_score_keyword(phone_number)
+            resp = MessagingResponse()
+            resp.message(staging_prefix(reply_text))
+            log_interaction(phone_number, incoming_msg, reply_text, "sports_score", True)
             return Response(content=str(resp), media_type="application/xml")
 
         # ==========================================
@@ -2956,6 +2991,13 @@ async def sms_reply(request: Request, Body: str = Form(...), From: str = Form(..
             from config import STRIPE_ENABLED, APP_BASE_URL, PREMIUM_MONTHLY_PRICE, PREMIUM_ANNUAL_PRICE
 
             subscription = get_user_subscription(phone_number)
+
+            # Growth analytics: paused score-beta users who text UPGRADE
+            try:
+                from services.sports_score_service import maybe_log_upgrade_to_keep
+                maybe_log_upgrade_to_keep(phone_number)
+            except Exception as sports_upgrade_err:
+                logger.warning(f"sports upgrade_to_keep log failed: {sports_upgrade_err}")
 
             # If already premium, show account management
             if subscription['tier'] != 'free' and subscription['status'] == 'active':

--- a/models/sports.py
+++ b/models/sports.py
@@ -1,0 +1,354 @@
+"""Data access for the NFL morning-after score beta.
+
+sports_optins: one row per opted-in user (team, cohort, ask/pause state).
+sports_score_events: growth-analytics events, always tagged with cohort so
+weekly and dormant counters never mix.
+users.sports_invite_*: invite tracking (sending is NOT in this PR).
+"""
+
+import json
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+from config import logger
+from database import get_db_connection, return_db_connection
+
+COHORT_WEEKLY = "weekly"
+COHORT_DORMANT = "dormant"
+VALID_COHORTS = (COHORT_WEEKLY, COHORT_DORMANT)
+
+EVENT_SCORE_ASK = "score_ask"
+EVENT_SCORE_REPLY = "score_reply"
+EVENT_SCORE_IGNORE = "score_ignore"
+EVENT_UPGRADE_TO_KEEP = "upgrade_to_keep"
+EVENT_SPORTS_YES = "sports_yes"
+
+
+def get_optin(phone_number: str) -> Optional[dict]:
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT phone_number, team_abbr, team_short, cohort, opted_in_at,
+                   ignore_streak, last_ask_date, last_ask_game_id, last_ask_replied,
+                   pending_score_payload, beta_started_at, pause_at, paused_at,
+                   stopped_silently
+            FROM sports_optins
+            WHERE phone_number = %s
+            """,
+            (phone_number,),
+        )
+        row = c.fetchone()
+        if not row:
+            return None
+        payload = row[9]
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except (TypeError, ValueError):
+                payload = None
+        return {
+            "phone_number": row[0],
+            "team_abbr": row[1],
+            "team_short": row[2],
+            "cohort": row[3],
+            "opted_in_at": row[4],
+            "ignore_streak": row[5] or 0,
+            "last_ask_date": row[6],
+            "last_ask_game_id": row[7],
+            "last_ask_replied": bool(row[8]),
+            "pending_score_payload": payload,
+            "beta_started_at": row[10],
+            "pause_at": row[11],
+            "paused_at": row[12],
+            "stopped_silently": bool(row[13]),
+        }
+    except Exception as e:
+        logger.error(f"Error getting sports opt-in: {e}")
+        return None
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def upsert_optin(
+    phone_number: str,
+    team_abbr: str,
+    team_short: str,
+    cohort: str,
+    opted_in_at: Optional[datetime] = None,
+    pause_at: Optional[datetime] = None,
+    beta_started_at: Optional[datetime] = None,
+) -> None:
+    """Insert or replace the user's one-team opt-in. Resets ask/ignore state on team change."""
+    if cohort not in VALID_COHORTS:
+        raise ValueError(f"Invalid sports cohort: {cohort}")
+    now = opted_in_at or datetime.utcnow()
+    beta_started = beta_started_at or now
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """
+            INSERT INTO sports_optins (
+                phone_number, team_abbr, team_short, cohort, opted_in_at,
+                ignore_streak, last_ask_date, last_ask_game_id, last_ask_replied,
+                pending_score_payload, beta_started_at, pause_at, paused_at,
+                stopped_silently, updated_at
+            ) VALUES (
+                %s, %s, %s, %s, %s,
+                0, NULL, NULL, FALSE,
+                NULL, %s, %s, NULL,
+                FALSE, CURRENT_TIMESTAMP
+            )
+            ON CONFLICT (phone_number) DO UPDATE SET
+                team_abbr = EXCLUDED.team_abbr,
+                team_short = EXCLUDED.team_short,
+                cohort = sports_optins.cohort,
+                ignore_streak = CASE
+                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
+                    THEN sports_optins.ignore_streak ELSE 0 END,
+                last_ask_date = CASE
+                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
+                    THEN sports_optins.last_ask_date ELSE NULL END,
+                last_ask_game_id = CASE
+                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
+                    THEN sports_optins.last_ask_game_id ELSE NULL END,
+                last_ask_replied = CASE
+                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
+                    THEN sports_optins.last_ask_replied ELSE FALSE END,
+                pending_score_payload = CASE
+                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
+                    THEN sports_optins.pending_score_payload ELSE NULL END,
+                stopped_silently = CASE
+                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
+                    THEN sports_optins.stopped_silently ELSE FALSE END,
+                pause_at = COALESCE(sports_optins.pause_at, EXCLUDED.pause_at),
+                beta_started_at = COALESCE(sports_optins.beta_started_at, EXCLUDED.beta_started_at),
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (phone_number, team_abbr, team_short, cohort, now, beta_started, pause_at),
+        )
+        conn.commit()
+    except Exception as e:
+        logger.error(f"Error upserting sports opt-in: {e}")
+        raise
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def update_optin(phone_number: str, **fields: Any) -> None:
+    allowed = {
+        "ignore_streak", "last_ask_date", "last_ask_game_id", "last_ask_replied",
+        "pending_score_payload", "pause_at", "paused_at", "stopped_silently",
+        "team_abbr", "team_short",
+    }
+    sets = []
+    values = []
+    for key, value in fields.items():
+        if key not in allowed:
+            raise ValueError(f"Invalid sports_optins field: {key}")
+        if key == "pending_score_payload" and value is not None and not isinstance(value, str):
+            value = json.dumps(value)
+        sets.append(f"{key} = %s")
+        values.append(value)
+    if not sets:
+        return
+    sets.append("updated_at = CURRENT_TIMESTAMP")
+    values.append(phone_number)
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            f"UPDATE sports_optins SET {', '.join(sets)} WHERE phone_number = %s",
+            tuple(values),
+        )
+        conn.commit()
+    except Exception as e:
+        logger.error(f"Error updating sports opt-in: {e}")
+        raise
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def list_active_optins() -> list[dict]:
+    """Opted-in users who have not silently stopped. Caller applies pause/time filters."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT s.phone_number, s.team_abbr, s.team_short, s.cohort, s.opted_in_at,
+                   s.ignore_streak, s.last_ask_date, s.last_ask_game_id, s.last_ask_replied,
+                   s.pending_score_payload, s.beta_started_at, s.pause_at, s.paused_at,
+                   s.stopped_silently, u.timezone, u.trial_end_date, u.premium_status,
+                   u.subscription_status, u.stripe_subscription_id, u.opted_out,
+                   u.winback_30d_sent, u.sports_invite_sent_at
+            FROM sports_optins s
+            JOIN users u ON u.phone_number = s.phone_number
+            WHERE COALESCE(s.stopped_silently, FALSE) = FALSE
+              AND u.onboarding_complete = TRUE
+              AND (u.opted_out IS NULL OR u.opted_out = FALSE)
+            """
+        )
+        rows = c.fetchall()
+        results = []
+        for row in rows:
+            payload = row[9]
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except (TypeError, ValueError):
+                    payload = None
+            results.append({
+                "phone_number": row[0],
+                "team_abbr": row[1],
+                "team_short": row[2],
+                "cohort": row[3],
+                "opted_in_at": row[4],
+                "ignore_streak": row[5] or 0,
+                "last_ask_date": row[6],
+                "last_ask_game_id": row[7],
+                "last_ask_replied": bool(row[8]),
+                "pending_score_payload": payload,
+                "beta_started_at": row[10],
+                "pause_at": row[11],
+                "paused_at": row[12],
+                "stopped_silently": bool(row[13]),
+                "timezone": row[14],
+                "trial_end_date": row[15],
+                "premium_status": row[16],
+                "subscription_status": row[17],
+                "stripe_subscription_id": row[18],
+                "opted_out": row[19],
+                "winback_30d_sent": row[20],
+                "sports_invite_sent_at": row[21],
+            })
+        return results
+    except Exception as e:
+        logger.error(f"Error listing sports opt-ins: {e}")
+        return []
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def log_sports_event(
+    phone_number: str,
+    event_type: str,
+    cohort: str,
+    metadata: Optional[dict] = None,
+) -> None:
+    """Record a growth-analytics event. Cohort is required so counters never mix."""
+    if cohort not in VALID_COHORTS:
+        raise ValueError(f"Invalid sports cohort for event: {cohort}")
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """
+            INSERT INTO sports_score_events (phone_number, cohort, event_type, metadata)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (phone_number, cohort, event_type, json.dumps(metadata) if metadata else None),
+        )
+        conn.commit()
+    except Exception as e:
+        logger.error(f"Error logging sports event: {e}")
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def count_sports_events(event_type: str, cohort: str) -> int:
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT COUNT(*) FROM sports_score_events
+            WHERE event_type = %s AND cohort = %s
+            """,
+            (event_type, cohort),
+        )
+        row = c.fetchone()
+        return int(row[0]) if row else 0
+    except Exception as e:
+        logger.error(f"Error counting sports events: {e}")
+        return 0
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def get_invite_state(phone_number: str) -> dict:
+    """Invite tracking on the user (sending is later; used for cohort + KEEP/CLEAR skip)."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT sports_invite_sent_at, sports_invite_cohort
+            FROM users WHERE phone_number = %s
+            """,
+            (phone_number,),
+        )
+        row = c.fetchone()
+        if not row:
+            return {"sports_invite_sent_at": None, "sports_invite_cohort": None}
+        return {
+            "sports_invite_sent_at": row[0],
+            "sports_invite_cohort": row[1],
+        }
+    except Exception as e:
+        logger.error(f"Error getting sports invite state: {e}")
+        return {"sports_invite_sent_at": None, "sports_invite_cohort": None}
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def mark_sports_invite(phone_number: str, cohort: str, sent_at: Optional[datetime] = None) -> None:
+    """Record that an invite was sent. Does NOT send SMS — invite sending is out of scope."""
+    if cohort not in VALID_COHORTS:
+        raise ValueError(f"Invalid sports invite cohort: {cohort}")
+    when = sent_at or datetime.utcnow()
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            """
+            UPDATE users
+            SET sports_invite_sent_at = %s, sports_invite_cohort = %s
+            WHERE phone_number = %s
+            """,
+            (when, cohort, phone_number),
+        )
+        conn.commit()
+    except Exception as e:
+        logger.error(f"Error marking sports invite: {e}")
+        raise
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def sports_invite_sent_this_week(phone_number: str, now: Optional[datetime] = None) -> bool:
+    """True if a sports invite was recorded in the last 7 days (blocks KEEP/CLEAR)."""
+    state = get_invite_state(phone_number)
+    sent_at = state.get("sports_invite_sent_at")
+    if not sent_at:
+        return False
+    now = now or datetime.utcnow()
+    return sent_at >= now - timedelta(days=7)

--- a/models/sports.py
+++ b/models/sports.py
@@ -1,6 +1,7 @@
 """Data access for the NFL morning-after score beta.
 
-sports_optins: one row per opted-in user (team, cohort, ask/pause state).
+sports_optins: one row per (phone, team). Production users are kept to one
+team in the service layer; founder dry-run phones may have two.
 sports_score_events: growth-analytics events, always tagged with cohort so
 weekly and dormant counters never mix.
 users.sports_invite_*: invite tracking (sending is NOT in this PR).
@@ -23,51 +24,88 @@ EVENT_SCORE_IGNORE = "score_ignore"
 EVENT_UPGRADE_TO_KEEP = "upgrade_to_keep"
 EVENT_SPORTS_YES = "sports_yes"
 
+_OPTIN_SELECT = """
+    phone_number, team_abbr, team_short, cohort, opted_in_at,
+    ignore_streak, last_ask_date, last_ask_game_id, last_ask_replied,
+    pending_score_payload, beta_started_at, pause_at, paused_at,
+    stopped_silently, last_ask_at
+"""
 
-def get_optin(phone_number: str) -> Optional[dict]:
+
+def _parse_payload(payload):
+    if isinstance(payload, str):
+        try:
+            return json.loads(payload)
+        except (TypeError, ValueError):
+            return None
+    return payload
+
+
+def _optin_from_row(row, extra=None) -> dict:
+    data = {
+        "phone_number": row[0],
+        "team_abbr": row[1],
+        "team_short": row[2],
+        "cohort": row[3],
+        "opted_in_at": row[4],
+        "ignore_streak": row[5] or 0,
+        "last_ask_date": row[6],
+        "last_ask_game_id": row[7],
+        "last_ask_replied": bool(row[8]),
+        "pending_score_payload": _parse_payload(row[9]),
+        "beta_started_at": row[10],
+        "pause_at": row[11],
+        "paused_at": row[12],
+        "stopped_silently": bool(row[13]),
+        "last_ask_at": row[14] if len(row) > 14 else None,
+    }
+    if extra:
+        data.update(extra)
+    return data
+
+
+def get_optin(phone_number: str, team_abbr: Optional[str] = None) -> Optional[dict]:
+    """One opt-in row. If team_abbr is omitted, the most recently updated row."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        if team_abbr:
+            c.execute(
+                f"SELECT {_OPTIN_SELECT} FROM sports_optins WHERE phone_number = %s AND team_abbr = %s",
+                (phone_number, team_abbr),
+            )
+        else:
+            c.execute(
+                f"SELECT {_OPTIN_SELECT} FROM sports_optins WHERE phone_number = %s "
+                "ORDER BY updated_at DESC NULLS LAST, opted_in_at DESC NULLS LAST LIMIT 1",
+                (phone_number,),
+            )
+        row = c.fetchone()
+        if not row:
+            return None
+        return _optin_from_row(row)
+    except Exception as e:
+        logger.error(f"Error getting sports opt-in: {e}")
+        return None
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def list_optins(phone_number: str) -> list:
     conn = None
     try:
         conn = get_db_connection()
         c = conn.cursor()
         c.execute(
-            """
-            SELECT phone_number, team_abbr, team_short, cohort, opted_in_at,
-                   ignore_streak, last_ask_date, last_ask_game_id, last_ask_replied,
-                   pending_score_payload, beta_started_at, pause_at, paused_at,
-                   stopped_silently
-            FROM sports_optins
-            WHERE phone_number = %s
-            """,
+            f"SELECT {_OPTIN_SELECT} FROM sports_optins WHERE phone_number = %s ORDER BY team_abbr",
             (phone_number,),
         )
-        row = c.fetchone()
-        if not row:
-            return None
-        payload = row[9]
-        if isinstance(payload, str):
-            try:
-                payload = json.loads(payload)
-            except (TypeError, ValueError):
-                payload = None
-        return {
-            "phone_number": row[0],
-            "team_abbr": row[1],
-            "team_short": row[2],
-            "cohort": row[3],
-            "opted_in_at": row[4],
-            "ignore_streak": row[5] or 0,
-            "last_ask_date": row[6],
-            "last_ask_game_id": row[7],
-            "last_ask_replied": bool(row[8]),
-            "pending_score_payload": payload,
-            "beta_started_at": row[10],
-            "pause_at": row[11],
-            "paused_at": row[12],
-            "stopped_silently": bool(row[13]),
-        }
+        return [_optin_from_row(row) for row in c.fetchall()]
     except Exception as e:
-        logger.error(f"Error getting sports opt-in: {e}")
-        return None
+        logger.error(f"Error listing sports opt-ins for phone: {e}")
+        return []
     finally:
         if conn:
             return_db_connection(conn)
@@ -81,8 +119,13 @@ def upsert_optin(
     opted_in_at: Optional[datetime] = None,
     pause_at: Optional[datetime] = None,
     beta_started_at: Optional[datetime] = None,
+    replace_others: bool = True,
 ) -> None:
-    """Insert or replace the user's one-team opt-in. Resets ask/ignore state on team change."""
+    """Insert or update one (phone, team) opt-in.
+
+    replace_others=True (production): delete any other teams for this phone.
+    replace_others=False (founder dual): keep existing other teams.
+    """
     if cohort not in VALID_COHORTS:
         raise ValueError(f"Invalid sports cohort: {cohort}")
     now = opted_in_at or datetime.utcnow()
@@ -91,41 +134,27 @@ def upsert_optin(
     try:
         conn = get_db_connection()
         c = conn.cursor()
+        if replace_others:
+            c.execute(
+                "DELETE FROM sports_optins WHERE phone_number = %s AND team_abbr <> %s",
+                (phone_number, team_abbr),
+            )
         c.execute(
             """
             INSERT INTO sports_optins (
                 phone_number, team_abbr, team_short, cohort, opted_in_at,
                 ignore_streak, last_ask_date, last_ask_game_id, last_ask_replied,
                 pending_score_payload, beta_started_at, pause_at, paused_at,
-                stopped_silently, updated_at
+                stopped_silently, last_ask_at, updated_at
             ) VALUES (
                 %s, %s, %s, %s, %s,
                 0, NULL, NULL, FALSE,
                 NULL, %s, %s, NULL,
-                FALSE, CURRENT_TIMESTAMP
+                FALSE, NULL, CURRENT_TIMESTAMP
             )
-            ON CONFLICT (phone_number) DO UPDATE SET
-                team_abbr = EXCLUDED.team_abbr,
+            ON CONFLICT (phone_number, team_abbr) DO UPDATE SET
                 team_short = EXCLUDED.team_short,
                 cohort = sports_optins.cohort,
-                ignore_streak = CASE
-                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
-                    THEN sports_optins.ignore_streak ELSE 0 END,
-                last_ask_date = CASE
-                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
-                    THEN sports_optins.last_ask_date ELSE NULL END,
-                last_ask_game_id = CASE
-                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
-                    THEN sports_optins.last_ask_game_id ELSE NULL END,
-                last_ask_replied = CASE
-                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
-                    THEN sports_optins.last_ask_replied ELSE FALSE END,
-                pending_score_payload = CASE
-                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
-                    THEN sports_optins.pending_score_payload ELSE NULL END,
-                stopped_silently = CASE
-                    WHEN sports_optins.team_abbr = EXCLUDED.team_abbr
-                    THEN sports_optins.stopped_silently ELSE FALSE END,
                 pause_at = COALESCE(sports_optins.pause_at, EXCLUDED.pause_at),
                 beta_started_at = COALESCE(sports_optins.beta_started_at, EXCLUDED.beta_started_at),
                 updated_at = CURRENT_TIMESTAMP
@@ -141,11 +170,11 @@ def upsert_optin(
             return_db_connection(conn)
 
 
-def update_optin(phone_number: str, **fields: Any) -> None:
+def update_optin(phone_number: str, team_abbr: Optional[str] = None, **fields: Any) -> None:
     allowed = {
         "ignore_streak", "last_ask_date", "last_ask_game_id", "last_ask_replied",
         "pending_score_payload", "pause_at", "paused_at", "stopped_silently",
-        "team_abbr", "team_short",
+        "team_abbr", "team_short", "last_ask_at",
     }
     sets = []
     values = []
@@ -159,15 +188,23 @@ def update_optin(phone_number: str, **fields: Any) -> None:
     if not sets:
         return
     sets.append("updated_at = CURRENT_TIMESTAMP")
-    values.append(phone_number)
     conn = None
     try:
         conn = get_db_connection()
         c = conn.cursor()
-        c.execute(
-            f"UPDATE sports_optins SET {', '.join(sets)} WHERE phone_number = %s",
-            tuple(values),
-        )
+        if team_abbr:
+            values.append(phone_number)
+            values.append(team_abbr)
+            c.execute(
+                f"UPDATE sports_optins SET {', '.join(sets)} WHERE phone_number = %s AND team_abbr = %s",
+                tuple(values),
+            )
+        else:
+            values.append(phone_number)
+            c.execute(
+                f"UPDATE sports_optins SET {', '.join(sets)} WHERE phone_number = %s",
+                tuple(values),
+            )
         conn.commit()
     except Exception as e:
         logger.error(f"Error updating sports opt-in: {e}")
@@ -177,8 +214,26 @@ def update_optin(phone_number: str, **fields: Any) -> None:
             return_db_connection(conn)
 
 
+def delete_optin(phone_number: str, team_abbr: str) -> None:
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            "DELETE FROM sports_optins WHERE phone_number = %s AND team_abbr = %s",
+            (phone_number, team_abbr),
+        )
+        conn.commit()
+    except Exception as e:
+        logger.error(f"Error deleting sports opt-in: {e}")
+        raise
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
 def list_active_optins() -> list[dict]:
-    """Opted-in users who have not silently stopped. Caller applies pause/time filters."""
+    """Opted-in (phone, team) rows that have not silently stopped."""
     conn = None
     try:
         conn = get_db_connection()
@@ -188,7 +243,8 @@ def list_active_optins() -> list[dict]:
             SELECT s.phone_number, s.team_abbr, s.team_short, s.cohort, s.opted_in_at,
                    s.ignore_streak, s.last_ask_date, s.last_ask_game_id, s.last_ask_replied,
                    s.pending_score_payload, s.beta_started_at, s.pause_at, s.paused_at,
-                   s.stopped_silently, u.timezone, u.trial_end_date, u.premium_status,
+                   s.stopped_silently, s.last_ask_at,
+                   u.timezone, u.trial_end_date, u.premium_status,
                    u.subscription_status, u.stripe_subscription_id, u.opted_out,
                    u.winback_30d_sent, u.sports_invite_sent_at
             FROM sports_optins s
@@ -201,36 +257,17 @@ def list_active_optins() -> list[dict]:
         rows = c.fetchall()
         results = []
         for row in rows:
-            payload = row[9]
-            if isinstance(payload, str):
-                try:
-                    payload = json.loads(payload)
-                except (TypeError, ValueError):
-                    payload = None
-            results.append({
-                "phone_number": row[0],
-                "team_abbr": row[1],
-                "team_short": row[2],
-                "cohort": row[3],
-                "opted_in_at": row[4],
-                "ignore_streak": row[5] or 0,
-                "last_ask_date": row[6],
-                "last_ask_game_id": row[7],
-                "last_ask_replied": bool(row[8]),
-                "pending_score_payload": payload,
-                "beta_started_at": row[10],
-                "pause_at": row[11],
-                "paused_at": row[12],
-                "stopped_silently": bool(row[13]),
-                "timezone": row[14],
-                "trial_end_date": row[15],
-                "premium_status": row[16],
-                "subscription_status": row[17],
-                "stripe_subscription_id": row[18],
-                "opted_out": row[19],
-                "winback_30d_sent": row[20],
-                "sports_invite_sent_at": row[21],
-            })
+            extra = {
+                "timezone": row[15],
+                "trial_end_date": row[16],
+                "premium_status": row[17],
+                "subscription_status": row[18],
+                "stripe_subscription_id": row[19],
+                "opted_out": row[20],
+                "winback_30d_sent": row[21],
+                "sports_invite_sent_at": row[22],
+            }
+            results.append(_optin_from_row(row, extra))
         return results
     except Exception as e:
         logger.error(f"Error listing sports opt-ins: {e}")

--- a/services/espn_nfl.py
+++ b/services/espn_nfl.py
@@ -1,0 +1,149 @@
+"""ESPN public NFL scoreboard client — finals only, no API key.
+
+Used by the morning-after score beta. Never returns in-progress scores.
+"""
+
+import json
+import urllib.error
+import urllib.request
+from datetime import date
+from typing import Optional
+
+from config import logger
+
+ESPN_SCOREBOARD_URL = (
+    "https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard"
+)
+REQUEST_TIMEOUT_SECONDS = 10
+
+# Canned final used by founder dry-run / preseason fake mornings.
+FAKE_GAME = {
+    "game_id": "fake-bengals-chiefs",
+    "away_abbr": "CIN",
+    "away_short": "Bengals",
+    "away_score": "27",
+    "home_abbr": "KC",
+    "home_short": "Chiefs",
+    "home_score": "24",
+}
+
+
+def _http_get_json(url: str) -> Optional[dict]:
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "RemyndrsScoreBeta/1.0"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError, json.JSONDecodeError) as e:
+        logger.warning(f"ESPN scoreboard fetch failed: {e}")
+        return None
+
+
+def fetch_scoreboard(game_date: date, fetch_fn=_http_get_json) -> Optional[dict]:
+    """Fetch ESPN scoreboard JSON for a YYYYMMDD date."""
+    dates = game_date.strftime("%Y%m%d")
+    url = f"{ESPN_SCOREBOARD_URL}?dates={dates}"
+    return fetch_fn(url)
+
+
+def _competitor_fields(competitor: dict) -> dict:
+    team = competitor.get("team") or {}
+    short = (
+        team.get("shortDisplayName")
+        or team.get("name")
+        or team.get("abbreviation")
+        or "Team"
+    )
+    return {
+        "abbr": (team.get("abbreviation") or "").upper(),
+        "short": short,
+        "score": str(competitor.get("score") or "0"),
+        "home_away": competitor.get("homeAway"),
+    }
+
+
+def parse_finals(scoreboard: Optional[dict]) -> list[dict]:
+    """Return completed NFL games only (STATUS_FINAL / completed=true)."""
+    if not scoreboard:
+        return []
+
+    finals = []
+    for event in scoreboard.get("events") or []:
+        competitions = event.get("competitions") or []
+        if not competitions:
+            continue
+        competition = competitions[0]
+        status = (competition.get("status") or {}).get("type") or {}
+        completed = bool(status.get("completed")) or (status.get("name") == "STATUS_FINAL")
+        if not completed:
+            continue
+
+        competitors = competition.get("competitors") or []
+        home = away = None
+        for c in competitors:
+            fields = _competitor_fields(c)
+            if fields["home_away"] == "home":
+                home = fields
+            elif fields["home_away"] == "away":
+                away = fields
+
+        if not home or not away:
+            continue
+
+        finals.append({
+            "game_id": str(event.get("id") or competition.get("id") or ""),
+            "away_abbr": away["abbr"],
+            "away_short": away["short"],
+            "away_score": away["score"],
+            "home_abbr": home["abbr"],
+            "home_short": home["short"],
+            "home_score": home["score"],
+        })
+    return finals
+
+
+def find_team_final(finals: list[dict], team_abbr: str) -> Optional[dict]:
+    """Return the final involving team_abbr, or None."""
+    want = (team_abbr or "").upper()
+    for game in finals:
+        if game["away_abbr"] == want or game["home_abbr"] == want:
+            return game
+    return None
+
+
+def format_final(game: dict) -> str:
+    """Locked SCORE reply format: 'Bengals 27, Chiefs 24' (away, home)."""
+    return (
+        f"{game['away_short']} {game['away_score']}, "
+        f"{game['home_short']} {game['home_score']}"
+    )
+
+
+def fake_game_for_team(team_abbr: str, team_short: str) -> dict:
+    """Canned final for founder dry-run. Keeps the user's team in the box score."""
+    abbr = (team_abbr or "CIN").upper()
+    short = team_short or "Bengals"
+    if abbr == "CIN":
+        return dict(FAKE_GAME)
+    if abbr == "KC":
+        return {
+            "game_id": "fake-chiefs-bengals",
+            "away_abbr": "KC",
+            "away_short": "Chiefs",
+            "away_score": "24",
+            "home_abbr": "CIN",
+            "home_short": "Bengals",
+            "home_score": "27",
+        }
+    return {
+        "game_id": f"fake-{abbr.lower()}-kc",
+        "away_abbr": abbr,
+        "away_short": short,
+        "away_score": "27",
+        "home_abbr": "KC",
+        "home_short": "Chiefs",
+        "home_score": "24",
+    }

--- a/services/nfl_teams.py
+++ b/services/nfl_teams.py
@@ -1,0 +1,264 @@
+"""NFL team alias map for the morning-after score beta.
+
+Users may text YES + Bengals, YES + Cincinnati, YES + CIN, etc.
+One team per user; aliases collapse to a canonical ESPN abbreviation.
+"""
+
+from typing import Optional
+
+
+# Canonical record: abbreviation (ESPN), short display name, full name, aliases.
+# Short name is what we put in SMS: "{Team} played last night..."
+NFL_TEAMS = {
+    "ARI": {
+        "abbr": "ARI",
+        "short": "Cardinals",
+        "full": "Arizona Cardinals",
+        "aliases": ["arizona", "arizona cardinals", "cardinals", "cards", "ari", "az"],
+    },
+    "ATL": {
+        "abbr": "ATL",
+        "short": "Falcons",
+        "full": "Atlanta Falcons",
+        "aliases": ["atlanta", "atlanta falcons", "falcons", "atl"],
+    },
+    "BAL": {
+        "abbr": "BAL",
+        "short": "Ravens",
+        "full": "Baltimore Ravens",
+        "aliases": ["baltimore", "baltimore ravens", "ravens", "bal"],
+    },
+    "BUF": {
+        "abbr": "BUF",
+        "short": "Bills",
+        "full": "Buffalo Bills",
+        "aliases": ["buffalo", "buffalo bills", "bills", "buf"],
+    },
+    "CAR": {
+        "abbr": "CAR",
+        "short": "Panthers",
+        "full": "Carolina Panthers",
+        "aliases": ["carolina", "carolina panthers", "panthers", "car"],
+    },
+    "CHI": {
+        "abbr": "CHI",
+        "short": "Bears",
+        "full": "Chicago Bears",
+        "aliases": ["chicago", "chicago bears", "bears", "chi"],
+    },
+    "CIN": {
+        "abbr": "CIN",
+        "short": "Bengals",
+        "full": "Cincinnati Bengals",
+        "aliases": ["cincinnati", "cincinnati bengals", "bengals", "cin", "cincy"],
+    },
+    "CLE": {
+        "abbr": "CLE",
+        "short": "Browns",
+        "full": "Cleveland Browns",
+        "aliases": ["cleveland", "cleveland browns", "browns", "cle"],
+    },
+    "DAL": {
+        "abbr": "DAL",
+        "short": "Cowboys",
+        "full": "Dallas Cowboys",
+        "aliases": ["dallas", "dallas cowboys", "cowboys", "dal"],
+    },
+    "DEN": {
+        "abbr": "DEN",
+        "short": "Broncos",
+        "full": "Denver Broncos",
+        "aliases": ["denver", "denver broncos", "broncos", "den"],
+    },
+    "DET": {
+        "abbr": "DET",
+        "short": "Lions",
+        "full": "Detroit Lions",
+        "aliases": ["detroit", "detroit lions", "lions", "det"],
+    },
+    "GB": {
+        "abbr": "GB",
+        "short": "Packers",
+        "full": "Green Bay Packers",
+        "aliases": ["green bay", "green bay packers", "packers", "gb", "pack"],
+    },
+    "HOU": {
+        "abbr": "HOU",
+        "short": "Texans",
+        "full": "Houston Texans",
+        "aliases": ["houston", "houston texans", "texans", "hou"],
+    },
+    "IND": {
+        "abbr": "IND",
+        "short": "Colts",
+        "full": "Indianapolis Colts",
+        "aliases": ["indianapolis", "indianapolis colts", "colts", "ind"],
+    },
+    "JAX": {
+        "abbr": "JAX",
+        "short": "Jaguars",
+        "full": "Jacksonville Jaguars",
+        "aliases": ["jacksonville", "jacksonville jaguars", "jaguars", "jags", "jax", "jac"],
+    },
+    "KC": {
+        "abbr": "KC",
+        "short": "Chiefs",
+        "full": "Kansas City Chiefs",
+        "aliases": ["kansas city", "kansas city chiefs", "chiefs", "kc"],
+    },
+    "LV": {
+        "abbr": "LV",
+        "short": "Raiders",
+        "full": "Las Vegas Raiders",
+        "aliases": ["las vegas", "las vegas raiders", "raiders", "lv", "lvr", "oakland", "oakland raiders"],
+    },
+    "LAC": {
+        "abbr": "LAC",
+        "short": "Chargers",
+        "full": "Los Angeles Chargers",
+        "aliases": ["chargers", "la chargers", "los angeles chargers", "lac", "san diego", "san diego chargers", "sd"],
+    },
+    "LAR": {
+        "abbr": "LAR",
+        "short": "Rams",
+        "full": "Los Angeles Rams",
+        "aliases": ["rams", "la rams", "los angeles rams", "lar", "st louis", "st louis rams", "stl"],
+    },
+    "MIA": {
+        "abbr": "MIA",
+        "short": "Dolphins",
+        "full": "Miami Dolphins",
+        "aliases": ["miami", "miami dolphins", "dolphins", "mia", "phins"],
+    },
+    "MIN": {
+        "abbr": "MIN",
+        "short": "Vikings",
+        "full": "Minnesota Vikings",
+        "aliases": ["minnesota", "minnesota vikings", "vikings", "min", "vikes"],
+    },
+    "NE": {
+        "abbr": "NE",
+        "short": "Patriots",
+        "full": "New England Patriots",
+        "aliases": ["new england", "new england patriots", "patriots", "pats", "ne"],
+    },
+    "NO": {
+        "abbr": "NO",
+        "short": "Saints",
+        "full": "New Orleans Saints",
+        "aliases": ["new orleans", "new orleans saints", "saints", "no", "nola"],
+    },
+    "NYG": {
+        "abbr": "NYG",
+        "short": "Giants",
+        "full": "New York Giants",
+        "aliases": ["giants", "ny giants", "new york giants", "nyg"],
+    },
+    "NYJ": {
+        "abbr": "NYJ",
+        "short": "Jets",
+        "full": "New York Jets",
+        "aliases": ["jets", "ny jets", "new york jets", "nyj"],
+    },
+    "PHI": {
+        "abbr": "PHI",
+        "short": "Eagles",
+        "full": "Philadelphia Eagles",
+        "aliases": ["philadelphia", "philadelphia eagles", "eagles", "phi", "philly"],
+    },
+    "PIT": {
+        "abbr": "PIT",
+        "short": "Steelers",
+        "full": "Pittsburgh Steelers",
+        "aliases": ["pittsburgh", "pittsburgh steelers", "steelers", "pit", "steelers"],
+    },
+    "SF": {
+        "abbr": "SF",
+        "short": "49ers",
+        "full": "San Francisco 49ers",
+        "aliases": [
+            "san francisco", "san francisco 49ers", "49ers", "niners",
+            "forty niners", "sf", "sfo",
+        ],
+    },
+    "SEA": {
+        "abbr": "SEA",
+        "short": "Seahawks",
+        "full": "Seattle Seahawks",
+        "aliases": ["seattle", "seattle seahawks", "seahawks", "sea", "hawks"],
+    },
+    "TB": {
+        "abbr": "TB",
+        "short": "Buccaneers",
+        "full": "Tampa Bay Buccaneers",
+        "aliases": ["tampa", "tampa bay", "tampa bay buccaneers", "buccaneers", "bucs", "bucs", "tb", "tbb"],
+    },
+    "TEN": {
+        "abbr": "TEN",
+        "short": "Titans",
+        "full": "Tennessee Titans",
+        "aliases": ["tennessee", "tennessee titans", "titans", "ten"],
+    },
+    "WAS": {
+        "abbr": "WAS",
+        "short": "Commanders",
+        "full": "Washington Commanders",
+        "aliases": ["washington", "washington commanders", "commanders", "was", "wsh"],
+    },
+}
+
+# Ambiguous city names that need a mascot.
+AMBIGUOUS_TEAMS = {
+    "new york": "Did you mean Giants or Jets?",
+    "ny": "Did you mean Giants or Jets?",
+    "los angeles": "Did you mean Rams or Chargers?",
+    "la": "Did you mean Rams or Chargers?",
+}
+
+
+def _normalize(raw: str) -> str:
+    text = (raw or "").strip().lower()
+    text = text.replace(".", "").replace(",", "")
+    text = " ".join(text.split())
+    if text.startswith("the "):
+        text = text[4:]
+    return text
+
+
+def build_alias_index() -> dict:
+    index = {}
+    for abbr, team in NFL_TEAMS.items():
+        index[abbr.lower()] = abbr
+        for alias in team["aliases"]:
+            index[alias.lower()] = abbr
+        index[team["short"].lower()] = abbr
+        index[team["full"].lower()] = abbr
+    return index
+
+
+_ALIAS_INDEX = build_alias_index()
+
+
+def resolve_team(raw: str) -> tuple[Optional[dict], Optional[str]]:
+    """Resolve a user-typed team to a canonical NFL team.
+
+    Returns (team_dict, error_message). On success error_message is None.
+    On failure team_dict is None and error_message is a short SMS reply.
+    """
+    key = _normalize(raw)
+    if not key:
+        return None, "Reply YES + team (NFL), like YES Bengals."
+
+    if key in AMBIGUOUS_TEAMS:
+        return None, AMBIGUOUS_TEAMS[key]
+
+    abbr = _ALIAS_INDEX.get(key)
+    if not abbr:
+        return None, "I didn't recognize that team. Reply YES + team (NFL), like YES Bengals."
+
+    team = NFL_TEAMS[abbr]
+    return {
+        "abbr": team["abbr"],
+        "short": team["short"],
+        "full": team["full"],
+    }, None

--- a/services/sports_score_service.py
+++ b/services/sports_score_service.py
@@ -1,0 +1,444 @@
+"""NFL morning-after score beta — opt-in, SCORE, asks, pause, anti-bunch.
+
+Closed beta plumbing. Invites are NOT sent from this module.
+"""
+
+import re
+from datetime import datetime, timedelta, date
+from typing import Optional
+
+import pytz
+
+from config import logger, FOUNDER_SURVEY_EXCLUDE_PHONES, TIER_PREMIUM, TIER_FAMILY
+from database import get_setting
+from models.sports import (
+    COHORT_WEEKLY,
+    COHORT_DORMANT,
+    EVENT_SCORE_ASK,
+    EVENT_SCORE_REPLY,
+    EVENT_SCORE_IGNORE,
+    EVENT_UPGRADE_TO_KEEP,
+    EVENT_SPORTS_YES,
+    get_optin,
+    upsert_optin,
+    update_optin,
+    list_active_optins,
+    log_sports_event,
+    get_invite_state,
+    sports_invite_sent_this_week,
+)
+from services.espn_nfl import (
+    fetch_scoreboard,
+    parse_finals,
+    find_team_final,
+    format_final,
+    fake_game_for_team,
+)
+from services.nfl_teams import resolve_team
+from services.sms_service import send_sms
+
+# Locked SMS copy — do not date, do not rewrite.
+INVITE_WEEKLY = (
+    "Trying something for football season. Want your team's score the morning after? "
+    "I'll ask first. Reply YES + team (NFL)."
+)
+INVITE_DORMANT = (
+    "Still here if you want. Trying football scores the morning after a game "
+    "(I'll ask first — no spoilers). Reply YES + team, or ignore."
+)
+ASK_TEMPLATE = "{team} played last night. Reply SCORE if you want it, or ignore."
+PAUSE_COPY = (
+    "That's the end of score texts unless you keep Premium. "
+    "Text UPGRADE to keep them — or ignore and I'll stop."
+)
+UNKNOWN_TEAM_COPY = "I didn't recognize that team. Reply YES + team (NFL), like YES Bengals."
+NO_PENDING_SCORE_COPY = "No score waiting — I'll ask the morning after your team plays."
+
+YES_TEAM_RE = re.compile(r"^\s*YES\s*\+?\s+(.+)$", re.IGNORECASE)
+SCORE_RE = re.compile(r"^\s*SCORE\s*$", re.IGNORECASE)
+
+BETA_DAYS = 28
+IGNORE_STOP_STREAK = 3
+
+# Day 7/13/14 of a 14-day trial, matching check_trial_expirations windows.
+DAY7_REMAINING = (6, 7)
+DAY13_REMAINING = (0, 1)  # 0 < remaining <= 1 handled separately
+
+
+def is_yes_team_message(text: str) -> bool:
+    return bool(YES_TEAM_RE.match(text or ""))
+
+
+def is_score_message(text: str) -> bool:
+    return bool(SCORE_RE.match(text or ""))
+
+
+def parse_yes_team(text: str) -> Optional[str]:
+    match = YES_TEAM_RE.match(text or "")
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def _user_tz(timezone_str: Optional[str]):
+    try:
+        return pytz.timezone(timezone_str or "America/New_York")
+    except pytz.exceptions.UnknownTimeZoneError:
+        return pytz.timezone("America/New_York")
+
+
+def _local_now(now_utc: datetime, timezone_str: Optional[str]):
+    tz = _user_tz(timezone_str)
+    if now_utc.tzinfo is None:
+        now_utc = pytz.utc.localize(now_utc)
+    return now_utc.astimezone(tz)
+
+
+def is_paid_premium(user_row: dict) -> bool:
+    """Paid Premium/Family (Stripe active). Trial-only premium does not count."""
+    status = (user_row.get("subscription_status") or "").lower()
+    if status == "active" and user_row.get("stripe_subscription_id"):
+        return True
+    # Family/premium with active sub but missing stripe id shouldn't happen; be conservative.
+    tier = (user_row.get("premium_status") or "").lower()
+    if status == "active" and tier in (TIER_PREMIUM, TIER_FAMILY) and user_row.get("stripe_subscription_id"):
+        return True
+    return False
+
+
+def compute_pause_at(opted_in_at: datetime, trial_end_date: Optional[datetime]) -> datetime:
+    """Pause after 4 weeks or trial end, whichever comes first."""
+    four_weeks = opted_in_at + timedelta(days=BETA_DAYS)
+    if trial_end_date and trial_end_date < four_weeks:
+        return trial_end_date
+    return four_weeks
+
+
+def should_pause_scores(optin: dict, now_utc: datetime, user_row: Optional[dict] = None) -> bool:
+    if user_row and is_paid_premium(user_row):
+        return False
+    pause_at = optin.get("pause_at")
+    if pause_at and now_utc >= pause_at:
+        return True
+    trial_end = (user_row or {}).get("trial_end_date") or optin.get("trial_end_date")
+    if trial_end and now_utc >= trial_end and not (user_row and is_paid_premium(user_row)):
+        return True
+    return False
+
+
+def trial_day_conflict(user_row: dict, now_utc: datetime) -> Optional[str]:
+    """Return skip reason if this local morning is Day 7, 13, 14, win-back, or sports invite."""
+    trial_end = user_row.get("trial_end_date")
+    local = _local_now(now_utc, user_row.get("timezone"))
+
+    if trial_end:
+        if trial_end.tzinfo is None:
+            trial_end_naive = trial_end
+        else:
+            trial_end_naive = trial_end.replace(tzinfo=None)
+        now_naive = now_utc.replace(tzinfo=None) if now_utc.tzinfo else now_utc
+        days_remaining = (trial_end_naive - now_naive).days
+
+        # Day 7 of trial (7 days remaining) — mid-trial / 7d warning
+        if DAY7_REMAINING[0] <= days_remaining <= DAY7_REMAINING[1]:
+            return "day_7"
+        # Day 13 (1 day remaining)
+        if 0 < days_remaining <= 1:
+            return "day_13"
+        # Day 14 (expired today)
+        if days_remaining <= 0:
+            days_since = (now_naive - trial_end_naive).days
+            if days_since <= 0:
+                return "day_14"
+            # 30-day win-back window (trial ended 29-31 days ago), unsent or sent today
+            if 29 <= days_since <= 31 and not user_row.get("winback_30d_sent"):
+                return "winback"
+            if user_row.get("winback_30d_sent"):
+                # If winback flag is set, only skip when it was sent this local morning
+                # (we don't store sent-at; skip whenever still in the 30d window after send
+                # would over-skip). Check invite/outbound instead below.
+                pass
+
+    invite_at = user_row.get("sports_invite_sent_at")
+    if invite_at:
+        invite_local = invite_at
+        if invite_at.tzinfo is None:
+            invite_local = pytz.utc.localize(invite_at).astimezone(_user_tz(user_row.get("timezone")))
+        elif invite_at.tzinfo:
+            invite_local = invite_at.astimezone(_user_tz(user_row.get("timezone")))
+        if getattr(invite_local, "date", None) and invite_local.date() == local.date():
+            return "sports_invite"
+
+    return None
+
+
+def winback_due_this_morning(user_row: dict, now_utc: datetime) -> bool:
+    trial_end = user_row.get("trial_end_date")
+    if not trial_end or user_row.get("winback_30d_sent"):
+        return False
+    now_naive = now_utc.replace(tzinfo=None) if now_utc.tzinfo else now_utc
+    trial_naive = trial_end.replace(tzinfo=None) if getattr(trial_end, "tzinfo", None) else trial_end
+    days_since = (now_naive - trial_naive).days
+    return 29 <= days_since <= 31
+
+
+def should_skip_score_ask(user_row: dict, now_utc: datetime) -> Optional[str]:
+    """Anti-bunch: score ping loses to Day 7/13/14, win-back, or the sports invite."""
+    reason = trial_day_conflict(user_row, now_utc)
+    if reason:
+        return reason
+    if winback_due_this_morning(user_row, now_utc):
+        return "winback"
+    return None
+
+
+def handle_yes_team(phone_number: str, incoming_msg: str) -> str:
+    """Opt the user in. Returns SMS reply (never None — caller always answers)."""
+    team_raw = parse_yes_team(incoming_msg)
+    if team_raw is None:
+        return UNKNOWN_TEAM_COPY
+
+    team, err = resolve_team(team_raw)
+    if err:
+        return err
+
+    invite = get_invite_state(phone_number)
+    cohort = invite.get("sports_invite_cohort") or COHORT_WEEKLY
+    if cohort not in (COHORT_WEEKLY, COHORT_DORMANT):
+        cohort = COHORT_WEEKLY
+
+    trial_end = _fetch_trial_end(phone_number)
+
+    now = datetime.utcnow()
+    pause_at = compute_pause_at(now, trial_end)
+    upsert_optin(
+        phone_number,
+        team["abbr"],
+        team["short"],
+        cohort,
+        opted_in_at=now,
+        pause_at=pause_at,
+        beta_started_at=now,
+    )
+    log_sports_event(
+        phone_number,
+        EVENT_SPORTS_YES,
+        cohort,
+        metadata={"team": team["abbr"]},
+    )
+    return (
+        f"Got it — {team['short']}. I'll ask the morning after they play. "
+        "Reply SCORE if you want it, or ignore."
+    )
+
+
+def _fetch_trial_end(phone_number: str) -> Optional[datetime]:
+    from database import get_db_connection, return_db_connection
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute("SELECT trial_end_date FROM users WHERE phone_number = %s", (phone_number,))
+        row = c.fetchone()
+        return row[0] if row else None
+    except Exception as e:
+        logger.error(f"Error fetching trial_end_date: {e}")
+        return None
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def handle_score_keyword(phone_number: str) -> Optional[str]:
+    """If a pending ask exists, send the final and mark replied. Never hits the AI."""
+    optin = get_optin(phone_number)
+    if not optin:
+        return NO_PENDING_SCORE_COPY
+    payload = optin.get("pending_score_payload")
+    if not payload or optin.get("last_ask_replied"):
+        return NO_PENDING_SCORE_COPY
+
+    reply = format_final(payload)
+    update_optin(
+        phone_number,
+        last_ask_replied=True,
+        ignore_streak=0,
+        pending_score_payload=None,
+    )
+    log_sports_event(
+        phone_number,
+        EVENT_SCORE_REPLY,
+        optin["cohort"],
+        metadata={"game_id": optin.get("last_ask_game_id"), "team": optin.get("team_abbr")},
+    )
+    return reply
+
+
+def maybe_log_upgrade_to_keep(phone_number: str) -> None:
+    """If the user was paused on scores, log upgrade_to_keep (does not change UPGRADE copy)."""
+    optin = get_optin(phone_number)
+    if not optin:
+        return
+    if optin.get("paused_at") or should_pause_scores(optin, datetime.utcnow(), optin):
+        log_sports_event(
+            phone_number,
+            EVENT_UPGRADE_TO_KEEP,
+            optin["cohort"],
+            metadata={"team": optin.get("team_abbr")},
+        )
+
+
+def _asks_enabled() -> bool:
+    return get_setting("nfl_score_asks_enabled", "true") != "false"
+
+
+def _in_morning_window(local_dt: datetime) -> bool:
+    return 9 <= local_dt.hour < 10
+
+
+def dry_run_phones() -> list[str]:
+    extra = get_setting("nfl_score_dry_run_phones", "") or ""
+    phones = list(FOUNDER_SURVEY_EXCLUDE_PHONES)
+    for part in extra.replace("\n", ",").split(","):
+        p = part.strip()
+        if p and p not in phones:
+            phones.append(p)
+    return phones
+
+
+def is_dry_run_allowed(phone_number: str) -> bool:
+    from config import ENVIRONMENT
+    if ENVIRONMENT in ("test", "testing", "development"):
+        return True
+    return phone_number in dry_run_phones()
+
+
+def process_morning_asks(
+    now_utc: Optional[datetime] = None,
+    dry_run_phone: Optional[str] = None,
+    fake_game: bool = False,
+    scoreboard_date: Optional[date] = None,
+    skip_window_check: bool = False,
+    fetch_fn=None,
+) -> dict:
+    """Send spoiler-free asks to opted-in users whose team finished yesterday.
+
+    dry_run_phone: process only that phone (founder fake/preseason morning).
+    fake_game: use canned Bengals/Chiefs-style final instead of ESPN.
+    Invites are never sent here.
+    """
+    now_utc = now_utc or datetime.utcnow()
+    if not _asks_enabled() and not dry_run_phone:
+        logger.info("NFL score asks disabled via nfl_score_asks_enabled setting")
+        return {"asked": 0, "paused": 0, "skipped": 0, "stopped": 0, "reason": "disabled"}
+
+    if dry_run_phone and not is_dry_run_allowed(dry_run_phone):
+        logger.warning("NFL score dry-run refused — phone not on founder allowlist")
+        return {"asked": 0, "paused": 0, "skipped": 0, "stopped": 0, "reason": "dry_run_not_allowed"}
+
+    optins = list_active_optins()
+    if dry_run_phone:
+        optins = [o for o in optins if o["phone_number"] == dry_run_phone]
+        skip_window_check = True
+
+    scoreboard_cache = {}
+    stats = {"asked": 0, "paused": 0, "skipped": 0, "stopped": 0, "ignored": 0}
+
+    for optin in optins:
+        phone = optin["phone_number"]
+        local = _local_now(now_utc, optin.get("timezone"))
+
+        if not skip_window_check and not _in_morning_window(local):
+            stats["skipped"] += 1
+            continue
+
+        skip_reason = should_skip_score_ask(optin, now_utc)
+        if skip_reason and not dry_run_phone:
+            logger.info(f"Skipping NFL score ask for ...{phone[-4:]} — {skip_reason} same morning")
+            stats["skipped"] += 1
+            continue
+
+        if should_pause_scores(optin, now_utc, optin):
+            if not optin.get("paused_at"):
+                try:
+                    send_sms(phone, PAUSE_COPY, message_type="sports_score_pause")
+                    update_optin(phone, paused_at=now_utc, pending_score_payload=None)
+                    stats["paused"] += 1
+                    logger.info(f"Sent NFL score pause to ...{phone[-4:]}")
+                except Exception as e:
+                    logger.error(f"Failed to send NFL score pause to ...{phone[-4:]}: {e}")
+            else:
+                stats["skipped"] += 1
+            continue
+
+        yesterday = scoreboard_date or (local.date() - timedelta(days=1))
+
+        if fake_game:
+            game = fake_game_for_team(optin["team_abbr"], optin["team_short"])
+            if dry_run_phone:
+                game = dict(game)
+                game["game_id"] = f"{game['game_id']}-{int(now_utc.timestamp())}"
+        else:
+            cache_key = yesterday.isoformat()
+            if cache_key not in scoreboard_cache:
+                kwargs = {}
+                if fetch_fn is not None:
+                    board = fetch_scoreboard(yesterday, fetch_fn=fetch_fn)
+                else:
+                    board = fetch_scoreboard(yesterday)
+                scoreboard_cache[cache_key] = parse_finals(board)
+            game = find_team_final(scoreboard_cache[cache_key], optin["team_abbr"])
+
+        if not game:
+            continue
+
+        # Don't ping again for the same game.
+        if optin.get("last_ask_game_id") == game["game_id"]:
+            stats["skipped"] += 1
+            continue
+
+        # Previous ask went unanswered → ignore streak.
+        if optin.get("last_ask_game_id") and not optin.get("last_ask_replied"):
+            new_streak = (optin.get("ignore_streak") or 0) + 1
+            log_sports_event(
+                phone,
+                EVENT_SCORE_IGNORE,
+                optin["cohort"],
+                metadata={"game_id": optin.get("last_ask_game_id"), "streak": new_streak},
+            )
+            stats["ignored"] += 1
+            if new_streak >= IGNORE_STOP_STREAK:
+                update_optin(
+                    phone,
+                    ignore_streak=new_streak,
+                    stopped_silently=True,
+                    pending_score_payload=None,
+                )
+                stats["stopped"] += 1
+                logger.info(f"NFL score beta silent-stop for ...{phone[-4:]} after {new_streak} ignores")
+                continue
+            update_optin(phone, ignore_streak=new_streak)
+            optin["ignore_streak"] = new_streak
+
+        ask_text = ASK_TEMPLATE.format(team=optin["team_short"])
+        try:
+            send_sms(phone, ask_text, message_type="sports_score_ask")
+            update_optin(
+                phone,
+                last_ask_date=local.date(),
+                last_ask_game_id=game["game_id"],
+                last_ask_replied=False,
+                pending_score_payload=game,
+            )
+            log_sports_event(
+                phone,
+                EVENT_SCORE_ASK,
+                optin["cohort"],
+                metadata={"game_id": game["game_id"], "team": optin["team_abbr"]},
+            )
+            stats["asked"] += 1
+            logger.info(f"Sent NFL score ask to ...{phone[-4:]} ({optin['team_short']}, {optin['cohort']})")
+        except Exception as e:
+            logger.error(f"Failed to send NFL score ask to ...{phone[-4:]}: {e}")
+
+    return stats

--- a/services/sports_score_service.py
+++ b/services/sports_score_service.py
@@ -1,6 +1,7 @@
 """NFL morning-after score beta — opt-in, SCORE, asks, pause, anti-bunch.
 
-Closed beta plumbing. Invites are NOT sent from this module.
+Closed beta plumbing. Production invites are never blasted from this module.
+Founder dry-run may send locked invite copy to one allowlisted phone.
 """
 
 import re
@@ -20,11 +21,14 @@ from models.sports import (
     EVENT_UPGRADE_TO_KEEP,
     EVENT_SPORTS_YES,
     get_optin,
+    list_optins,
     upsert_optin,
     update_optin,
+    delete_optin,
     list_active_optins,
     log_sports_event,
     get_invite_state,
+    mark_sports_invite,
     sports_invite_sent_this_week,
 )
 from services.espn_nfl import (
@@ -55,10 +59,13 @@ UNKNOWN_TEAM_COPY = "I didn't recognize that team. Reply YES + team (NFL), like 
 NO_PENDING_SCORE_COPY = "No score waiting — I'll ask the morning after your team plays."
 
 YES_TEAM_RE = re.compile(r"^\s*YES\s*\+?\s+(.+)$", re.IGNORECASE)
-SCORE_RE = re.compile(r"^\s*SCORE\s*$", re.IGNORECASE)
+SCORE_RE = re.compile(r"^\s*SCORE(?:\s*\+?\s+(.+))?\s*$", re.IGNORECASE)
 
 BETA_DAYS = 28
 IGNORE_STOP_STREAK = 3
+FOUNDER_DUAL_MAX = 2
+FOUNDER_DUAL_TEAMS = ("CIN", "DET")  # Bengals + Lions dry-run default
+STAGGER_SECONDS = 180  # a few minutes between asks on the same phone
 
 # Day 7/13/14 of a 14-day trial, matching check_trial_expirations windows.
 DAY7_REMAINING = (6, 7)
@@ -78,6 +85,15 @@ def parse_yes_team(text: str) -> Optional[str]:
     if not match:
         return None
     return match.group(1).strip()
+
+
+def parse_score_team(text: str) -> Optional[str]:
+    """Optional team after SCORE (founder dual). Bare SCORE returns None."""
+    match = SCORE_RE.match(text or "")
+    if not match:
+        return None
+    extra = match.group(1)
+    return extra.strip() if extra else None
 
 
 def _user_tz(timezone_str: Optional[str]):
@@ -193,7 +209,11 @@ def should_skip_score_ask(user_row: dict, now_utc: datetime) -> Optional[str]:
 
 
 def handle_yes_team(phone_number: str, incoming_msg: str) -> str:
-    """Opt the user in. Returns SMS reply (never None — caller always answers)."""
+    """Opt the user in. Returns SMS reply (never None — caller always answers).
+
+    Production: one team (a new YES replaces the old).
+    Founder allowlist: up to two teams so Bengals + Lions can both be dry-run.
+    """
     team_raw = parse_yes_team(incoming_msg)
     if team_raw is None:
         return UNKNOWN_TEAM_COPY
@@ -208,26 +228,53 @@ def handle_yes_team(phone_number: str, incoming_msg: str) -> str:
         cohort = COHORT_WEEKLY
 
     trial_end = _fetch_trial_end(phone_number)
-
     now = datetime.utcnow()
     pause_at = compute_pause_at(now, trial_end)
-    upsert_optin(
-        phone_number,
-        team["abbr"],
-        team["short"],
-        cohort,
-        opted_in_at=now,
-        pause_at=pause_at,
-        beta_started_at=now,
-    )
+    founder = is_founder_phone(phone_number)
+    existing = list_optins(phone_number)
+
+    if founder:
+        already = [o for o in existing if o["team_abbr"] == team["abbr"]]
+        others = [o for o in existing if o["team_abbr"] != team["abbr"]]
+        if not already and len(others) >= FOUNDER_DUAL_MAX:
+            oldest = min(others, key=lambda o: o.get("opted_in_at") or now)
+            delete_optin(phone_number, oldest["team_abbr"])
+        upsert_optin(
+            phone_number,
+            team["abbr"],
+            team["short"],
+            cohort,
+            opted_in_at=now,
+            pause_at=pause_at,
+            beta_started_at=now,
+            replace_others=False,
+        )
+    else:
+        upsert_optin(
+            phone_number,
+            team["abbr"],
+            team["short"],
+            cohort,
+            opted_in_at=now,
+            pause_at=pause_at,
+            beta_started_at=now,
+            replace_others=True,
+        )
+
     log_sports_event(
         phone_number,
         EVENT_SPORTS_YES,
         cohort,
-        metadata={"team": team["abbr"]},
+        metadata={"team": team["abbr"], "founder_dual": founder},
     )
+    extra = ""
+    if founder:
+        teams = list_optins(phone_number)
+        if len(teams) > 1:
+            names = " and ".join(o["team_short"] for o in teams)
+            extra = f" (founder dual: {names})"
     return (
-        f"Got it — {team['short']}. I'll ask the morning after they play. "
+        f"Got it — {team['short']}{extra}. I'll ask the morning after they play. "
         "Reply SCORE if you want it, or ignore."
     )
 
@@ -249,18 +296,22 @@ def _fetch_trial_end(phone_number: str) -> Optional[datetime]:
             return_db_connection(conn)
 
 
-def handle_score_keyword(phone_number: str) -> Optional[str]:
-    """If a pending ask exists, send the final and mark replied. Never hits the AI."""
-    optin = get_optin(phone_number)
-    if not optin:
-        return NO_PENDING_SCORE_COPY
-    payload = optin.get("pending_score_payload")
-    if not payload or optin.get("last_ask_replied"):
+def handle_score_keyword(phone_number: str, incoming_msg: str = "SCORE") -> Optional[str]:
+    """If a pending ask exists, send the final and mark replied. Never hits the AI.
+
+    Bare SCORE: most recently asked unreplied team (stagger-friendly).
+    SCORE + team: that team's pending final (founder dual).
+    """
+    team_hint = parse_score_team(incoming_msg)
+    target = _pending_score_optin(phone_number, team_hint)
+    if not target:
         return NO_PENDING_SCORE_COPY
 
+    payload = target.get("pending_score_payload")
     reply = format_final(payload)
     update_optin(
         phone_number,
+        team_abbr=target["team_abbr"],
         last_ask_replied=True,
         ignore_streak=0,
         pending_score_payload=None,
@@ -268,10 +319,36 @@ def handle_score_keyword(phone_number: str) -> Optional[str]:
     log_sports_event(
         phone_number,
         EVENT_SCORE_REPLY,
-        optin["cohort"],
-        metadata={"game_id": optin.get("last_ask_game_id"), "team": optin.get("team_abbr")},
+        target["cohort"],
+        metadata={"game_id": target.get("last_ask_game_id"), "team": target.get("team_abbr")},
     )
     return reply
+
+
+def _pending_score_optin(phone_number: str, team_hint: Optional[str] = None) -> Optional[dict]:
+    optins = list_optins(phone_number)
+    pending = [
+        o for o in optins
+        if o.get("pending_score_payload") and not o.get("last_ask_replied")
+    ]
+    if team_hint:
+        team, err = resolve_team(team_hint)
+        if err or not team:
+            return None
+        pending = [o for o in pending if o["team_abbr"] == team["abbr"]]
+    if not pending:
+        return None
+
+    def _ask_key(optin):
+        at = optin.get("last_ask_at")
+        if at:
+            return at
+        d = optin.get("last_ask_date")
+        if d:
+            return datetime.combine(d, datetime.min.time())
+        return datetime.min
+
+    return max(pending, key=_ask_key)
 
 
 def maybe_log_upgrade_to_keep(phone_number: str) -> None:
@@ -306,11 +383,117 @@ def dry_run_phones() -> list[str]:
     return phones
 
 
+def is_founder_phone(phone_number: str) -> bool:
+    """Allowlist for dual-team dry-run. Production users are never on this list."""
+    return phone_number in dry_run_phones()
+
+
 def is_dry_run_allowed(phone_number: str) -> bool:
     from config import ENVIRONMENT
     if ENVIRONMENT in ("test", "testing", "development"):
         return True
-    return phone_number in dry_run_phones()
+    return is_founder_phone(phone_number)
+
+
+def send_founder_invite(phone_number: str, cohort: str = COHORT_WEEKLY) -> bool:
+    """Send locked invite copy to one founder phone. Not a production blast."""
+    if not is_founder_phone(phone_number):
+        logger.warning("Founder invite refused — phone not on dry-run allowlist")
+        return False
+    copy = INVITE_DORMANT if cohort == COHORT_DORMANT else INVITE_WEEKLY
+    send_sms(phone_number, copy, message_type="sports_invite_dry_run")
+    mark_sports_invite(phone_number, cohort)
+    return True
+
+
+def ensure_founder_teams(
+    phone_number: str,
+    team_abbrs=None,
+    cohort: str = COHORT_WEEKLY,
+) -> list:
+    """Opt a founder phone into Bengals + Lions (or given teams). No-op off allowlist."""
+    from services.nfl_teams import NFL_TEAMS
+    if not is_founder_phone(phone_number):
+        return list_optins(phone_number)
+    wanted = list(team_abbrs or FOUNDER_DUAL_TEAMS)
+    trial_end = _fetch_trial_end(phone_number)
+    now = datetime.utcnow()
+    pause_at = compute_pause_at(now, trial_end)
+    for abbr in wanted:
+        team = NFL_TEAMS.get(abbr.upper())
+        if not team:
+            continue
+        upsert_optin(
+            phone_number,
+            team["abbr"],
+            team["short"],
+            cohort,
+            opted_in_at=now,
+            pause_at=pause_at,
+            beta_started_at=now,
+            replace_others=False,
+        )
+        log_sports_event(
+            phone_number,
+            EVENT_SPORTS_YES,
+            cohort,
+            metadata={"team": team["abbr"], "source": "founder_dry_run"},
+        )
+    return list_optins(phone_number)
+
+
+def deliver_score_ask(phone_number: str, team_abbr: str, game: dict, ask_date=None, asked_at=None) -> bool:
+    """Send the spoiler-free ask and store the final for a later SCORE. Never includes the score."""
+    optin = get_optin(phone_number, team_abbr=team_abbr)
+    if not optin:
+        return False
+    ask_text = ASK_TEMPLATE.format(team=optin["team_short"])
+    if _ask_would_leak_score(ask_text, game):
+        logger.error("Refusing score ask that would leak a score")
+        return False
+    send_sms(phone_number, ask_text, message_type="sports_score_ask")
+    update_optin(
+        phone_number,
+        team_abbr=team_abbr,
+        last_ask_date=ask_date,
+        last_ask_at=asked_at or datetime.utcnow(),
+        last_ask_game_id=game["game_id"],
+        last_ask_replied=False,
+        pending_score_payload=game,
+    )
+    log_sports_event(
+        phone_number,
+        EVENT_SCORE_ASK,
+        optin["cohort"],
+        metadata={"game_id": game["game_id"], "team": team_abbr},
+    )
+    logger.info(f"Sent NFL score ask to ...{phone_number[-4:]} ({optin['team_short']}, {optin['cohort']})")
+    return True
+
+
+def _ask_would_leak_score(ask_text: str, game: dict) -> bool:
+    """True if the ask body contains a score digit string from the stored final."""
+    for key in ("away_score", "home_score"):
+        score = game.get(key)
+        if score is None:
+            continue
+        s = str(score).strip()
+        if s and s in ask_text:
+            return True
+    return False
+
+
+def _schedule_staggered_ask(phone_number: str, team_abbr: str, game: dict, delay_seconds: int, ask_date_iso: Optional[str]):
+    from tasks.reminder_tasks import send_one_nfl_score_ask
+    send_one_nfl_score_ask.apply_async(
+        kwargs={
+            "phone_number": phone_number,
+            "team_abbr": team_abbr,
+            "game": game,
+            "ask_date_iso": ask_date_iso,
+        },
+        countdown=delay_seconds,
+    )
 
 
 def process_morning_asks(
@@ -320,21 +503,41 @@ def process_morning_asks(
     scoreboard_date: Optional[date] = None,
     skip_window_check: bool = False,
     fetch_fn=None,
+    send_invite: bool = False,
+    full_loop: bool = False,
+    teams=None,
+    schedule_staggered=None,
 ) -> dict:
     """Send spoiler-free asks to opted-in users whose team finished yesterday.
 
     dry_run_phone: process only that phone (founder fake/preseason morning).
-    fake_game: use canned Bengals/Chiefs-style final instead of ESPN.
-    Invites are never sent here.
+    fake_game: use canned finals instead of ESPN.
+    full_loop: founder only — send invite copy, ensure Bengals+Lions, then asks.
+    Invites are never blasted to production users.
     """
     now_utc = now_utc or datetime.utcnow()
+    stats = {
+        "asked": 0, "paused": 0, "skipped": 0, "stopped": 0, "ignored": 0,
+        "invite_sent": 0, "scheduled": 0,
+    }
+
     if not _asks_enabled() and not dry_run_phone:
         logger.info("NFL score asks disabled via nfl_score_asks_enabled setting")
-        return {"asked": 0, "paused": 0, "skipped": 0, "stopped": 0, "reason": "disabled"}
+        stats["reason"] = "disabled"
+        return stats
 
     if dry_run_phone and not is_dry_run_allowed(dry_run_phone):
         logger.warning("NFL score dry-run refused — phone not on founder allowlist")
-        return {"asked": 0, "paused": 0, "skipped": 0, "stopped": 0, "reason": "dry_run_not_allowed"}
+        stats["reason"] = "dry_run_not_allowed"
+        return stats
+
+    if dry_run_phone and (send_invite or full_loop):
+        if send_founder_invite(dry_run_phone):
+            stats["invite_sent"] = 1
+        skip_window_check = True
+
+    if dry_run_phone and full_loop:
+        ensure_founder_teams(dry_run_phone, team_abbrs=teams or FOUNDER_DUAL_TEAMS)
 
     optins = list_active_optins()
     if dry_run_phone:
@@ -342,7 +545,8 @@ def process_morning_asks(
         skip_window_check = True
 
     scoreboard_cache = {}
-    stats = {"asked": 0, "paused": 0, "skipped": 0, "stopped": 0, "ignored": 0}
+    due_by_phone = {}
+    paused_phones = set()
 
     for optin in optins:
         phone = optin["phone_number"]
@@ -359,16 +563,20 @@ def process_morning_asks(
             continue
 
         if should_pause_scores(optin, now_utc, optin):
-            if not optin.get("paused_at"):
+            if phone not in paused_phones and not optin.get("paused_at"):
                 try:
                     send_sms(phone, PAUSE_COPY, message_type="sports_score_pause")
                     update_optin(phone, paused_at=now_utc, pending_score_payload=None)
                     stats["paused"] += 1
+                    paused_phones.add(phone)
                     logger.info(f"Sent NFL score pause to ...{phone[-4:]}")
                 except Exception as e:
                     logger.error(f"Failed to send NFL score pause to ...{phone[-4:]}: {e}")
             else:
-                stats["skipped"] += 1
+                if optin.get("paused_at"):
+                    stats["skipped"] += 1
+                else:
+                    update_optin(phone, team_abbr=optin["team_abbr"], paused_at=now_utc, pending_score_payload=None)
             continue
 
         yesterday = scoreboard_date or (local.date() - timedelta(days=1))
@@ -381,7 +589,6 @@ def process_morning_asks(
         else:
             cache_key = yesterday.isoformat()
             if cache_key not in scoreboard_cache:
-                kwargs = {}
                 if fetch_fn is not None:
                     board = fetch_scoreboard(yesterday, fetch_fn=fetch_fn)
                 else:
@@ -392,53 +599,83 @@ def process_morning_asks(
         if not game:
             continue
 
-        # Don't ping again for the same game.
         if optin.get("last_ask_game_id") == game["game_id"]:
             stats["skipped"] += 1
             continue
 
-        # Previous ask went unanswered → ignore streak.
         if optin.get("last_ask_game_id") and not optin.get("last_ask_replied"):
             new_streak = (optin.get("ignore_streak") or 0) + 1
             log_sports_event(
                 phone,
                 EVENT_SCORE_IGNORE,
                 optin["cohort"],
-                metadata={"game_id": optin.get("last_ask_game_id"), "streak": new_streak},
+                metadata={"game_id": optin.get("last_ask_game_id"), "streak": new_streak, "team": optin["team_abbr"]},
             )
             stats["ignored"] += 1
             if new_streak >= IGNORE_STOP_STREAK:
                 update_optin(
                     phone,
+                    team_abbr=optin["team_abbr"],
                     ignore_streak=new_streak,
                     stopped_silently=True,
                     pending_score_payload=None,
                 )
                 stats["stopped"] += 1
-                logger.info(f"NFL score beta silent-stop for ...{phone[-4:]} after {new_streak} ignores")
+                logger.info(f"NFL score beta silent-stop for ...{phone[-4:]} {optin['team_abbr']} after {new_streak} ignores")
                 continue
-            update_optin(phone, ignore_streak=new_streak)
+            update_optin(phone, team_abbr=optin["team_abbr"], ignore_streak=new_streak)
             optin["ignore_streak"] = new_streak
 
-        ask_text = ASK_TEMPLATE.format(team=optin["team_short"])
-        try:
-            send_sms(phone, ask_text, message_type="sports_score_ask")
-            update_optin(
-                phone,
-                last_ask_date=local.date(),
-                last_ask_game_id=game["game_id"],
-                last_ask_replied=False,
-                pending_score_payload=game,
-            )
-            log_sports_event(
-                phone,
-                EVENT_SCORE_ASK,
-                optin["cohort"],
-                metadata={"game_id": game["game_id"], "team": optin["team_abbr"]},
-            )
-            stats["asked"] += 1
-            logger.info(f"Sent NFL score ask to ...{phone[-4:]} ({optin['team_short']}, {optin['cohort']})")
-        except Exception as e:
-            logger.error(f"Failed to send NFL score ask to ...{phone[-4:]}: {e}")
+        due_by_phone.setdefault(phone, []).append({
+            "optin": optin,
+            "game": game,
+            "ask_date": local.date(),
+        })
+
+    scheduler = schedule_staggered if schedule_staggered is not None else _schedule_staggered_ask
+
+    for phone, items in due_by_phone.items():
+        items.sort(key=lambda x: x["optin"]["team_abbr"])
+        for idx, item in enumerate(items):
+            optin = item["optin"]
+            if idx == 0:
+                try:
+                    if deliver_score_ask(
+                        phone,
+                        optin["team_abbr"],
+                        item["game"],
+                        ask_date=item["ask_date"],
+                        asked_at=now_utc,
+                    ):
+                        stats["asked"] += 1
+                except Exception as e:
+                    logger.error(f"Failed to send NFL score ask to ...{phone[-4:]}: {e}")
+            else:
+                delay = STAGGER_SECONDS * idx
+                try:
+                    scheduler(
+                        phone,
+                        optin["team_abbr"],
+                        item["game"],
+                        delay,
+                        item["ask_date"].isoformat(),
+                    )
+                    stats["scheduled"] += 1
+                    logger.info(
+                        f"Staggered NFL score ask for ...{phone[-4:]} {optin['team_short']} in {delay}s"
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to schedule staggered ask for ...{phone[-4:]}: {e}")
+                    try:
+                        if deliver_score_ask(
+                            phone,
+                            optin["team_abbr"],
+                            item["game"],
+                            ask_date=item["ask_date"],
+                            asked_at=now_utc,
+                        ):
+                            stats["asked"] += 1
+                    except Exception as send_err:
+                        logger.error(f"Fallback ask failed for ...{phone[-4:]}: {send_err}")
 
     return stats

--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -2413,15 +2413,17 @@ def generate_daily_analytics_summary(self):
     time_limit=300,
     soft_time_limit=270,
 )
-def send_nfl_score_asks(self, dry_run_phone=None, fake_game=False, scoreboard_date=None):
+def send_nfl_score_asks(self, dry_run_phone=None, fake_game=False, scoreboard_date=None,
+                       send_invite=False, full_loop=False, teams=None):
     """
     Morning-after NFL score asks (9-10 AM local), same window as trial lifecycle.
 
-    Does NOT send weekly/dormant invites. Opt-in is YES + team; SCORE is inbound.
+    Does NOT send weekly/dormant invites to production. Opt-in is YES + team; SCORE is inbound.
 
     Founder dry-run (does not blast anyone else):
-        celery -A celery_app call tasks.reminder_tasks.send_nfl_score_asks --kwargs='{"dry_run_phone":"+18593935374","fake_game":true}'
-    Or POST /admin/sports-scores/dry-run with {"phone":"+18593935374","fake_game":true}.
+        celery -A celery_app call tasks.reminder_tasks.send_nfl_score_asks --kwargs='{"dry_run_phone":"+18593935374","fake_game":true,"full_loop":true}'
+    full_loop sends invite copy, opts that phone into Bengals+Lions, then staggered asks.
+    Or POST /admin/sports-scores/dry-run with the same fields.
     """
     from datetime import datetime, date as date_cls
     from services.sports_score_service import process_morning_asks
@@ -2437,15 +2439,45 @@ def send_nfl_score_asks(self, dry_run_phone=None, fake_game=False, scoreboard_da
         "Starting NFL score asks"
         + (f" dry_run={dry_run_phone[-4:]}" if dry_run_phone else "")
         + (" fake_game" if fake_game else "")
+        + (" full_loop" if full_loop else "")
     )
     try:
         result = process_morning_asks(
             dry_run_phone=dry_run_phone,
             fake_game=bool(fake_game),
             scoreboard_date=parsed_date,
+            send_invite=bool(send_invite) or bool(full_loop),
+            full_loop=bool(full_loop),
+            teams=teams,
         )
         logger.info(f"NFL score asks complete: {result}")
         return result
     except Exception as exc:
         logger.exception("Error in send_nfl_score_asks")
+        raise self.retry(exc=exc)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    default_retry_delay=30,
+    time_limit=60,
+    soft_time_limit=50,
+)
+def send_one_nfl_score_ask(self, phone_number, team_abbr, game, ask_date_iso=None):
+    """Delayed single-team ask used to stagger two founder-phone asks."""
+    from datetime import datetime
+    from services.sports_score_service import deliver_score_ask
+
+    ask_date = None
+    if ask_date_iso:
+        try:
+            ask_date = datetime.strptime(ask_date_iso, "%Y-%m-%d").date()
+        except ValueError:
+            ask_date = None
+    try:
+        ok = deliver_score_ask(phone_number, team_abbr, game, ask_date=ask_date)
+        return {"sent": bool(ok), "team": team_abbr}
+    except Exception as exc:
+        logger.exception("Error in send_one_nfl_score_ask")
         raise self.retry(exc=exc)

--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -2265,6 +2265,13 @@ def send_inactivity_nudge(self):
                 logger.info(f"Skipping inactivity nudge for ...{phone_number[-4:]} — another lifecycle message sent in last 48h")
                 continue
 
+            # Dormant sports invite replaces KEEP/CLEAR for those users the
+            # same week. Invite sending is later; this skip is the double-send guard.
+            from models.sports import sports_invite_sent_this_week
+            if sports_invite_sent_this_week(phone_number, now_utc):
+                logger.info(f"Skipping inactivity nudge for ...{phone_number[-4:]} — sports invite sent this week")
+                continue
+
             try:
                 greeting = f"Hi {first_name}!" if first_name else "Hi there!"
 
@@ -2397,3 +2404,48 @@ def generate_daily_analytics_summary(self):
     except Exception as e:
         logger.error(f"Error generating analytics summary: {e}")
         raise self.retry(exc=e)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    default_retry_delay=60,
+    time_limit=300,
+    soft_time_limit=270,
+)
+def send_nfl_score_asks(self, dry_run_phone=None, fake_game=False, scoreboard_date=None):
+    """
+    Morning-after NFL score asks (9-10 AM local), same window as trial lifecycle.
+
+    Does NOT send weekly/dormant invites. Opt-in is YES + team; SCORE is inbound.
+
+    Founder dry-run (does not blast anyone else):
+        celery -A celery_app call tasks.reminder_tasks.send_nfl_score_asks --kwargs='{"dry_run_phone":"+18593935374","fake_game":true}'
+    Or POST /admin/sports-scores/dry-run with {"phone":"+18593935374","fake_game":true}.
+    """
+    from datetime import datetime, date as date_cls
+    from services.sports_score_service import process_morning_asks
+
+    parsed_date = None
+    if scoreboard_date:
+        if isinstance(scoreboard_date, str):
+            parsed_date = datetime.strptime(scoreboard_date, "%Y%m%d").date()
+        elif isinstance(scoreboard_date, date_cls):
+            parsed_date = scoreboard_date
+
+    logger.info(
+        "Starting NFL score asks"
+        + (f" dry_run={dry_run_phone[-4:]}" if dry_run_phone else "")
+        + (" fake_game" if fake_game else "")
+    )
+    try:
+        result = process_morning_asks(
+            dry_run_phone=dry_run_phone,
+            fake_game=bool(fake_game),
+            scoreboard_date=parsed_date,
+        )
+        logger.info(f"NFL score asks complete: {result}")
+        return result
+    except Exception as exc:
+        logger.exception("Error in send_nfl_score_asks")
+        raise self.retry(exc=exc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,6 +305,7 @@ def sms_capture():
          patch('services.onboarding_recovery_service.send_sms', side_effect=capture.send_sms), \
          patch('services.onboarding_service.send_sms', side_effect=capture.send_sms), \
          patch('tasks.reminder_tasks.send_sms', side_effect=capture.send_sms), \
+         patch('services.sports_score_service.send_sms', side_effect=capture.send_sms), \
          patch('services.onboarding_service.send_delayed_sms.apply_async', side_effect=mock_delayed_sms_apply_async), \
          patch('services.onboarding_service.send_engagement_nudge.apply_async', side_effect=mock_engagement_nudge_apply_async), \
          patch('main.send_sms', side_effect=capture.send_sms), \
@@ -410,6 +411,8 @@ def onboarded_user(test_phone):
         c.execute("DELETE FROM support_tickets WHERE phone_number = %s", (test_phone,))
         c.execute("DELETE FROM logs WHERE phone_number = %s", (test_phone,))
         c.execute("DELETE FROM sms_inbound_log WHERE phone_number = %s", (test_phone,))
+        c.execute("DELETE FROM sports_score_events WHERE phone_number = %s", (test_phone,))
+        c.execute("DELETE FROM sports_optins WHERE phone_number = %s", (test_phone,))
         c.execute("DELETE FROM users WHERE phone_number = %s", (test_phone,))
         c.execute("DELETE FROM onboarding_progress WHERE phone_number = %s", (test_phone,))
         conn.commit()
@@ -457,6 +460,8 @@ def onboarded_user(test_phone):
         c.execute("DELETE FROM support_tickets WHERE phone_number = %s", (test_phone,))
         c.execute("DELETE FROM logs WHERE phone_number = %s", (test_phone,))
         c.execute("DELETE FROM sms_inbound_log WHERE phone_number = %s", (test_phone,))
+        c.execute("DELETE FROM sports_score_events WHERE phone_number = %s", (test_phone,))
+        c.execute("DELETE FROM sports_optins WHERE phone_number = %s", (test_phone,))
         c.execute("DELETE FROM users WHERE phone_number = %s", (test_phone,))
         c.execute("DELETE FROM onboarding_progress WHERE phone_number = %s", (test_phone,))
         conn.commit()
@@ -491,6 +496,8 @@ def clean_test_user(test_phone):
             c.execute("DELETE FROM memories WHERE phone_number = %s", (test_phone,))
             c.execute("DELETE FROM support_tickets WHERE phone_number = %s", (test_phone,))
             c.execute("DELETE FROM logs WHERE phone_number = %s", (test_phone,))
+            c.execute("DELETE FROM sports_score_events WHERE phone_number = %s", (test_phone,))
+            c.execute("DELETE FROM sports_optins WHERE phone_number = %s", (test_phone,))
             c.execute("DELETE FROM users WHERE phone_number = %s", (test_phone,))
             c.execute("DELETE FROM onboarding_progress WHERE phone_number = %s", (test_phone,))
             conn.commit()
@@ -613,6 +620,7 @@ def disable_twilio_globally():
         patch('services.onboarding_recovery_service.send_sms', side_effect=mock_send_sms),
         patch('services.stripe_service.send_sms', side_effect=mock_send_sms),
         patch('tasks.reminder_tasks.send_sms', side_effect=mock_send_sms),
+        patch('services.sports_score_service.send_sms', side_effect=mock_send_sms),
         patch('main.send_sms', side_effect=mock_send_sms),
         patch('admin_dashboard.send_sms', side_effect=mock_send_sms),
     ]

--- a/tests/test_nfl_scores.py
+++ b/tests/test_nfl_scores.py
@@ -269,8 +269,9 @@ class TestIgnoreAndStop:
 
     def test_three_ignores_stops_silently(self, onboarded_user):
         phone = onboarded_user["phone"]
-        _opt_in(phone)
         now = _et_morning()
+        _set_trial(phone, now + timedelta(days=90))
+        _opt_in(phone, opted_in_at=now, pause_at=now + timedelta(days=90))
         with patch("services.sports_score_service.send_sms") as mock_sms:
             mock_sms.return_value = None
             for i, gid in enumerate(["g1", "g2", "g3", "g4"], start=1):

--- a/tests/test_nfl_scores.py
+++ b/tests/test_nfl_scores.py
@@ -1,0 +1,505 @@
+"""NFL morning-after score beta.
+
+Covers opt-in, SCORE, ignore/stop, anti-bunch vs Day 7/13/14, keyword
+isolation from AI, weekly vs dormant event logging, and 4-week pause.
+Invites are not sent by this feature — tests assert that.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+import pytz
+
+from database import get_db_connection, return_db_connection, init_db
+
+init_db()
+from models.sports import (
+    COHORT_WEEKLY,
+    COHORT_DORMANT,
+    EVENT_SCORE_ASK,
+    EVENT_SCORE_REPLY,
+    EVENT_SCORE_IGNORE,
+    EVENT_SPORTS_YES,
+    EVENT_UPGRADE_TO_KEEP,
+    get_optin,
+    upsert_optin,
+    update_optin,
+    log_sports_event,
+    count_sports_events,
+    mark_sports_invite,
+    sports_invite_sent_this_week,
+)
+from services.espn_nfl import parse_finals, format_final, fake_game_for_team
+from services.nfl_teams import resolve_team
+from services.sports_score_service import (
+    ASK_TEMPLATE,
+    PAUSE_COPY,
+    INVITE_WEEKLY,
+    INVITE_DORMANT,
+    handle_yes_team,
+    handle_score_keyword,
+    process_morning_asks,
+    should_skip_score_ask,
+    compute_pause_at,
+    is_paid_premium,
+    maybe_log_upgrade_to_keep,
+)
+
+
+PHONE = "+15559876543"
+
+
+def _et_morning(day=15, month=9, year=2026, hour=9, minute=30):
+    """9:30 AM America/New_York as naive UTC (matches onboarded_user tz)."""
+    tz = pytz.timezone("America/New_York")
+    local = tz.localize(datetime(year, month, day, hour, minute, 0))
+    return local.astimezone(pytz.utc).replace(tzinfo=None)
+
+
+def _espn_final(game_id="game-cin-kc", away="CIN", home="KC", away_score="27", home_score="24"):
+    return {
+        "events": [{
+            "id": game_id,
+            "competitions": [{
+                "status": {"type": {"name": "STATUS_FINAL", "completed": True}},
+                "competitors": [
+                    {
+                        "homeAway": "away",
+                        "score": away_score,
+                        "team": {"abbreviation": away, "shortDisplayName": "Bengals" if away == "CIN" else away},
+                    },
+                    {
+                        "homeAway": "home",
+                        "score": home_score,
+                        "team": {"abbreviation": home, "shortDisplayName": "Chiefs" if home == "KC" else home},
+                    },
+                ],
+            }],
+        }]
+    }
+
+
+def _fetch(board):
+    return lambda url: board
+
+
+def _set_trial(phone, trial_end, premium_status="premium", stripe_id=None, sub_status=None):
+    conn = get_db_connection()
+    try:
+        c = conn.cursor()
+        c.execute(
+            """
+            UPDATE users SET trial_end_date = %s, premium_status = %s,
+                   stripe_subscription_id = %s, subscription_status = %s
+            WHERE phone_number = %s
+            """,
+            (trial_end, premium_status, stripe_id, sub_status, phone),
+        )
+        conn.commit()
+    finally:
+        return_db_connection(conn)
+
+
+def _opt_in(phone, team_abbr="CIN", team_short="Bengals", cohort=COHORT_WEEKLY, **kwargs):
+    now = kwargs.pop("opted_in_at", datetime.utcnow())
+    pause_at = kwargs.pop("pause_at", now + timedelta(days=28))
+    upsert_optin(phone, team_abbr, team_short, cohort, opted_in_at=now, pause_at=pause_at, beta_started_at=now)
+    if kwargs:
+        update_optin(phone, **kwargs)
+
+
+def _event_counts(phone=None):
+    conn = get_db_connection()
+    try:
+        c = conn.cursor()
+        if phone:
+            c.execute(
+                "SELECT cohort, event_type, COUNT(*) FROM sports_score_events "
+                "WHERE phone_number = %s GROUP BY cohort, event_type",
+                (phone,),
+            )
+        else:
+            c.execute(
+                "SELECT cohort, event_type, COUNT(*) FROM sports_score_events "
+                "GROUP BY cohort, event_type"
+            )
+        return {(row[0], row[1]): row[2] for row in c.fetchall()}
+    finally:
+        return_db_connection(conn)
+
+
+class TestTeamAliases:
+    def test_bengals_variants(self):
+        for raw in ("Bengals", "Cincinnati Bengals", "CIN", "cincinnati", "cincy"):
+            team, err = resolve_team(raw)
+            assert err is None
+            assert team["abbr"] == "CIN"
+            assert team["short"] == "Bengals"
+
+    def test_unknown_team(self):
+        team, err = resolve_team("Manchester United")
+        assert team is None
+        assert "didn't recognize" in err.lower()
+
+    def test_ambiguous_new_york(self):
+        team, err = resolve_team("New York")
+        assert team is None
+        assert "Giants" in err and "Jets" in err
+
+
+class TestEspnFinalsOnly:
+    def test_skips_in_progress(self):
+        board = {
+            "events": [{
+                "id": "live",
+                "competitions": [{
+                    "status": {"type": {"name": "STATUS_IN_PROGRESS", "completed": False}},
+                    "competitors": [
+                        {"homeAway": "away", "score": "7", "team": {"abbreviation": "CIN", "shortDisplayName": "Bengals"}},
+                        {"homeAway": "home", "score": "3", "team": {"abbreviation": "KC", "shortDisplayName": "Chiefs"}},
+                    ],
+                }],
+            }]
+        }
+        assert parse_finals(board) == []
+
+    def test_format_final(self):
+        game = fake_game_for_team("CIN", "Bengals")
+        assert format_final(game) == "Bengals 27, Chiefs 24"
+
+
+class TestYesTeamOptIn:
+    @pytest.mark.asyncio
+    async def test_yes_plus_team_opts_in(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        result = await simulator.send_message(phone, "YES Bengals")
+        assert "Bengals" in result["output"]
+        optin = get_optin(phone)
+        assert optin is not None
+        assert optin["team_abbr"] == "CIN"
+        assert optin["cohort"] == COHORT_WEEKLY
+        assert count_sports_events(EVENT_SPORTS_YES, COHORT_WEEKLY) >= 1
+
+    @pytest.mark.asyncio
+    async def test_yes_plus_sign_form(self, simulator, onboarded_user):
+        phone = onboarded_user["phone"]
+        result = await simulator.send_message(phone, "YES + Cincinnati Bengals")
+        assert "Bengals" in result["output"]
+        assert get_optin(phone)["team_abbr"] == "CIN"
+
+    @pytest.mark.asyncio
+    async def test_dormant_invite_cohort_stays_dormant(self, simulator, onboarded_user):
+        phone = onboarded_user["phone"]
+        mark_sports_invite(phone, COHORT_DORMANT)
+        await simulator.send_message(phone, "YES Bengals")
+        assert get_optin(phone)["cohort"] == COHORT_DORMANT
+        assert count_sports_events(EVENT_SPORTS_YES, COHORT_DORMANT) >= 1
+        # Dormant YES must not land in the weekly counter.
+        weekly_yes = count_sports_events(EVENT_SPORTS_YES, COHORT_WEEKLY)
+        # Other tests may have written weekly events; this phone's YES is dormant.
+        events = _event_counts(phone)
+        assert (COHORT_DORMANT, EVENT_SPORTS_YES) in events
+        assert (COHORT_WEEKLY, EVENT_SPORTS_YES) not in events
+        assert weekly_yes == weekly_yes  # sanity: helper doesn't mix
+
+    @pytest.mark.asyncio
+    async def test_unknown_team_does_not_opt_in(self, simulator, onboarded_user):
+        phone = onboarded_user["phone"]
+        result = await simulator.send_message(phone, "YES Real Madrid")
+        assert "didn't recognize" in result["output"].lower()
+        assert get_optin(phone) is None
+
+
+class TestScoreKeyword:
+    @pytest.mark.asyncio
+    async def test_score_after_ask(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        _opt_in(phone)
+        now = _et_morning()
+        process_morning_asks(
+            now_utc=now,
+            skip_window_check=True,
+            fetch_fn=_fetch(_espn_final()),
+        )
+        ai_mock.clear_history()
+        result = await simulator.send_message(phone, "SCORE")
+        assert result["output"] == "Bengals 27, Chiefs 24"
+        optin = get_optin(phone)
+        assert optin["last_ask_replied"] is True
+        assert optin["ignore_streak"] == 0
+        assert not any(c["message"].strip().upper() == "SCORE" for c in ai_mock.call_history)
+        assert count_sports_events(EVENT_SCORE_REPLY, COHORT_WEEKLY) >= 1
+
+    @pytest.mark.asyncio
+    async def test_score_not_sent_to_ai_without_optin(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        ai_mock.clear_history()
+        result = await simulator.send_message(phone, "SCORE")
+        assert "No score waiting" in result["output"]
+        assert not any("SCORE" in (c["message"] or "").upper() for c in ai_mock.call_history)
+
+    @pytest.mark.asyncio
+    async def test_yes_team_not_sent_to_ai(self, simulator, onboarded_user, ai_mock):
+        phone = onboarded_user["phone"]
+        ai_mock.clear_history()
+        await simulator.send_message(phone, "YES Bengals")
+        assert not any("YES" in (c["message"] or "").upper() and "BENGAL" in (c["message"] or "").upper()
+                      for c in ai_mock.call_history)
+
+
+class TestIgnoreAndStop:
+    def test_ignore_does_not_ping_again_that_game(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        _opt_in(phone)
+        now = _et_morning()
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            first = process_morning_asks(
+                now_utc=now, skip_window_check=True, fetch_fn=_fetch(_espn_final("game-1")),
+            )
+            second = process_morning_asks(
+                now_utc=now, skip_window_check=True, fetch_fn=_fetch(_espn_final("game-1")),
+            )
+        assert first["asked"] == 1
+        assert second["asked"] == 0
+        assert mock_sms.call_count == 1
+        ask_bodies = [c.args[1] for c in mock_sms.call_args_list]
+        assert ASK_TEMPLATE.format(team="Bengals") in ask_bodies
+
+    def test_three_ignores_stops_silently(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        _opt_in(phone)
+        now = _et_morning()
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            for i, gid in enumerate(["g1", "g2", "g3", "g4"], start=1):
+                process_morning_asks(
+                    now_utc=now + timedelta(days=7 * (i - 1)),
+                    skip_window_check=True,
+                    fetch_fn=_fetch(_espn_final(gid)),
+                )
+        optin = get_optin(phone)
+        assert optin["stopped_silently"] is True
+        assert optin["ignore_streak"] >= 3
+        # Three asks sent; the fourth is the silent stop (no 4th ask, no goodbye).
+        ask_sends = [c for c in mock_sms.call_args_list if "Reply SCORE" in c.args[1]]
+        assert len(ask_sends) == 3
+        goodbye = [c for c in mock_sms.call_args_list if "goodbye" in c.args[1].lower() or "stop" in c.args[1].lower()]
+        assert goodbye == []
+        assert count_sports_events(EVENT_SCORE_IGNORE, COHORT_WEEKLY) >= 3
+
+
+class TestAntiBunch:
+    def test_skip_day_7_same_morning(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        now = _et_morning()
+        _set_trial(phone, now + timedelta(days=7))
+        _opt_in(phone)
+        row = _user_fields(phone)
+        row.update(get_optin(phone))
+        assert should_skip_score_ask(row, now) == "day_7"
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            result = process_morning_asks(
+                now_utc=now, skip_window_check=True, fetch_fn=_fetch(_espn_final()),
+            )
+        assert result["asked"] == 0
+        assert mock_sms.call_count == 0
+
+    def test_skip_day_13_same_morning(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        now = _et_morning()
+        _set_trial(phone, now + timedelta(days=1))  # 1 day remaining → Day 13
+        _opt_in(phone)
+        row = _user_fields(phone)
+        row.update(get_optin(phone))
+        assert should_skip_score_ask(row, now) == "day_13"
+
+    def test_skip_day_14_same_morning(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        now = _et_morning()
+        _set_trial(phone, now - timedelta(hours=2))  # expired today
+        _opt_in(phone)
+        row = _user_fields(phone)
+        row.update(get_optin(phone))
+        assert should_skip_score_ask(row, now) == "day_14"
+
+    def test_skip_winback_window(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        now = _et_morning()
+        _set_trial(phone, now - timedelta(days=30), premium_status="free")
+        _opt_in(phone)
+        row = _user_fields(phone)
+        row.update(get_optin(phone))
+        assert should_skip_score_ask(row, now) == "winback"
+
+    def test_reminder_sms_not_blocked(self):
+        """Anti-bunch is score-ping only; reminder message types stay sendable."""
+        from services.sms_service import PUSHED_MESSAGE_TYPES
+        assert "reminder" not in PUSHED_MESSAGE_TYPES
+        assert "sports_score_ask" not in PUSHED_MESSAGE_TYPES
+
+
+def _user_fields(phone):
+    conn = get_db_connection()
+    try:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT timezone, trial_end_date, premium_status, subscription_status,
+                   stripe_subscription_id, winback_30d_sent, sports_invite_sent_at
+            FROM users WHERE phone_number = %s
+            """,
+            (phone,),
+        )
+        row = c.fetchone()
+        return {
+            "timezone": row[0],
+            "trial_end_date": row[1],
+            "premium_status": row[2],
+            "subscription_status": row[3],
+            "stripe_subscription_id": row[4],
+            "winback_30d_sent": row[5],
+            "sports_invite_sent_at": row[6],
+            "phone_number": phone,
+        }
+    finally:
+        return_db_connection(conn)
+
+
+class TestCohortEventSeparation:
+    def test_weekly_and_dormant_events_are_separate(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        _opt_in(phone, cohort=COHORT_WEEKLY)
+        log_sports_event(phone, EVENT_SCORE_ASK, COHORT_WEEKLY, metadata={"team": "CIN"})
+        # Simulate a dormant user on a different phone stored as same test user after reset —
+        # log dormant events explicitly; counters must not mix.
+        log_sports_event(phone, EVENT_SPORTS_YES, COHORT_DORMANT, metadata={"team": "KC"})
+        weekly_asks = count_sports_events(EVENT_SCORE_ASK, COHORT_WEEKLY)
+        dormant_asks = count_sports_events(EVENT_SCORE_ASK, COHORT_DORMANT)
+        weekly_yes = count_sports_events(EVENT_SPORTS_YES, COHORT_WEEKLY)
+        dormant_yes = count_sports_events(EVENT_SPORTS_YES, COHORT_DORMANT)
+        assert weekly_asks >= 1
+        assert dormant_asks == 0
+        assert dormant_yes >= 1
+        # A dormant YES is not a weekly ask and not a weekly YES from this log call.
+        assert count_sports_events(EVENT_SCORE_ASK, COHORT_WEEKLY) != count_sports_events(EVENT_SCORE_ASK, COHORT_DORMANT)
+
+    def test_dormant_opt_in_score_events_stay_dormant(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        mark_sports_invite(phone, COHORT_DORMANT)
+        handle_yes_team(phone, "YES Bengals")
+        now = _et_morning()
+        with patch("services.sports_score_service.send_sms"):
+            process_morning_asks(
+                now_utc=now, skip_window_check=True, fetch_fn=_fetch(_espn_final()),
+            )
+        events = _event_counts(phone)
+        assert (COHORT_DORMANT, EVENT_SPORTS_YES) in events
+        assert (COHORT_DORMANT, EVENT_SCORE_ASK) in events
+        assert (COHORT_WEEKLY, EVENT_SPORTS_YES) not in events
+        assert (COHORT_WEEKLY, EVENT_SCORE_ASK) not in events
+
+
+class TestPauseAfterFourWeeks:
+    def test_pause_after_four_weeks_unless_premium(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        now = _et_morning()
+        opted = now - timedelta(days=29)
+        _set_trial(phone, now + timedelta(days=40))  # trial still running, 4-week cap hits first
+        _opt_in(phone, opted_in_at=opted, pause_at=compute_pause_at(opted, now + timedelta(days=40)))
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            result = process_morning_asks(
+                now_utc=now, skip_window_check=True, fetch_fn=_fetch(_espn_final()),
+            )
+        assert result["paused"] == 1
+        assert result["asked"] == 0
+        assert mock_sms.call_args.args[1] == PAUSE_COPY
+        assert get_optin(phone)["paused_at"] is not None
+
+    def test_paid_premium_is_not_paused(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        now = _et_morning()
+        opted = now - timedelta(days=29)
+        _set_trial(
+            phone,
+            now - timedelta(days=10),
+            premium_status="premium",
+            stripe_id="sub_test",
+            sub_status="active",
+        )
+        _opt_in(phone, opted_in_at=opted, pause_at=opted + timedelta(days=28))
+        row = _user_fields(phone)
+        assert is_paid_premium(row) is True
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            result = process_morning_asks(
+                now_utc=now, skip_window_check=True, fetch_fn=_fetch(_espn_final()),
+            )
+        assert result["paused"] == 0
+        assert result["asked"] == 1
+        assert mock_sms.call_args.args[1] == ASK_TEMPLATE.format(team="Bengals")
+
+    def test_trial_end_pauses_non_premium(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        now = _et_morning()
+        trial_end = now - timedelta(days=1)
+        # Not in day-14 window (expired yesterday), so pause can fire.
+        _set_trial(phone, trial_end, premium_status="free")
+        _opt_in(phone, opted_in_at=now - timedelta(days=5), pause_at=trial_end)
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            result = process_morning_asks(
+                now_utc=now, skip_window_check=True, fetch_fn=_fetch(_espn_final()),
+            )
+        assert result["paused"] == 1
+        assert mock_sms.call_args.args[1] == PAUSE_COPY
+
+    def test_upgrade_to_keep_logged_on_upgrade_keyword(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        now = datetime.utcnow()
+        _opt_in(phone, pause_at=now - timedelta(days=1))
+        update_optin(phone, paused_at=now - timedelta(hours=1))
+        maybe_log_upgrade_to_keep(phone)
+        assert count_sports_events(EVENT_UPGRADE_TO_KEEP, COHORT_WEEKLY) >= 1
+
+
+class TestNoInviteSendPath:
+    def test_invite_copy_locked_but_not_scheduled(self):
+        assert INVITE_WEEKLY == (
+            "Trying something for football season. Want your team's score the morning after? "
+            "I'll ask first. Reply YES + team (NFL)."
+        )
+        assert INVITE_DORMANT == (
+            "Still here if you want. Trying football scores the morning after a game "
+            "(I'll ask first — no spoilers). Reply YES + team, or ignore."
+        )
+        from celery_config import beat_schedule
+        task_names = [v["task"] for v in beat_schedule.values()]
+        assert "tasks.reminder_tasks.send_nfl_score_asks" in task_names
+        assert not any("invite" in name for name in beat_schedule)
+        assert not any("invite" in t for t in task_names)
+
+    def test_inactivity_skipped_when_sports_invite_this_week(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        mark_sports_invite(phone, COHORT_DORMANT)
+        assert sports_invite_sent_this_week(phone) is True
+        source = open("tasks/reminder_tasks.py", encoding="utf-8").read()
+        assert "sports_invite_sent_this_week" in source
+        assert "KEEP" not in source or "sports invite" in source.lower()
+
+
+class TestLockedAskCopy:
+    def test_ask_copy(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        _opt_in(phone)
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            process_morning_asks(
+                now_utc=_et_morning(), skip_window_check=True, fetch_fn=_fetch(_espn_final()),
+            )
+        assert mock_sms.call_args.args[1] == "Bengals played last night. Reply SCORE if you want it, or ignore."
+        assert "Sept" not in mock_sms.call_args.args[1]
+        assert "recap" not in mock_sms.call_args.args[1].lower()

--- a/tests/test_nfl_scores.py
+++ b/tests/test_nfl_scores.py
@@ -38,7 +38,6 @@ from services.sports_score_service import (
     INVITE_WEEKLY,
     INVITE_DORMANT,
     handle_yes_team,
-    handle_score_keyword,
     process_morning_asks,
     should_skip_score_ask,
     compute_pause_at,

--- a/tests/test_nfl_scores.py
+++ b/tests/test_nfl_scores.py
@@ -23,6 +23,7 @@ from models.sports import (
     EVENT_SPORTS_YES,
     EVENT_UPGRADE_TO_KEEP,
     get_optin,
+    list_optins,
     upsert_optin,
     update_optin,
     log_sports_event,
@@ -37,7 +38,10 @@ from services.sports_score_service import (
     PAUSE_COPY,
     INVITE_WEEKLY,
     INVITE_DORMANT,
+    STAGGER_SECONDS,
     handle_yes_team,
+    handle_score_keyword,
+    deliver_score_ask,
     process_morning_asks,
     should_skip_score_ask,
     compute_pause_at,
@@ -503,3 +507,186 @@ class TestLockedAskCopy:
         assert mock_sms.call_args.args[1] == "Bengals played last night. Reply SCORE if you want it, or ignore."
         assert "Sept" not in mock_sms.call_args.args[1]
         assert "recap" not in mock_sms.call_args.args[1].lower()
+
+
+def _espn_two_finals():
+    """Bengals and Lions both final last night, distinct scores."""
+    return {
+        "events": [
+            _espn_final("game-cin-kc", "CIN", "KC", "27", "24")["events"][0],
+            {
+                "id": "game-det-gb",
+                "competitions": [{
+                    "status": {"type": {"name": "STATUS_FINAL", "completed": True}},
+                    "competitors": [
+                        {
+                            "homeAway": "away",
+                            "score": "31",
+                            "team": {"abbreviation": "DET", "shortDisplayName": "Lions"},
+                        },
+                        {
+                            "homeAway": "home",
+                            "score": "17",
+                            "team": {"abbreviation": "GB", "shortDisplayName": "Packers"},
+                        },
+                    ],
+                }],
+            },
+        ]
+    }
+
+
+def _opt_in_team(phone, team_abbr, team_short, **kwargs):
+    now = kwargs.pop("opted_in_at", datetime.utcnow())
+    pause_at = kwargs.pop("pause_at", now + timedelta(days=28))
+    upsert_optin(
+        phone, team_abbr, team_short, kwargs.pop("cohort", COHORT_WEEKLY),
+        opted_in_at=now, pause_at=pause_at, beta_started_at=now,
+        replace_others=kwargs.pop("replace_others", False),
+    )
+    if kwargs:
+        update_optin(phone, team_abbr=team_abbr, **kwargs)
+
+
+class TestProductionStaysOneTeam:
+    def test_second_yes_replaces_first(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        handle_yes_team(phone, "YES Bengals")
+        handle_yes_team(phone, "YES Lions")
+        teams = list_optins(phone)
+        assert len(teams) == 1
+        assert teams[0]["team_abbr"] == "DET"
+        assert teams[0]["team_short"] == "Lions"
+
+
+class TestFounderDualOptIn:
+    def test_yes_bengals_then_lions_keeps_both(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        with patch("services.sports_score_service.is_founder_phone", return_value=True):
+            handle_yes_team(phone, "YES Bengals")
+            handle_yes_team(phone, "YES Lions")
+        teams = {o["team_abbr"]: o["team_short"] for o in list_optins(phone)}
+        assert teams == {"CIN": "Bengals", "DET": "Lions"}
+
+    def test_third_yes_replaces_oldest(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        with patch("services.sports_score_service.is_founder_phone", return_value=True):
+            handle_yes_team(phone, "YES Bengals")
+            handle_yes_team(phone, "YES Lions")
+            handle_yes_team(phone, "YES Chiefs")
+        abbrs = {o["team_abbr"] for o in list_optins(phone)}
+        assert len(abbrs) == 2
+        assert "KC" in abbrs
+
+
+class TestFounderStaggeredAsks:
+    def test_two_played_last_night_staggers_and_does_not_leak(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        _opt_in_team(phone, "CIN", "Bengals")
+        _opt_in_team(phone, "DET", "Lions")
+        scheduled = []
+
+        def capture_schedule(p, team_abbr, game, delay, ask_date_iso):
+            scheduled.append((p, team_abbr, game, delay, ask_date_iso))
+
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            result = process_morning_asks(
+                now_utc=_et_morning(),
+                skip_window_check=True,
+                fetch_fn=_fetch(_espn_two_finals()),
+                schedule_staggered=capture_schedule,
+            )
+        assert result["asked"] == 1
+        assert result["scheduled"] == 1
+        assert mock_sms.call_count == 1
+        ask = mock_sms.call_args.args[1]
+        assert ask == "Bengals played last night. Reply SCORE if you want it, or ignore."
+        assert "27" not in ask
+        assert "24" not in ask
+        assert "31" not in ask
+        assert "17" not in ask
+        assert "Packers" not in ask
+        assert "Chiefs" not in ask
+        assert scheduled[0][1] == "DET"
+        assert scheduled[0][3] == STAGGER_SECONDS
+        assert STAGGER_SECONDS >= 120
+        # Staggered team is not dumped in the same send.
+        assert get_optin(phone, "DET")["last_ask_game_id"] is None
+        assert get_optin(phone, "CIN")["pending_score_payload"]["away_score"] == "27"
+
+    def test_score_one_ignore_the_other(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        _opt_in_team(phone, "CIN", "Bengals")
+        _opt_in_team(phone, "DET", "Lions")
+        now = _et_morning()
+        scheduled = []
+
+        def capture_schedule(p, team_abbr, game, delay, ask_date_iso):
+            scheduled.append((team_abbr, game, ask_date_iso))
+
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            process_morning_asks(
+                now_utc=now,
+                skip_window_check=True,
+                fetch_fn=_fetch(_espn_two_finals()),
+                schedule_staggered=capture_schedule,
+            )
+            # Stagger fires a few minutes later — deliver Lions ask separately.
+            team_abbr, game, ask_date_iso = scheduled[0]
+            deliver_score_ask(
+                phone, team_abbr, game, ask_date=now.date(),
+                asked_at=now + timedelta(minutes=3),
+            )
+
+        with patch("services.sports_score_service.send_sms"):
+            reply = handle_score_keyword(phone, "SCORE")
+        assert reply == "Lions 31, Packers 17"
+        scored = get_optin(phone, "DET")
+        ignored = get_optin(phone, "CIN")
+        assert scored["last_ask_replied"] is True
+        assert ignored["last_ask_replied"] is False
+        assert ignored["pending_score_payload"] is not None
+        events = _event_counts(phone)
+        assert (COHORT_WEEKLY, EVENT_SCORE_REPLY) in events
+        assert (COHORT_WEEKLY, EVENT_SCORE_ASK) in events
+
+    def test_full_loop_invite_then_staggered_asks(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        scheduled = []
+
+        def capture_schedule(p, team_abbr, game, delay, ask_date_iso):
+            scheduled.append((team_abbr, delay))
+
+        with patch("services.sports_score_service.is_founder_phone", return_value=True):
+            with patch("services.sports_score_service.send_sms") as mock_sms:
+                mock_sms.return_value = None
+                result = process_morning_asks(
+                    now_utc=_et_morning(),
+                    dry_run_phone=phone,
+                    fake_game=True,
+                    full_loop=True,
+                    schedule_staggered=capture_schedule,
+                )
+        assert result["invite_sent"] == 1
+        assert result["asked"] == 1
+        assert result["scheduled"] == 1
+        bodies = [c.args[1] for c in mock_sms.call_args_list]
+        assert bodies[0] == INVITE_WEEKLY
+        assert bodies[1] == "Bengals played last night. Reply SCORE if you want it, or ignore."
+        assert "27" not in bodies[1]
+        assert "24" not in bodies[1]
+        assert scheduled == [("DET", STAGGER_SECONDS)]
+        teams = {o["team_abbr"] for o in list_optins(phone)}
+        assert teams == {"CIN", "DET"}
+        from celery_config import beat_schedule
+        assert not any("invite" in v["task"] for v in beat_schedule.values())
+
+    def test_ensure_founder_teams_noops_for_production_phone(self, onboarded_user):
+        from services.sports_score_service import ensure_founder_teams
+        phone = onboarded_user["phone"]
+        with patch("services.sports_score_service.is_founder_phone", return_value=False):
+            ensure_founder_teams(phone)
+        assert list_optins(phone) == []
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closed-beta plumbing for NFL scores the morning after a user’s team plays. **This PR does not send weekly or dormant invites to production.**

## Schema
- `sports_optins` — one row per `(phone_number, team_abbr)`. Production users stay one team in the service layer. Founder dry-run phones may have two.
- Fields: `team_short`, `cohort` (`weekly`|`dormant`), ignore streak, `last_ask_date` / `last_ask_at` / `last_ask_game_id` / `last_ask_replied`, `pending_score_payload`, pause, silent stop
- `sports_score_events` — growth analytics, always tagged with cohort so weekly and dormant counters never mix (`score_ask`, `score_reply`, `score_ignore`, `upgrade_to_keep`, `sports_yes`)
- `users.sports_invite_sent_at` / `sports_invite_cohort` — invite tracking only. No beat-scheduled invite send. Inactivity KEEP/CLEAR is skipped the same week if an invite was recorded.

## Job
`send_nfl_score_asks` on Celery Beat at **:35** past each hour, same 9–10 AM local window as `check_trial_expirations`. ESPN public scoreboard, **finals only** (Monday night → Tuesday 9am local). Score ping loses to Day 7 / 13 / 14 trial lifecycle, win-back, or a sports invite the same morning. Reminder SMS is unaffected.

After 4 weeks or trial end: pause copy (locked) unless paid Premium. 3 ignored asks → silent stop, no goodbye text.

## Inbound parsing
`YES + team` and `SCORE` (optional `SCORE + team`) are keyword handlers in `/sms` **before** the AI (after STOP/CANCEL). Team aliases cover Bengals / Cincinnati Bengals / CIN, Lions / DET, etc. A second `YES` **replaces** the team for normal users.

Locked copy is used as-is (not dated). Asks never include the score.

## Founder dual dry-run (Bengals + Lions)
Allowlist: `FOUNDER_SURVEY_EXCLUDE_PHONES` plus setting `nfl_score_dry_run_phones`. Those phones may hold **two** opt-ins. If both played last night, asks are staggered by 3 minutes (`send_one_nfl_score_ask`), not dumped together. Founder can `SCORE` one and ignore the other.

Full loop on one founder phone (invite copy → spoiler-free asks, canned or ESPN):

```
celery -A celery_app call tasks.reminder_tasks.send_nfl_score_asks --kwargs='{"dry_run_phone":"+18593935374","fake_game":true,"full_loop":true}'
```

or `POST /admin/sports-scores/dry-run` with `{"phone":"+18593935374","fake_game":true,"full_loop":true}`.

Optional `scoreboard_date=YYYYMMDD` uses a real ESPN date instead of canned finals. Two-step alternative: `send_invite=true`, text `YES Bengals` then `YES Lions`, then fire asks without `full_loop`.

Kill switch: `nfl_score_asks_enabled` (default true for opted-in asks only).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c11f92b7-b1e7-4693-98ae-8f20244125b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c11f92b7-b1e7-4693-98ae-8f20244125b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

