### PR TITLE
One-shot beta-comp wall for 32 premium comps

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -72,6 +72,8 @@ beat_schedule = {
     # "your trial is expiring" warnings were crying wolf to ~46 users (a top STOP
     # driver). The task function is kept intact; re-add this schedule entry only
     # once a genuine trial/paywall exists. See docs/changelog.md.
+    # Do NOT re-enable for the Aug 2026 beta-comp wall — fake Day 13 would lie
+    # to the September-dated comps. Use the one-shot tasks below instead.
     # "check-trial-expirations": {
     #     "task": "tasks.reminder_tasks.check_trial_expirations",
     #     "schedule": crontab(minute=0),  # Every hour, on the hour
@@ -79,6 +81,22 @@ beat_schedule = {
     #         "expires": 3500,  # Just under 1 hour
     #     },
     # },
+    # One-shot beta-comp wall (32 comps). Thu/Fri warning at :00, Saturday
+    # flip+confirm at :08 so the warning has had a chance to send first.
+    "send-beta-comp-warnings": {
+        "task": "tasks.reminder_tasks.send_beta_comp_warnings",
+        "schedule": crontab(minute=0),
+        "options": {
+            "expires": 3500,
+        },
+    },
+    "send-beta-comp-downgrade": {
+        "task": "tasks.reminder_tasks.send_beta_comp_downgrade",
+        "schedule": crontab(minute=8),
+        "options": {
+            "expires": 3500,
+        },
+    },
     # Send mid-trial value reminders hourly — timezone-aware (9-10 AM local)
     "send-mid-trial-value-reminders": {
         "task": "tasks.reminder_tasks.send_mid_trial_value_reminders",

--- a/database.py
+++ b/database.py
@@ -758,6 +758,10 @@ def init_db():
                 metadata JSONB,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )""",
+            # One-shot beta-comp wall (Thu/Fri warning, Saturday flip). Not a
+            # restore of check_trial_expirations — that stay unscheduled.
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS beta_comp_warning_sent_at TIMESTAMP",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS beta_comp_downgraded_at TIMESTAMP",
         ]
 
         # Create indexes on phone_hash columns for efficient lookups

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog — Recent Improvements & Bug Fixes
 
+## Beta-comp wall (Aug 2026)
+
+One-shot downgrade for the 32 premium comps with no Stripe (trial_end_date 2026-08-29 or 2026-06-18). The four September comps (2026-09-07, 2026-09-12), `subscription_status='manual'`, and anyone with a real Stripe subscription are left alone. **Does not re-enable `check_trial_expirations`** — that stays commented out on purpose (a fake Day 13 would lie to the September-dated comps). Copy locked by Retention.
+
+- **Thu/Fri 9–10 AM local:** warning SMS, once per user (`beta_comp_warning_sent_at`). A regular reminder that morning does not suppress it. Sports score pings and 30-day win-back lose the same local morning.
+- **Saturday 9–10 AM local:** flip to free (Day-14 behavior: `premium_status='free'`, new recurring blocked, existing recurring keep running) and send confirm. Scheduled after the warning task. Idempotent (`beta_comp_downgraded_at`).
+- **In-product limit-hit copy** (when they bounce on Free, not a blast): 3rd reminder today, and new repeating reminders.
+
+**Files:** `services/beta_comp_downgrade.py` (new), `services/tier_service.py`, `tasks/reminder_tasks.py`, `celery_config.py`, `database.py`, `models/user.py`, `models/sports.py`, `services/sports_score_service.py`, `tests/test_beta_comp_downgrade.py`.
+
 ## NFL Morning-After Score Beta v1 (Aug 2026)
 
 Closed-beta plumbing for NFL scores the morning after a user's team plays. **Invites are not sent by this change.** Users who text `YES + team` opt in; the 9–10 AM local Celery job (`send_nfl_score_asks`, :35 past the hour) asks; `SCORE` returns only the final (`Bengals 27, Chiefs 24`). ESPN public scoreboard, finals only.

--- a/models/sports.py
+++ b/models/sports.py
@@ -246,7 +246,8 @@ def list_active_optins() -> list[dict]:
                    s.stopped_silently, s.last_ask_at,
                    u.timezone, u.trial_end_date, u.premium_status,
                    u.subscription_status, u.stripe_subscription_id, u.opted_out,
-                   u.winback_30d_sent, u.sports_invite_sent_at
+                   u.winback_30d_sent, u.sports_invite_sent_at,
+                   u.beta_comp_warning_sent_at, u.beta_comp_downgraded_at
             FROM sports_optins s
             JOIN users u ON u.phone_number = s.phone_number
             WHERE COALESCE(s.stopped_silently, FALSE) = FALSE
@@ -266,6 +267,8 @@ def list_active_optins() -> list[dict]:
                 "opted_out": row[20],
                 "winback_30d_sent": row[21],
                 "sports_invite_sent_at": row[22],
+                "beta_comp_warning_sent_at": row[23],
+                "beta_comp_downgraded_at": row[24],
             }
             results.append(_optin_from_row(row, extra))
         return results

--- a/models/user.py
+++ b/models/user.py
@@ -52,6 +52,8 @@ ALLOWED_USER_FIELDS = {
     'shared_lists_beta_opt_in',
     # Soft opt-out for proactive lifecycle messages
     'lifecycle_messages_opted_out', 'lifecycle_messages_opted_out_at',
+    # One-shot beta-comp wall (Thu/Fri warning, Saturday flip)
+    'beta_comp_warning_sent_at', 'beta_comp_downgraded_at',
 }
 
 

--- a/services/beta_comp_downgrade.py
+++ b/services/beta_comp_downgrade.py
@@ -1,0 +1,349 @@
+"""One-shot beta-comp wall: Thu/Fri warning, Saturday flip to Free.
+
+This is NOT a restore of check_trial_expirations (still unscheduled on
+purpose — a fake Day 13 would lie to September-dated comps). Target is the
+32 premium comps whose trial_end_date is 2026-08-29 or 2026-06-18. The four
+September comps, Stripe subscribers, and subscription_status='manual' are
+left alone.
+
+Copy is locked by Retention. Do not rewrite.
+"""
+
+from datetime import date, datetime
+from typing import Optional
+
+import pytz
+
+from config import logger
+from database import get_db_connection, return_db_connection
+from services.sms_service import send_sms
+
+# Locked target dates. September 2026-09-07 / 2026-09-12 stay premium.
+BETA_COMP_TRIAL_END_DATES = (date(2026, 8, 29), date(2026, 6, 18))
+BETA_COMP_SKIP_TRIAL_END_DATES = (date(2026, 9, 7), date(2026, 9, 12))
+
+BETA_COMP_TARGET_SQL = """
+    premium_status = 'premium'
+    AND (stripe_subscription_id IS NULL OR stripe_subscription_id = '')
+    AND (subscription_status IS NULL OR subscription_status NOT IN ('active', 'manual'))
+    AND trial_end_date::date IN ('2026-08-29', '2026-06-18')
+"""
+
+WARNING_COPY = (
+    "You've had full Premium. Saturday you go to Free "
+    "(2 reminders/day, 2 lists, 5 memories, no new recurring). "
+    "Existing recurring keep running.\n\n"
+    "Text UPGRADE to keep unlimited — $8.99/mo or $89.99/yr ($7.50/mo)."
+)
+
+DOWNGRADE_COPY = (
+    "You're on Free now: 2 reminders/day, 2 lists, 5 memories. "
+    "New recurring is Premium.\n\n"
+    "Text UPGRADE to get unlimited back — $8.99/mo or $89.99/yr."
+)
+
+WARNING_MESSAGE_TYPE = "beta_comp_warning"
+DOWNGRADE_MESSAGE_TYPE = "beta_comp_downgrade"
+
+THURSDAY = 3
+FRIDAY = 4
+SATURDAY = 5
+WARNING_WEEKDAYS = (THURSDAY, FRIDAY)
+MORNING_START_HOUR = 9
+MORNING_END_HOUR = 10
+
+
+def _as_date(value) -> Optional[date]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    return None
+
+
+def _user_tz(timezone_str: Optional[str]):
+    try:
+        return pytz.timezone(timezone_str or "America/New_York")
+    except pytz.exceptions.UnknownTimeZoneError:
+        return pytz.timezone("America/New_York")
+
+
+def _aware_utc(now_utc: datetime) -> datetime:
+    if now_utc.tzinfo is None:
+        return pytz.utc.localize(now_utc)
+    return now_utc.astimezone(pytz.utc)
+
+
+def local_now(now_utc: datetime, timezone_str: Optional[str]):
+    return _aware_utc(now_utc).astimezone(_user_tz(timezone_str))
+
+
+def in_morning_window(local_dt: datetime) -> bool:
+    return MORNING_START_HOUR <= local_dt.hour < MORNING_END_HOUR
+
+
+def is_warning_weekday(local_dt: datetime) -> bool:
+    return local_dt.weekday() in WARNING_WEEKDAYS
+
+
+def is_flip_weekday(local_dt: datetime) -> bool:
+    return local_dt.weekday() == SATURDAY
+
+
+def is_beta_comp_target_row(user_row: dict) -> bool:
+    """Python equivalent of BETA_COMP_TARGET_SQL for sports skip / tests."""
+    if (user_row.get("premium_status") or "").lower() != "premium":
+        return False
+    stripe = user_row.get("stripe_subscription_id") or ""
+    if str(stripe).strip():
+        return False
+    status = (user_row.get("subscription_status") or "").lower()
+    if status in ("active", "manual"):
+        return False
+    trial_day = _as_date(user_row.get("trial_end_date"))
+    return trial_day in BETA_COMP_TRIAL_END_DATES
+
+
+def _timestamp_on_local_date(ts, timezone_str: Optional[str], local_day: date) -> bool:
+    if not ts:
+        return False
+    if isinstance(ts, datetime):
+        if ts.tzinfo is None:
+            ts_local = pytz.utc.localize(ts).astimezone(_user_tz(timezone_str))
+        else:
+            ts_local = ts.astimezone(_user_tz(timezone_str))
+        return ts_local.date() == local_day
+    if isinstance(ts, date):
+        return ts == local_day
+    return False
+
+
+def beta_comp_message_sent_this_local_morning(user_row: dict, now_utc: datetime) -> bool:
+    """True if the Thu/Fri warning or Saturday confirm already went this local day."""
+    local = local_now(now_utc, user_row.get("timezone"))
+    tz = user_row.get("timezone")
+    return (
+        _timestamp_on_local_date(user_row.get("beta_comp_warning_sent_at"), tz, local.date())
+        or _timestamp_on_local_date(user_row.get("beta_comp_downgraded_at"), tz, local.date())
+    )
+
+
+def should_skip_score_for_beta_comp(user_row: dict, now_utc: datetime) -> Optional[str]:
+    """Score ping loses the local morning this warning/confirm is (or will be) sent."""
+    if beta_comp_message_sent_this_local_morning(user_row, now_utc):
+        return "beta_comp_warning"
+    local = local_now(now_utc, user_row.get("timezone"))
+    if local.weekday() in (THURSDAY, FRIDAY, SATURDAY) and is_beta_comp_target_row(user_row):
+        return "beta_comp_warning"
+    return None
+
+
+def list_beta_comp_targets() -> list[dict]:
+    """All 32-set rows (no SMS-opt-out filter). Used by tests and both tasks."""
+    conn = None
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            f"""
+            SELECT phone_number, first_name, timezone, trial_end_date,
+                   premium_status, subscription_status, stripe_subscription_id,
+                   beta_comp_warning_sent_at, beta_comp_downgraded_at
+            FROM users
+            WHERE {BETA_COMP_TARGET_SQL}
+            """
+        )
+        rows = c.fetchall()
+        return [
+            {
+                "phone_number": row[0],
+                "first_name": row[1],
+                "timezone": row[2],
+                "trial_end_date": row[3],
+                "premium_status": row[4],
+                "subscription_status": row[5],
+                "stripe_subscription_id": row[6],
+                "beta_comp_warning_sent_at": row[7],
+                "beta_comp_downgraded_at": row[8],
+            }
+            for row in rows
+        ]
+    except Exception as e:
+        logger.error(f"Error listing beta-comp targets: {e}")
+        return []
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def _is_sms_silenced(opted_out, lifecycle_paused) -> bool:
+    return bool(opted_out) or bool(lifecycle_paused)
+
+
+def process_beta_comp_warnings(now_utc: datetime = None) -> dict:
+    """Thu/Fri 9-10am local warning. Once per user. Does not flip."""
+    if now_utc is None:
+        now_utc = datetime.utcnow()
+
+    logger.info("Starting beta-comp warning check")
+    conn = None
+    warnings_sent = 0
+    skipped = 0
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            f"""
+            SELECT phone_number, timezone, opted_out, lifecycle_messages_opted_out
+            FROM users
+            WHERE {BETA_COMP_TARGET_SQL}
+              AND onboarding_complete = TRUE
+              AND beta_comp_warning_sent_at IS NULL
+            """
+        )
+        users = c.fetchall()
+        if not users:
+            logger.info("No beta-comp users due for warning")
+            return {"warnings_sent": 0, "skipped": 0}
+
+        for phone_number, timezone_str, opted_out, lifecycle_paused in users:
+            local = local_now(now_utc, timezone_str)
+            if not is_warning_weekday(local) or not in_morning_window(local):
+                skipped += 1
+                continue
+            if _is_sms_silenced(opted_out, lifecycle_paused):
+                skipped += 1
+                continue
+            try:
+                send_sms(phone_number, WARNING_COPY, message_type=WARNING_MESSAGE_TYPE)
+                c.execute(
+                    """
+                    UPDATE users
+                    SET beta_comp_warning_sent_at = %s
+                    WHERE phone_number = %s
+                      AND beta_comp_warning_sent_at IS NULL
+                    """,
+                    (now_utc.replace(tzinfo=None) if now_utc.tzinfo else now_utc, phone_number),
+                )
+                conn.commit()
+                if c.rowcount:
+                    warnings_sent += 1
+                    logger.info(f"Sent beta-comp warning to ...{phone_number[-4:]}")
+                else:
+                    skipped += 1
+            except Exception as sms_error:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                logger.error(f"Failed to send beta-comp warning to ...{phone_number[-4:]}: {sms_error}")
+                continue
+
+        logger.info(f"Beta-comp warning check complete: {warnings_sent} sent")
+        return {"warnings_sent": warnings_sent, "skipped": skipped}
+    except Exception:
+        logger.exception("Error in process_beta_comp_warnings")
+        raise
+    finally:
+        if conn:
+            return_db_connection(conn)
+
+
+def _apply_downgrade(cursor, phone_number: str, now_utc: datetime) -> int:
+    """Match Day-14 (premium_status=free) and actually drop the trial so
+    get_user_tier cannot keep them premium. Pin v1 so locked copy matches.
+    Existing recurring rows are untouched — generate_recurring_reminders
+    does not check tier.
+    """
+    naive_now = now_utc.replace(tzinfo=None) if getattr(now_utc, "tzinfo", None) else now_utc
+    cursor.execute(
+        f"""
+        UPDATE users
+        SET premium_status = 'free',
+            free_tier_version = 1,
+            trial_end_date = CASE
+                WHEN trial_end_date IS NOT NULL AND trial_end_date > %s THEN %s
+                ELSE trial_end_date
+            END,
+            beta_comp_downgraded_at = %s
+        WHERE phone_number = %s
+          AND beta_comp_downgraded_at IS NULL
+          AND {BETA_COMP_TARGET_SQL}
+        """,
+        (naive_now, naive_now, naive_now, phone_number),
+    )
+    return cursor.rowcount
+
+
+def process_beta_comp_downgrade(now_utc: datetime = None) -> dict:
+    """Saturday 9-10am local: flip the 32 to free, then confirm SMS.
+
+    Runs only on Saturday so the Thu/Fri warning has had a chance to send.
+    Idempotent via beta_comp_downgraded_at. Stripe/manual still excluded by
+    BETA_COMP_TARGET_SQL.
+    """
+    if now_utc is None:
+        now_utc = datetime.utcnow()
+
+    logger.info("Starting beta-comp Saturday downgrade")
+    conn = None
+    downgraded = 0
+    confirms_sent = 0
+    skipped = 0
+    try:
+        conn = get_db_connection()
+        c = conn.cursor()
+        c.execute(
+            f"""
+            SELECT phone_number, timezone, opted_out, lifecycle_messages_opted_out
+            FROM users
+            WHERE {BETA_COMP_TARGET_SQL}
+              AND onboarding_complete = TRUE
+              AND beta_comp_downgraded_at IS NULL
+            """
+        )
+        users = c.fetchall()
+        if not users:
+            logger.info("No beta-comp users due for Saturday downgrade")
+            return {"downgraded": 0, "confirms_sent": 0, "skipped": 0}
+
+        for phone_number, timezone_str, opted_out, lifecycle_paused in users:
+            local = local_now(now_utc, timezone_str)
+            if not is_flip_weekday(local) or not in_morning_window(local):
+                skipped += 1
+                continue
+
+            silenced = _is_sms_silenced(opted_out, lifecycle_paused)
+            try:
+                if not silenced:
+                    send_sms(phone_number, DOWNGRADE_COPY, message_type=DOWNGRADE_MESSAGE_TYPE)
+                updated = _apply_downgrade(c, phone_number, now_utc)
+                conn.commit()
+                if updated:
+                    downgraded += 1
+                    if not silenced:
+                        confirms_sent += 1
+                    logger.info(f"Beta-comp downgraded ...{phone_number[-4:]}")
+                else:
+                    skipped += 1
+            except Exception as err:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                logger.error(f"Failed beta-comp downgrade for ...{phone_number[-4:]}: {err}")
+                continue
+
+        logger.info(
+            f"Beta-comp Saturday downgrade complete: {downgraded} flipped, "
+            f"{confirms_sent} confirms sent"
+        )
+        return {"downgraded": downgraded, "confirms_sent": confirms_sent, "skipped": skipped}
+    except Exception:
+        logger.exception("Error in process_beta_comp_downgrade")
+        raise
+    finally:
+        if conn:
+            return_db_connection(conn)

--- a/services/sports_score_service.py
+++ b/services/sports_score_service.py
@@ -199,12 +199,18 @@ def winback_due_this_morning(user_row: dict, now_utc: datetime) -> bool:
 
 
 def should_skip_score_ask(user_row: dict, now_utc: datetime) -> Optional[str]:
-    """Anti-bunch: score ping loses to Day 7/13/14, win-back, or the sports invite."""
+    """Anti-bunch: score ping loses to Day 7/13/14, win-back, sports invite,
+    or the beta-comp warning/confirm the same local morning.
+    """
     reason = trial_day_conflict(user_row, now_utc)
     if reason:
         return reason
     if winback_due_this_morning(user_row, now_utc):
         return "winback"
+    from services.beta_comp_downgrade import should_skip_score_for_beta_comp
+    beta_reason = should_skip_score_for_beta_comp(user_row, now_utc)
+    if beta_reason:
+        return beta_reason
     return None
 
 

--- a/services/tier_service.py
+++ b/services/tier_service.py
@@ -11,6 +11,15 @@ from config import (
     TIER_LIMITS, FREE_TIER_LIMITS, get_tier_limits
 )
 
+# Retention-locked free-tier bounce copy. In-product when they hit a wall
+# after going Free — not a blast. Do not rewrite.
+V1_DAILY_REMINDER_LIMIT_COPY = (
+    "You're at 2 reminders today on Free. Text UPGRADE for unlimited, or try again tomorrow."
+)
+NEW_RECURRING_LIMIT_COPY = (
+    "New repeating reminders are Premium. Text UPGRADE to set this one, or send it as a one-off."
+)
+
 
 def get_user_tier(phone_number: str) -> str:
     """Get user's subscription tier. Returns 'free' if not found.
@@ -352,11 +361,8 @@ def can_create_reminder(phone_number: str, reminder_date: datetime = None) -> tu
     current_count = get_reminders_created_today(phone_number)
 
     if current_count >= limits['reminders_per_day']:
-        return (
-            False,
-            f"You've used all {limits['reminders_per_day']} reminders for today — they reset at midnight. "
-            f"Need more? Text UPGRADE for unlimited reminders ({PREMIUM_MONTHLY_PRICE}/mo)."
-        )
+        # Retention-locked copy for v1 (2/day). Do not rewrite.
+        return (False, V1_DAILY_REMINDER_LIMIT_COPY)
 
     return (True, None)
 
@@ -473,12 +479,7 @@ def can_create_recurring_reminder(phone_number: str) -> tuple[bool, str | None]:
     limits = get_tier_limits(tier)
 
     if not limits['recurring_reminders']:
-        from config import PREMIUM_MONTHLY_PRICE
-        return (
-            False,
-            "Recurring reminders are a Premium feature. "
-            f"Text UPGRADE for daily, weekly & monthly reminders ({PREMIUM_MONTHLY_PRICE}/mo)."
-        )
+        return (False, NEW_RECURRING_LIMIT_COPY)
 
     return (True, None)
 

--- a/tasks/reminder_tasks.py
+++ b/tasks/reminder_tasks.py
@@ -1095,6 +1095,54 @@ Want unlimited access back? Text UPGRADE — {PREMIUM_MONTHLY_PRICE}/mo or {PREM
             return_db_connection(conn)
 
 
+# =====================================================
+# ONE-SHOT BETA-COMP WALL (not a restore of check_trial_expirations)
+# =====================================================
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    default_retry_delay=60,
+    time_limit=300,
+    soft_time_limit=270,
+)
+def send_beta_comp_warnings(self, now_utc=None):
+    """Thu/Fri 9-10am local warning to the 32 beta comps. Once per user.
+
+    Does not flip. Does not re-enable check_trial_expirations.
+    A regular reminder the same morning does not suppress this.
+    """
+    from services.beta_comp_downgrade import process_beta_comp_warnings
+
+    try:
+        return process_beta_comp_warnings(now_utc=now_utc)
+    except Exception as exc:
+        logger.exception("Error in send_beta_comp_warnings")
+        raise self.retry(exc=exc)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    default_retry_delay=60,
+    time_limit=300,
+    soft_time_limit=270,
+)
+def send_beta_comp_downgrade(self, now_utc=None):
+    """Saturday 9-10am local: flip the 32 to free and send confirm.
+
+    Scheduled after the warning task so Thu/Fri warning goes first.
+    Saturday-only so the warning window has closed. Idempotent.
+    """
+    from services.beta_comp_downgrade import process_beta_comp_downgrade
+
+    try:
+        return process_beta_comp_downgrade(now_utc=now_utc)
+    except Exception as exc:
+        logger.exception("Error in send_beta_comp_downgrade")
+        raise self.retry(exc=exc)
+
+
 @celery_app.task(
     bind=True,
     max_retries=2,
@@ -2111,7 +2159,8 @@ def send_30d_winback(self):
         window_start = target_date - timedelta(days=1)
 
         c.execute("""
-            SELECT phone_number, first_name, trial_end_date, timezone
+            SELECT phone_number, first_name, trial_end_date, timezone,
+                   beta_comp_warning_sent_at, beta_comp_downgraded_at
             FROM users
             WHERE trial_end_date IS NOT NULL
               AND trial_end_date >= %s
@@ -2133,7 +2182,7 @@ def send_30d_winback(self):
         messages_sent = 0
 
         for user in users:
-            phone_number, first_name, trial_end_date, timezone_str = user
+            phone_number, first_name, trial_end_date, timezone_str, warning_at, downgraded_at = user
 
             # Only send when it's 9-10 AM in user's local timezone
             try:
@@ -2142,6 +2191,21 @@ def send_30d_winback(self):
                 user_tz = pytz.timezone('America/New_York')
             user_local_hour = datetime.now(pytz.utc).astimezone(user_tz).hour
             if not (9 <= user_local_hour < 10):
+                continue
+
+            from services.beta_comp_downgrade import beta_comp_message_sent_this_local_morning
+            if beta_comp_message_sent_this_local_morning(
+                {
+                    "timezone": timezone_str,
+                    "beta_comp_warning_sent_at": warning_at,
+                    "beta_comp_downgraded_at": downgraded_at,
+                },
+                now_utc,
+            ):
+                logger.info(
+                    f"Skipping 30-day winback for ...{phone_number[-4:]} — "
+                    "beta-comp warning/confirm sent this local morning"
+                )
                 continue
 
             # Anti-bunching: skip if any other lifecycle/nudge fired in last 48h

--- a/tests/test_beta_comp_downgrade.py
+++ b/tests/test_beta_comp_downgrade.py
@@ -1,0 +1,422 @@
+"""One-shot beta-comp wall: target selection, Thu/Fri warning, Saturday flip.
+
+Does not restore check_trial_expirations. Copy locked by Retention.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytz
+
+from database import get_db_connection, return_db_connection, init_db
+
+init_db()
+
+from models.user import create_or_update_user
+from services.beta_comp_downgrade import (
+    BETA_COMP_SKIP_TRIAL_END_DATES,
+    BETA_COMP_TRIAL_END_DATES,
+    DOWNGRADE_COPY,
+    WARNING_COPY,
+    is_beta_comp_target_row,
+    list_beta_comp_targets,
+    process_beta_comp_downgrade,
+    process_beta_comp_warnings,
+    should_skip_score_for_beta_comp,
+)
+from services.tier_service import (
+    NEW_RECURRING_LIMIT_COPY,
+    V1_DAILY_REMINDER_LIMIT_COPY,
+    can_create_recurring_reminder,
+    can_create_reminder,
+)
+
+
+PHONE_PREFIX = "+1555110"
+INCLUDED_START = 1
+INCLUDED_COUNT = 32
+SEPT_PHONES = (41, 42, 43, 44)  # two 09-07, two 09-12
+MANUAL_N = 51
+STRIPE_N = 52
+ACTIVE_NO_STRIPE_N = 53
+
+
+def _phone(n: int) -> str:
+    return f"{PHONE_PREFIX}{n:04d}"
+
+
+def _et_morning(day, month=8, year=2026, hour=9, minute=30):
+    tz = pytz.timezone("America/New_York")
+    local = tz.localize(datetime(year, month, day, hour, minute, 0))
+    return local.astimezone(pytz.utc).replace(tzinfo=None)
+
+
+def _cleanup_cohort():
+    conn = get_db_connection()
+    try:
+        c = conn.cursor()
+        c.execute(
+            "DELETE FROM recurring_reminders WHERE phone_number LIKE %s",
+            (PHONE_PREFIX + "%",),
+        )
+        c.execute(
+            "DELETE FROM reminders WHERE phone_number LIKE %s",
+            (PHONE_PREFIX + "%",),
+        )
+        c.execute(
+            "DELETE FROM sms_outbound_log WHERE phone_number LIKE %s",
+            (PHONE_PREFIX + "%",),
+        )
+        c.execute("DELETE FROM users WHERE phone_number LIKE %s", (PHONE_PREFIX + "%",))
+        conn.commit()
+    finally:
+        return_db_connection(conn)
+
+
+def _insert_user(
+    phone,
+    trial_end,
+    premium_status="premium",
+    stripe_id=None,
+    sub_status=None,
+    timezone="America/New_York",
+):
+    create_or_update_user(
+        phone,
+        first_name="Comp",
+        timezone=timezone,
+        onboarding_complete=True,
+        premium_status=premium_status,
+        trial_end_date=trial_end,
+        stripe_subscription_id=stripe_id,
+        subscription_status=sub_status,
+        opted_out=False,
+        lifecycle_messages_opted_out=False,
+    )
+
+
+def _seed_target_set():
+    """32 included + 4 September + manual + stripe + active-without-stripe."""
+    aug = datetime(2026, 8, 29, 16, 0, 0)
+    jun = datetime(2026, 6, 18, 16, 0, 0)
+    sept7 = datetime(2026, 9, 7, 16, 0, 0)
+    sept12 = datetime(2026, 9, 12, 16, 0, 0)
+
+    for i in range(INCLUDED_START, INCLUDED_START + 16):
+        _insert_user(_phone(i), aug)
+    for i in range(INCLUDED_START + 16, INCLUDED_START + INCLUDED_COUNT):
+        _insert_user(_phone(i), jun)
+
+    _insert_user(_phone(41), sept7)
+    _insert_user(_phone(42), sept7)
+    _insert_user(_phone(43), sept12)
+    _insert_user(_phone(44), sept12)
+
+    _insert_user(_phone(MANUAL_N), aug, sub_status="manual")
+    _insert_user(_phone(STRIPE_N), aug, stripe_id="sub_live", sub_status="active")
+    _insert_user(_phone(ACTIVE_NO_STRIPE_N), aug, sub_status="active")
+
+
+def _user_row(phone):
+    conn = get_db_connection()
+    try:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT premium_status, trial_end_date, subscription_status,
+                   stripe_subscription_id, beta_comp_warning_sent_at,
+                   beta_comp_downgraded_at, free_tier_version, timezone
+            FROM users WHERE phone_number = %s
+            """,
+            (phone,),
+        )
+        row = c.fetchone()
+        return {
+            "premium_status": row[0],
+            "trial_end_date": row[1],
+            "subscription_status": row[2],
+            "stripe_subscription_id": row[3],
+            "beta_comp_warning_sent_at": row[4],
+            "beta_comp_downgraded_at": row[5],
+            "free_tier_version": row[6],
+            "timezone": row[7],
+            "phone_number": phone,
+        }
+    finally:
+        return_db_connection(conn)
+
+
+class TestTargetSelection:
+    def setup_method(self):
+        _cleanup_cohort()
+        _seed_target_set()
+
+    def teardown_method(self):
+        _cleanup_cohort()
+
+    def test_selects_32_and_skips_sept_manual_stripe(self):
+        targets = list_beta_comp_targets()
+        phones = {t["phone_number"] for t in targets}
+        included = {_phone(i) for i in range(INCLUDED_START, INCLUDED_START + INCLUDED_COUNT)}
+        assert phones == included
+        assert len(targets) == 32
+
+        for n in SEPT_PHONES:
+            row = _user_row(_phone(n))
+            assert is_beta_comp_target_row(row) is False
+            assert _as_trial_date(row["trial_end_date"]) in BETA_COMP_SKIP_TRIAL_END_DATES
+
+        assert is_beta_comp_target_row(_user_row(_phone(MANUAL_N))) is False
+        assert is_beta_comp_target_row(_user_row(_phone(STRIPE_N))) is False
+        assert is_beta_comp_target_row(_user_row(_phone(ACTIVE_NO_STRIPE_N))) is False
+
+        # Included dates are only the two wall dates
+        dates = {_as_trial_date(t["trial_end_date"]) for t in targets}
+        assert dates == set(BETA_COMP_TRIAL_END_DATES)
+
+
+def _as_trial_date(value):
+    return value.date() if hasattr(value, "date") else value
+
+
+class TestWarningOnceOnly:
+    def setup_method(self):
+        _cleanup_cohort()
+        _insert_user(_phone(1), datetime(2026, 8, 29, 16, 0, 0))
+
+    def teardown_method(self):
+        _cleanup_cohort()
+
+    def test_sends_thursday_skips_friday(self):
+        phone = _phone(1)
+        thursday = _et_morning(27)
+        friday = _et_morning(28)
+        with patch("services.beta_comp_downgrade.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            first = process_beta_comp_warnings(now_utc=thursday)
+            second = process_beta_comp_warnings(now_utc=friday)
+        assert first["warnings_sent"] == 1
+        assert second["warnings_sent"] == 0
+        assert mock_sms.call_count == 1
+        assert mock_sms.call_args.args[1] == WARNING_COPY
+        row = _user_row(phone)
+        assert row["beta_comp_warning_sent_at"] is not None
+        assert row["premium_status"] == "premium"
+
+    def test_wednesday_does_not_send(self):
+        wednesday = _et_morning(26)
+        with patch("services.beta_comp_downgrade.send_sms") as mock_sms:
+            result = process_beta_comp_warnings(now_utc=wednesday)
+        assert result["warnings_sent"] == 0
+        mock_sms.assert_not_called()
+
+    def test_reminder_same_morning_does_not_block_warning(self):
+        phone = _phone(1)
+        thursday = _et_morning(27)
+        conn = get_db_connection()
+        try:
+            c = conn.cursor()
+            c.execute(
+                "INSERT INTO sms_outbound_log (phone_number, message_type, created_at) "
+                "VALUES (%s, %s, %s)",
+                (phone, "reminder", thursday),
+            )
+            conn.commit()
+        finally:
+            return_db_connection(conn)
+        with patch("services.beta_comp_downgrade.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            result = process_beta_comp_warnings(now_utc=thursday)
+        assert result["warnings_sent"] == 1
+        mock_sms.assert_called_once()
+
+    def test_skips_manual_and_stripe(self):
+        _insert_user(_phone(MANUAL_N), datetime(2026, 8, 29, 16, 0, 0), sub_status="manual")
+        _insert_user(
+            _phone(STRIPE_N),
+            datetime(2026, 8, 29, 16, 0, 0),
+            stripe_id="sub_live",
+            sub_status="active",
+        )
+        thursday = _et_morning(27)
+        with patch("services.beta_comp_downgrade.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            result = process_beta_comp_warnings(now_utc=thursday)
+        sent_to = {c.args[0] for c in mock_sms.call_args_list}
+        assert _phone(1) in sent_to
+        assert _phone(MANUAL_N) not in sent_to
+        assert _phone(STRIPE_N) not in sent_to
+        assert result["warnings_sent"] == 1
+
+
+class TestSaturdayFlipAndConfirm:
+    def setup_method(self):
+        _cleanup_cohort()
+        _insert_user(_phone(1), datetime(2026, 8, 29, 16, 0, 0))
+
+    def teardown_method(self):
+        _cleanup_cohort()
+
+    def test_thursday_does_not_flip(self):
+        thursday = _et_morning(27)
+        with patch("services.beta_comp_downgrade.send_sms") as mock_sms:
+            result = process_beta_comp_downgrade(now_utc=thursday)
+        assert result["downgraded"] == 0
+        mock_sms.assert_not_called()
+        assert _user_row(_phone(1))["premium_status"] == "premium"
+
+    def test_saturday_flips_sends_confirm_and_is_idempotent(self):
+        phone = _phone(1)
+        thursday = _et_morning(27)
+        saturday = _et_morning(29)
+        with patch("services.beta_comp_downgrade.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            process_beta_comp_warnings(now_utc=thursday)
+            first = process_beta_comp_downgrade(now_utc=saturday)
+            second = process_beta_comp_downgrade(now_utc=saturday)
+        assert first["downgraded"] == 1
+        assert first["confirms_sent"] == 1
+        assert second["downgraded"] == 0
+        bodies = [c.args[1] for c in mock_sms.call_args_list]
+        assert WARNING_COPY in bodies
+        assert DOWNGRADE_COPY in bodies
+        assert bodies.count(DOWNGRADE_COPY) == 1
+
+        row = _user_row(phone)
+        assert row["premium_status"] == "free"
+        assert row["beta_comp_downgraded_at"] is not None
+        assert row["free_tier_version"] == 1
+        # Trial must not still look active to get_user_tier
+        assert row["trial_end_date"] <= saturday
+
+    def test_saturday_skips_sept_manual_stripe(self):
+        _insert_user(_phone(41), datetime(2026, 9, 7, 16, 0, 0))
+        _insert_user(_phone(MANUAL_N), datetime(2026, 8, 29, 16, 0, 0), sub_status="manual")
+        _insert_user(
+            _phone(STRIPE_N),
+            datetime(2026, 8, 29, 16, 0, 0),
+            stripe_id="sub_live",
+            sub_status="active",
+        )
+        saturday = _et_morning(29)
+        with patch("services.beta_comp_downgrade.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            result = process_beta_comp_downgrade(now_utc=saturday)
+        flipped = {c.args[0] for c in mock_sms.call_args_list}
+        assert _phone(1) in flipped
+        assert _phone(41) not in flipped
+        assert _phone(MANUAL_N) not in flipped
+        assert _phone(STRIPE_N) not in flipped
+        assert result["downgraded"] == 1
+        assert _user_row(_phone(41))["premium_status"] == "premium"
+        assert _user_row(_phone(MANUAL_N))["premium_status"] == "premium"
+        assert _user_row(_phone(STRIPE_N))["premium_status"] == "premium"
+
+    def test_existing_recurring_keeps_generating_after_flip(self, onboarded_user):
+        phone = onboarded_user["phone"]
+        create_or_update_user(
+            phone,
+            premium_status="premium",
+            trial_end_date=datetime(2026, 8, 29, 16, 0, 0),
+            stripe_subscription_id=None,
+            subscription_status=None,
+        )
+        from models.reminder import save_recurring_reminder
+
+        recurring_id = save_recurring_reminder(
+            phone, "Daily vitamin", "daily", None, "09:00", "America/New_York"
+        )
+        saturday = _et_morning(29)
+        with patch("services.beta_comp_downgrade.send_sms"):
+            process_beta_comp_downgrade(now_utc=saturday)
+        assert _user_row(phone)["premium_status"] == "free"
+
+        conn = get_db_connection()
+        try:
+            c = conn.cursor()
+            c.execute("DELETE FROM reminders WHERE recurring_id = %s", (recurring_id,))
+            conn.commit()
+        finally:
+            return_db_connection(conn)
+
+        with patch("services.sms_service.send_sms"):
+            from tasks.reminder_tasks import generate_recurring_reminders
+
+            generate_recurring_reminders()
+
+        conn = get_db_connection()
+        try:
+            c = conn.cursor()
+            c.execute("SELECT COUNT(*) FROM reminders WHERE recurring_id = %s", (recurring_id,))
+            count = c.fetchone()[0]
+        finally:
+            return_db_connection(conn)
+        assert count > 0
+
+
+class TestLimitHitCopy:
+    @patch("services.tier_service.BETA_MODE", False)
+    @patch("services.tier_service.get_reminders_created_today", return_value=2)
+    @patch("services.tier_service.get_user_free_tier_version", return_value=1)
+    @patch("services.tier_service.get_user_tier", return_value="free")
+    def test_v1_third_reminder_today(self, _tier, _ver, _count):
+        allowed, msg = can_create_reminder("+15559876543")
+        assert allowed is False
+        assert msg == V1_DAILY_REMINDER_LIMIT_COPY
+        assert msg == (
+            "You're at 2 reminders today on Free. "
+            "Text UPGRADE for unlimited, or try again tomorrow."
+        )
+
+    @patch("services.tier_service.BETA_MODE", False)
+    @patch("services.tier_service.get_user_tier", return_value="free")
+    def test_new_recurring_blocked_copy(self, _tier):
+        allowed, msg = can_create_recurring_reminder("+15559876543")
+        assert allowed is False
+        assert msg == NEW_RECURRING_LIMIT_COPY
+        assert msg == (
+            "New repeating reminders are Premium. "
+            "Text UPGRADE to set this one, or send it as a one-off."
+        )
+
+
+class TestSportsSkipSameMorning:
+    def setup_method(self):
+        _cleanup_cohort()
+        _insert_user(_phone(1), datetime(2026, 8, 29, 16, 0, 0))
+
+    def teardown_method(self):
+        _cleanup_cohort()
+
+    def test_skip_if_warning_sent_that_local_morning(self):
+        phone = _phone(1)
+        thursday = _et_morning(27)
+        with patch("services.beta_comp_downgrade.send_sms"):
+            process_beta_comp_warnings(now_utc=thursday)
+        row = _user_row(phone)
+        assert should_skip_score_for_beta_comp(row, thursday) == "beta_comp_warning"
+
+    def test_skip_target_thursday_even_before_send(self):
+        row = _user_row(_phone(1))
+        thursday = _et_morning(27)
+        assert should_skip_score_for_beta_comp(row, thursday) == "beta_comp_warning"
+
+    def test_does_not_skip_unrelated_tuesday(self):
+        row = _user_row(_phone(1))
+        tuesday = _et_morning(25)
+        assert should_skip_score_for_beta_comp(row, tuesday) is None
+
+
+class TestCeleryScheduleIsOneShotNotTrialRestore:
+    def test_check_trial_expirations_stays_unscheduled(self):
+        from celery_config import beat_schedule
+
+        task_names = [v["task"] for v in beat_schedule.values()]
+        assert "tasks.reminder_tasks.check_trial_expirations" not in task_names
+        assert "tasks.reminder_tasks.send_beta_comp_warnings" in task_names
+        assert "tasks.reminder_tasks.send_beta_comp_downgrade" in task_names
+        assert not any("invite" in t for t in task_names)
+
+        source = open("celery_config.py", encoding="utf-8").read()
+        assert '# "check-trial-expirations":' in source
+        assert "check-trial-expirations" not in beat_schedule

--- a/tests/test_nfl_scores.py
+++ b/tests/test_nfl_scores.py
@@ -344,6 +344,34 @@ class TestAntiBunch:
         assert "reminder" not in PUSHED_MESSAGE_TYPES
         assert "sports_score_ask" not in PUSHED_MESSAGE_TYPES
 
+    def test_skip_if_beta_comp_warning_sent_that_local_morning(self, onboarded_user):
+        """Score ping loses if the beta-comp warning went the same local morning."""
+        phone = onboarded_user["phone"]
+        now = _et_morning(day=27, month=8, year=2026)  # Thursday
+        trial_end = datetime(2026, 6, 18, 16, 0, 0)  # not a Day 13/14 window
+        _set_trial(phone, trial_end, premium_status="premium")
+        conn = get_db_connection()
+        try:
+            c = conn.cursor()
+            c.execute(
+                "UPDATE users SET beta_comp_warning_sent_at = %s WHERE phone_number = %s",
+                (now, phone),
+            )
+            conn.commit()
+        finally:
+            return_db_connection(conn)
+        _opt_in(phone)
+        row = _user_fields(phone)
+        row.update(get_optin(phone))
+        assert should_skip_score_ask(row, now) == "beta_comp_warning"
+        with patch("services.sports_score_service.send_sms") as mock_sms:
+            mock_sms.return_value = None
+            result = process_morning_asks(
+                now_utc=now, skip_window_check=True, fetch_fn=_fetch(_espn_final()),
+            )
+        assert result["asked"] == 0
+        assert mock_sms.call_count == 0
+
 
 def _user_fields(phone):
     conn = get_db_connection()
@@ -352,7 +380,8 @@ def _user_fields(phone):
         c.execute(
             """
             SELECT timezone, trial_end_date, premium_status, subscription_status,
-                   stripe_subscription_id, winback_30d_sent, sports_invite_sent_at
+                   stripe_subscription_id, winback_30d_sent, sports_invite_sent_at,
+                   beta_comp_warning_sent_at, beta_comp_downgraded_at
             FROM users WHERE phone_number = %s
             """,
             (phone,),
@@ -366,6 +395,8 @@ def _user_fields(phone):
             "stripe_subscription_id": row[4],
             "winback_30d_sent": row[5],
             "sports_invite_sent_at": row[6],
+            "beta_comp_warning_sent_at": row[7],
+            "beta_comp_downgraded_at": row[8],
             "phone_number": phone,
         }
     finally:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
One-shot beta-comp wall for the 32 premium comps with no Stripe. **Does not re-enable `check_trial_expirations`** — that stays commented out in `celery_config.py` on purpose (a fake Day 13 would lie to the September-dated comps). Copy is locked by Retention. No sports invites. Does not touch the weekly/dormant 15.

## Target set (32)

- `premium_status='premium'`
- `stripe_subscription_id` IS NULL or `''`
- `subscription_status` IS NULL or NOT IN (`'active'`, `'manual'`)
- `trial_end_date::date` IN (`'2026-08-29'`, `'2026-06-18'`)

Left alone: the 4 with September trial ends (`2026-09-07`, `2026-09-12`), `subscription_status='manual'`, and anyone with a real Stripe subscription.

## What ships

**Thu/Fri 9–10 AM user local** (timezone-aware, same window as other lifecycle tasks): warning SMS, once per user (`beta_comp_warning_sent_at`). A regular reminder fire that morning does **not** suppress this. Sports score pings and 30-day win-back lose the same local morning.

```
You've had full Premium. Saturday you go to Free (2 reminders/day, 2 lists, 5 memories, no new recurring). Existing recurring keep running.

Text UPGRADE to keep unlimited — $8.99/mo or $89.99/yr ($7.50/mo).
```

**Saturday 9–10 AM local** (scheduled at :08, after the warning task): flip those 32 to free matching Day-14 (`premium_status='free'`, new recurring blocked, existing recurring keep running), then send confirm. Idempotent (`beta_comp_downgraded_at`). Does not flip before Saturday.

```
You're on Free now: 2 reminders/day, 2 lists, 5 memories. New recurring is Premium.

Text UPGRADE to get unlimited back — $8.99/mo or $89.99/yr.
```

**In-product limit-hit copy** (when they bounce after they are Free — not a blast):

- 3rd reminder today (v1 is 2/day): `You're at 2 reminders today on Free. Text UPGRADE for unlimited, or try again tomorrow.`
- New recurring: `New repeating reminders are Premium. Text UPGRADE to set this one, or send it as a one-off.`

## Tests

`tests/test_beta_comp_downgrade.py` covers target selection (32 vs Sept 4 vs manual/Stripe), warning once-only, Saturday flip + confirm, locked copy strings, and sports skip if this warning is sent that local morning. `check_trial_expirations` stays unscheduled.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b13fda21-34b3-425b-a843-5617324e4bba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b13fda21-34b3-425b-a843-5617324e4bba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

