### PR TITLE
Stop init_db from resetting new free-tier users to v1

### DIFF
--- a/database.py
+++ b/database.py
@@ -708,10 +708,11 @@ def init_db():
             "UPDATE users SET last_nudged_at = '2026-03-10 16:35:00', nudge_count_24h = 1 WHERE phone_number LIKE '%4793' AND last_nudged_at IS NULL AND onboarding_complete = FALSE",
             "UPDATE users SET last_nudged_at = '2026-03-10 16:35:00', nudge_count_24h = 1 WHERE phone_number LIKE '%2936' AND last_nudged_at IS NULL AND onboarding_complete = FALSE",
             "UPDATE users SET last_nudged_at = '2026-03-10 16:35:00', nudge_count_24h = 1 WHERE phone_number LIKE '%6167' AND last_nudged_at IS NULL AND onboarding_complete = FALSE",
-            # Free tier versioning: v1 = grandfathered existing users, v2 = new users (default)
+            # Free tier versioning: v1 = grandfathered existing users, v2 = new users (default).
+            # One-time prod backfill to v1 already ran. Do not re-add an UPDATE that
+            # sets free_tier_version = 1 — it re-runs on every API/worker boot and
+            # converts new users (column default 2) back to grandfathered 1.
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS free_tier_version INTEGER DEFAULT 2",
-            # Backfill all existing users to v1 (grandfathered)
-            "UPDATE users SET free_tier_version = 1 WHERE free_tier_version = 2 OR free_tier_version IS NULL",
             # Shared lists: pending name prompt state (JSON with list_id, shared_with_phone, list_name)
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS pending_share_name TEXT",
             # Shared lists: owner-assigned name for the person they shared with

--- a/tests/test_free_tier_version_init.py
+++ b/tests/test_free_tier_version_init.py
@@ -1,0 +1,97 @@
+"""
+Guard: init_db must not re-apply the one-time free_tier_version v1 backfill.
+
+New users inherit column default 2 (3 reminders/week). A repeating
+UPDATE ... SET free_tier_version = 1 WHERE free_tier_version = 2
+converts them to grandfathered v1 (2 reminders/day) on every process boot.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_DATABASE_PY = Path(__file__).resolve().parents[1] / "database.py"
+
+_RESET_V2_TO_V1 = re.compile(
+    r"UPDATE\s+users\s+SET\s+free_tier_version\s*=\s*1\b",
+    re.IGNORECASE,
+)
+
+_PROBE_PHONE = "+15550000002"
+
+
+def _sql_literals_in_init_db():
+    tree = ast.parse(_DATABASE_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "init_db":
+            return [
+                n.value
+                for n in ast.walk(node)
+                if isinstance(n, ast.Constant) and isinstance(n.value, str)
+            ]
+    raise AssertionError("init_db not found in database.py")
+
+
+class TestInitDbDoesNotResetFreeTierV2:
+    def test_column_default_2_stays_in_migrations(self):
+        sql = _sql_literals_in_init_db()
+        assert any(
+            "ADD COLUMN IF NOT EXISTS free_tier_version INTEGER DEFAULT 2" in stmt
+            for stmt in sql
+        ), "Expected free_tier_version column (default 2) to remain in init_db migrations"
+
+    def test_migrations_do_not_set_version_2_users_back_to_1(self):
+        for stmt in _sql_literals_in_init_db():
+            assert _RESET_V2_TO_V1.search(stmt) is None, (
+                "init_db must not re-run the one-time v1 backfill on boot: "
+                f"{' '.join(stmt.split())}"
+            )
+
+
+class TestInitDbPreservesExistingV2User:
+    def test_user_with_free_tier_version_2_stays_2_after_init_db(self):
+        from database import get_db_connection, init_db, return_db_connection
+        from models.user import create_or_update_user
+
+        try:
+            conn = get_db_connection()
+            return_db_connection(conn)
+        except Exception as e:
+            pytest.skip(f"test DB unavailable: {e}")
+
+        def _version():
+            conn = get_db_connection()
+            try:
+                c = conn.cursor()
+                c.execute(
+                    "SELECT free_tier_version FROM users WHERE phone_number = %s",
+                    (_PROBE_PHONE,),
+                )
+                row = c.fetchone()
+                return row[0] if row else None
+            finally:
+                return_db_connection(conn)
+
+        def _cleanup():
+            conn = get_db_connection()
+            try:
+                c = conn.cursor()
+                c.execute("DELETE FROM users WHERE phone_number = %s", (_PROBE_PHONE,))
+                conn.commit()
+            finally:
+                return_db_connection(conn)
+
+        _cleanup()
+        try:
+            create_or_update_user(
+                _PROBE_PHONE, free_tier_version=2, first_name="V2Probe"
+            )
+            assert _version() == 2
+            init_db()
+            assert _version() == 2, (
+                f"init_db changed free_tier_version from 2 to {_version()}"
+            )
+        finally:
+            _cleanup()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`init_db()` re-runs its migrations list on every API and worker start. Most entries are `ALTER … IF NOT EXISTS`. This one was not:

```sql
UPDATE users SET free_tier_version = 1 WHERE free_tier_version = 2 OR free_tier_version IS NULL
```

New users inherit column default **2** (3 reminders/week). The next process boot converted them to **1** (grandfathered 2 reminders/day). Finding #1 in PR #281 / `REVIEW.md`.

The original grandfathering backfill already ran. That `UPDATE` must not keep running.

## Change

- Removed the repeating `UPDATE` from the runtime migrations list in `database.py`.
- Kept `ALTER TABLE users ADD COLUMN IF NOT EXISTS free_tier_version INTEGER DEFAULT 2`.
- No extra runtime DML. `init_db` / Alembic were not rewritten.

## Tests

`tests/test_free_tier_version_init.py`:

- Asserts `init_db` SQL literals still add `free_tier_version` with default 2.
- Asserts no `UPDATE users SET free_tier_version = 1` in that list.
- If the test DB is reachable, inserts a user with `free_tier_version=2`, calls `init_db()`, and asserts they stay at 2 (no fixture wipe).

## Prod follow-up (not in this PR)

**This does not automatically restore users already knocked back to 1 in production.**

Check current mix:

```sql
SELECT free_tier_version, count(*) FROM users GROUP BY 1;
```

Restoring the right people (new v2 vs true grandfathered v1) is a separate, careful prod data fix. Do not guess a blanket `UPDATE … SET free_tier_version = 2 WHERE free_tier_version = 1`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c41eff7c-6e46-4d02-abad-302cb0c7d5d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c41eff7c-6e46-4d02-abad-302cb0c7d5d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

